### PR TITLE
WIP: Make astropy a soft dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,14 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
 
+        # Add a couple of configurations without Astropy, since it's a
+        # soft dependency.
+        - python: 2.7
+          env: ASTROPY_VERSION=
+
+        - python: 3.4
+          env: ASTROPY_VERSION=
+
         # Try older numpy versions
         - python: 2.7
           env: NUMPY_VERSION=1.8 SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ install:
     # install since this ensures Numpy does not get automatically upgraded.
     # - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
     # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL jsonschema pyyaml; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL jsonschema pyyaml six; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ matrix:
         # Add a couple of configurations without Astropy, since it's a
         # soft dependency.
         - python: 2.7
-          env: ASTROPY_VERSION=
+          env: ASTROPY_VERSION=none
 
         - python: 3.4
-          env: ASTROPY_VERSION=
+          env: ASTROPY_VERSION=none
 
         # Try older numpy versions
         - python: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython jinja2 pyyaml jsonschema psutil"
+    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython jinja2 pyyaml jsonschema psutil six"
 
     # Install the development version of astropy
     - "%CMD_IN_ENV% pip install git+http://github.com/astropy/astropy.git#egg=astropy"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,11 +11,17 @@ Installation
 
 - `numpy <http://www.numpy.org/>`__ 1.6 or later
 
-- `astropy <http://www.astropy.org/>`__ 1.0 or later
-
 - `jsonschema <http://python-jsonschema.readthedocs.org/>`__ 2.3.0 or later
 
 - `pyyaml <http://pyyaml.org>`__ 3.10 or later
+
+- `six <https://pypi.python.org/pypi/six>`__ 1.9.0 or later
+
+For support for units, time, transform or wcs, ``pyasdf`` also
+requires:
+
+- `astropy <http://www.astropy.org/>`__ 1.0 or later
+
 
 Getting Started
 ---------------

--- a/pyasdf/__init__.py
+++ b/pyasdf/__init__.py
@@ -11,10 +11,10 @@ Data Format (ASDF) files
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
-from ._astropy_init import *
+from ._internal_init import *
 # ----------------------------------------------------------------------------
 
-if _ASTROPY_SETUP_ is False:
+if _PYASDF_SETUP_ is False:
     __all__ = ['AsdfFile', 'AsdfType', 'AsdfExtension',
                'Stream', 'open', 'test', 'commands',
                'ValidationError']
@@ -33,11 +33,6 @@ if _ASTROPY_SETUP_ is False:
         import numpy as _
     except ImportError:
         raise ImportError("pyasdf requires numpy")
-
-    try:
-        import astropy as _
-    except ImportError:
-        raise ImportError("pyasdf requires astropy")
 
     from .asdf import AsdfFile
     from .asdftypes import AsdfType

--- a/pyasdf/_internal_init.py
+++ b/pyasdf/_internal_init.py
@@ -7,14 +7,14 @@ __all__ = ['__version__', '__githash__', 'test']
 
 # this indicates whether or not we are in the package's setup.py
 try:
-    _ASTROPY_SETUP_
+    _PYASDF_SETUP_
 except NameError:
     from sys import version_info
     if version_info[0] >= 3:
         import builtins
     else:
         import __builtin__ as builtins
-    builtins._ASTROPY_SETUP_ = False
+    builtins._PYASDF_SETUP_ = False
 
 try:
     from .version import version as __version__
@@ -29,7 +29,7 @@ except ImportError:
 # set up the test command
 def _get_test_runner():
     import os
-    from astropy.tests.helper import TestRunner
+    from .tests.extern.astropy_helper import TestRunner
     return TestRunner(os.path.dirname(__file__))
 
 
@@ -114,31 +114,3 @@ def test(package=None, test_path=None, args=None, plugins=None,
         plugins=plugins, verbose=verbose, pastebin=pastebin,
         remote_data=remote_data, pep8=pep8, pdb=pdb,
         coverage=coverage, open_files=open_files, **kwargs)
-
-
-if not _ASTROPY_SETUP_:
-    import os
-    from warnings import warn
-    from astropy import config
-
-    # add these here so we only need to cleanup the namespace at the end
-    config_dir = None
-
-    if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
-        config_dir = os.path.dirname(__file__)
-        config_template = os.path.join(config_dir, __package__ + ".cfg")
-        if os.path.isfile(config_template):
-            try:
-                config.configuration.update_default_config(
-                    __package__, config_dir, version=__version__)
-            except TypeError as orig_error:
-                try:
-                    config.configuration.update_default_config(
-                        __package__, config_dir)
-                except config.configuration.ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] + " Cannot install default profile. If you are "
-                            "importing from source, this is expected.")
-                    warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
-                    del e
-                except:
-                    raise orig_error

--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -14,13 +14,13 @@ import weakref
 
 import numpy as np
 
-from astropy.extern import six
-from astropy.extern.six.moves.urllib import parse as urlparse
-from astropy.utils.compat import NUMPY_LT_1_7
+import six
+from six.moves.urllib import parse as urlparse
 
 import yaml
 
 from . import compression as mcompression
+from .compat.numpycompat import NUMPY_LT_1_7
 from . import constants
 from . import generic_io
 from . import stream

--- a/pyasdf/commands/main.py
+++ b/pyasdf/commands/main.py
@@ -5,10 +5,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import argparse
+import logging
 import sys
 
-from astropy.extern import six
-from astropy.logger import log
+import six
 
 from .. import util
 
@@ -80,10 +80,10 @@ def main_from_args(args):
     try:
         result = args.func(args)
     except RuntimeError as e:
-        log.error(six.text_type(e))
+        logging.error(six.text_type(e))
         return 1
     except IOError as e:
-        log.error(six.text_type(e))
+        logging.error(six.text_type(e))
         return e.errno
 
     if result is None:

--- a/pyasdf/commands/tests/test_main.py
+++ b/pyasdf/commands/tests/test_main.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import main
 

--- a/pyasdf/compat/__init__.py
+++ b/pyasdf/compat/__init__.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
+import six
 
 if six.PY2:
     from UserDict import UserDict

--- a/pyasdf/compat/_odict_py2/__init__.py
+++ b/pyasdf/compat/_odict_py2/__init__.py
@@ -1,0 +1,190 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Backport of the Python 2.7 collections.OrderedDict class to Python 2.6.
+
+Ordered dictionaries are just like regular dictionaries but they remember the
+order that items were inserted.  When iterating over an ordered dictionary,
+the items are returned in the order their keys were first added.
+
+See: http://docs.python.org/library/collections.html#collections.OrderedDict
+"""
+
+from __future__ import absolute_import
+
+__all__ = ['OrderedDict']
+
+from collections import MutableMapping
+from operator import eq as _eq
+from itertools import imap as _imap
+
+try:
+    from thread import get_ident
+except ImportError:
+    from dummy_thread import get_ident
+
+
+def _recursive_repr(user_function):
+    'Decorator to make a repr function return "..." for a recursive call'
+    repr_running = set()
+
+    def wrapper(self):
+        key = id(self), get_ident()
+        if key in repr_running:
+            return '...'
+        repr_running.add(key)
+        try:
+            result = user_function(self)
+        finally:
+            repr_running.discard(key)
+        return result
+
+    # Can't use functools.wraps() here because of bootstrap issues
+    wrapper.__module__ = getattr(user_function, '__module__')
+    wrapper.__doc__ = getattr(user_function, '__doc__')
+    wrapper.__name__ = getattr(user_function, '__name__')
+    return wrapper
+
+class OrderedDict(dict, MutableMapping):
+    'Dictionary that remembers insertion order'
+    # An inherited dict maps keys to values.
+    # The inherited dict provides __getitem__, __len__, __contains__, and get.
+    # The remaining methods are order-aware.
+    # Big-O running times for all methods are the same as for regular dictionaries.
+
+    # The internal self.__map dictionary maps keys to links in a doubly linked list.
+    # The circular doubly linked list starts and ends with a sentinel element.
+    # The sentinel element never gets deleted (this simplifies the algorithm).
+    # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+
+    def __init__(self, *args, **kwds):
+        '''Initialize an ordered dictionary.  Signature is the same as for
+        regular dictionaries, but keyword arguments are not recommended
+        because their insertion order is arbitrary.
+
+        '''
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__root
+        except AttributeError:
+            self.__root = root = [None, None, None]     # sentinel node
+            PREV = 0
+            NEXT = 1
+            root[PREV] = root[NEXT] = root
+            self.__map = {}
+        self.update(*args, **kwds)
+
+    def __setitem__(self, key, value, PREV=0, NEXT=1, dict_setitem=dict.__setitem__):
+        'od.__setitem__(i, y) <==> od[i]=y'
+        # Setting a new item creates a new link which goes at the end of the linked
+        # list, and the inherited dictionary is updated with the new key/value pair.
+        if key not in self:
+            root = self.__root
+            last = root[PREV]
+            last[NEXT] = root[PREV] = self.__map[key] = [last, root, key]
+        dict_setitem(self, key, value)
+
+    def __delitem__(self, key, PREV=0, NEXT=1, dict_delitem=dict.__delitem__):
+        'od.__delitem__(y) <==> del od[y]'
+        # Deleting an existing item uses self.__map to find the link which is
+        # then removed by updating the links in the predecessor and successor nodes.
+        dict_delitem(self, key)
+        link = self.__map.pop(key)
+        link_prev = link[PREV]
+        link_next = link[NEXT]
+        link_prev[NEXT] = link_next
+        link_next[PREV] = link_prev
+
+    def __iter__(self, NEXT=1, KEY=2):
+        'od.__iter__() <==> iter(od)'
+        # Traverse the linked list in order.
+        root = self.__root
+        curr = root[NEXT]
+        while curr is not root:
+            yield curr[KEY]
+            curr = curr[NEXT]
+
+    def __reversed__(self, PREV=0, KEY=2):
+        'od.__reversed__() <==> reversed(od)'
+        # Traverse the linked list in reverse order.
+        root = self.__root
+        curr = root[PREV]
+        while curr is not root:
+            yield curr[KEY]
+            curr = curr[PREV]
+
+    def __reduce__(self):
+        'Return state information for pickling'
+        items = [[k, self[k]] for k in self]
+        tmp = self.__map, self.__root
+        del self.__map, self.__root
+        inst_dict = vars(self).copy()
+        self.__map, self.__root = tmp
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
+
+    def clear(self):
+        'od.clear() -> None.  Remove all items from od.'
+        try:
+            for node in self.__map.itervalues():
+                del node[:]
+            self.__root[:] = [self.__root, self.__root, None]
+            self.__map.clear()
+        except AttributeError:
+            pass
+        dict.clear(self)
+
+    setdefault = MutableMapping.setdefault
+    update = MutableMapping.update
+    pop = MutableMapping.pop
+    keys = MutableMapping.keys
+    values = MutableMapping.values
+    items = MutableMapping.items
+    iterkeys = MutableMapping.iterkeys
+    itervalues = MutableMapping.itervalues
+    iteritems = MutableMapping.iteritems
+    __ne__ = MutableMapping.__ne__
+
+    def popitem(self, last=True):
+        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+        Pairs are returned in LIFO order if last is true or FIFO order if false.
+
+        '''
+        if not self:
+            raise KeyError('dictionary is empty')
+        key = next(reversed(self) if last else iter(self))
+        value = self.pop(key)
+        return key, value
+
+    @_recursive_repr
+    def __repr__(self):
+        'od.__repr__() <==> repr(od)'
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, self.items())
+
+    def copy(self):
+        'od.copy() -> a shallow copy of od'
+        return self.__class__(self)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S
+        and values equal to v (which defaults to None).
+
+        '''
+        d = cls()
+        for key in iterable:
+            d[key] = value
+        return d
+
+    def __eq__(self, other):
+        '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+        while comparison to a regular mapping is order-insensitive.
+
+        '''
+        if isinstance(other, OrderedDict):
+            return len(self)==len(other) and \
+                   all(_imap(_eq, self.iteritems(), other.iteritems()))
+        return dict.__eq__(self, other)

--- a/pyasdf/compat/numpycompat.py
+++ b/pyasdf/compat/numpycompat.py
@@ -1,0 +1,10 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ..util import minversion
+
+
+__all__ = ['NUMPY_LT_1_7']
+
+
+NUMPY_LT_1_7 = not minversion('numpy', '1.7.0')

--- a/pyasdf/compat/odict.py
+++ b/pyasdf/compat/odict.py
@@ -1,0 +1,7 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ._odict_py2 import *

--- a/pyasdf/compression.py
+++ b/pyasdf/compression.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import numpy as np
 
-from astropy.extern import six
+import six
 
 
 def validate(compression):

--- a/pyasdf/conftest.py
+++ b/pyasdf/conftest.py
@@ -3,11 +3,11 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-# this contains imports plugins that configure py.test for astropy tests.
+# this contains imports plugins that configure py.test for pyasdf tests.
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+from pyasdf.tests.extern.pytest_plugins import *
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
@@ -16,10 +16,11 @@ enable_deprecations_as_exceptions()
 try:
     PYTEST_HEADER_MODULES['jsonschema'] = 'jsonschema'
     PYTEST_HEADER_MODULES['pyyaml'] = 'yaml'
+    PYTEST_HEADER_MODULES['six'] = 'six'
     del PYTEST_HEADER_MODULES['h5py']
     del PYTEST_HEADER_MODULES['Matplotlib']
     del PYTEST_HEADER_MODULES['Scipy']
-except NameError:  # needed to support Astropy < 1.0
+except NameError:
     pass
 
 
@@ -28,8 +29,9 @@ import os
 import shutil
 import tempfile
 
-from astropy.extern import six
-from astropy.tests.helper import pytest
+import pytest
+
+import six
 
 from .extern.RangeHTTPServer import RangeHTTPRequestHandler
 

--- a/pyasdf/extension.py
+++ b/pyasdf/extension.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import abc
 
-from astropy.extern import six
+import six
 
 from . import asdftypes
 from . import resolver

--- a/pyasdf/extern/RangeHTTPServer.py
+++ b/pyasdf/extern/RangeHTTPServer.py
@@ -31,15 +31,11 @@ __version__ = "0.1"
 
 __all__ = ["RangeHTTPRequestHandler"]
 
-import io
 import os
 import posixpath
-import urllib
-import cgi
 import shutil
-import mimetypes
 
-from astropy.extern import six
+import six
 
 
 class RangeHTTPRequestHandler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):  # pragma: no cover

--- a/pyasdf/extern/atomicfile.py
+++ b/pyasdf/extern/atomicfile.py
@@ -1,4 +1,4 @@
-from astropy.extern import six
+import six
 
 import os
 import tempfile

--- a/pyasdf/fits_embed.py
+++ b/pyasdf/fits_embed.py
@@ -11,12 +11,16 @@ import re
 
 import numpy as np
 
-from astropy.extern import six
-from astropy.io import fits
+import six
 
 from . import asdf
 from . import block
 from . import util
+
+try:
+    from astropy.io import fits
+except ImportError:
+    raise ImportError("AsdfInFits requires astropy")
 
 
 ASDF_EXTENSION_NAME = 'ASDF'

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -22,11 +22,10 @@ import tempfile
 
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 
-from astropy.extern import six
-from astropy.extern.six.moves import xrange
-from astropy.extern.six.moves.urllib import parse as urlparse
-from astropy.extern.six.moves.urllib.request import url2pathname
-from astropy.utils.misc import InheritDocstrings
+import six
+from six.moves import xrange
+from six.moves.urllib import parse as urlparse
+from six.moves.urllib.request import url2pathname
 
 import numpy as np
 
@@ -234,7 +233,7 @@ class _TruncatedReader(object):
         return content
 
 
-@six.add_metaclass(InheritDocstrings)
+@six.add_metaclass(util.InheritDocstrings)
 class GenericFile(object):
     """
     Base class for an abstraction layer around a number of different
@@ -1023,7 +1022,7 @@ def _make_http_connection(init, mode, uri=None):
     Creates a HTTPConnection instance if the HTTP server supports
     Range requests, otherwise falls back to a generic InputStream.
     """
-    from astropy.extern.six.moves import http_client
+    from six.moves import http_client
 
     parsed = urlparse.urlparse(init)
     connection = http_client.HTTPConnection(parsed.netloc)

--- a/pyasdf/reference.py
+++ b/pyasdf/reference.py
@@ -14,7 +14,7 @@ import weakref
 
 import numpy as np
 
-from astropy.extern.six.moves.urllib import parse as urlparse
+from six.moves.urllib import parse as urlparse
 
 from .asdftypes import AsdfType
 from . import generic_io

--- a/pyasdf/resolver.py
+++ b/pyasdf/resolver.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import os.path
 
-from astropy.extern import six
+import six
 
 from . import constants
 from . import util

--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -6,9 +6,8 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import json
 import os
 
-from astropy.extern import six
-from astropy.utils.compat.odict import OrderedDict
-from astropy.extern.six.moves.urllib import parse as urlparse
+import six
+from six.moves.urllib import parse as urlparse
 
 from jsonschema import validators as mvalidators
 from jsonschema.exceptions import ValidationError
@@ -16,6 +15,7 @@ from jsonschema.exceptions import ValidationError
 import yaml
 
 from .compat import lru_cache
+from .compat.odict import OrderedDict
 from . import constants
 from . import generic_io
 from . import reference

--- a/pyasdf/tagged.py
+++ b/pyasdf/tagged.py
@@ -33,8 +33,8 @@ is not intended to be exposed to the end user.
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import six
 
-from astropy.extern import six
 from .compat import UserDict, UserList, UserString
 
 

--- a/pyasdf/tags/core/complex.py
+++ b/pyasdf/tags/core/complex.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
+import six
 
 import numpy as np
 

--- a/pyasdf/tags/core/ndarray.py
+++ b/pyasdf/tags/core/ndarray.py
@@ -9,7 +9,7 @@ from numpy import ma
 
 from jsonschema import ValidationError
 
-from astropy.extern import six
+import six
 
 from ...asdftypes import AsdfType
 from ... import schema

--- a/pyasdf/tags/core/tests/setup_package.py
+++ b/pyasdf/tags/core/tests/setup_package.py
@@ -6,4 +6,4 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 def get_package_data():  # pragma: no cover
     return {
-        str(_ASTROPY_PACKAGE_NAME_ + '.tags.core.tests'): ['data/*.yaml']}
+        str(_PACKAGE_NAME_ + '.tags.core.tests'): ['data/*.yaml']}

--- a/pyasdf/tags/core/tests/test_complex.py
+++ b/pyasdf/tags/core/tests/test_complex.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.tests.helper import pytest
+import pytest
 
 from .... import asdf
 

--- a/pyasdf/tags/core/tests/test_history.py
+++ b/pyasdf/tags/core/tests/test_history.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.tests.helper import pytest
+import pytest
 
 from jsonschema import ValidationError
 

--- a/pyasdf/tags/core/tests/test_ndarray.py
+++ b/pyasdf/tags/core/tests/test_ndarray.py
@@ -15,8 +15,15 @@ except ImportError:
 else:
     HAS_PSUTIL = True
 
-from astropy.extern import six
-from astropy.tests.helper import pytest
+import six
+import pytest
+
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
 
 import numpy as np
 from numpy import ma
@@ -176,6 +183,7 @@ def test_table_inline(tmpdir):
         tree, tmpdir, None, check_raw_yaml, {'auto_inline': 64})
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_auto_inline_recursive(tmpdir):
     from astropy.modeling import models
     aff = models.AffineTransformation2D(matrix=[[1, 2], [3, 4]])

--- a/pyasdf/tags/fits/fits.py
+++ b/pyasdf/tags/fits/fits.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.io import fits
 import numpy as np
 
 from ...asdftypes import AsdfType
@@ -12,10 +11,13 @@ from ... import yamlutil
 
 class FitsType(AsdfType):
     name = 'fits/fits'
-    types = [fits.HDUList]
+    types = ['astropy.io.fits.HDUList']
+    requires = ['astropy']
 
     @classmethod
     def from_tree(cls, data, ctx):
+        from astropy.io import fits
+
         hdus = []
         first = True
         for hdu_entry in data:

--- a/pyasdf/tags/fits/tests/test_fits.py
+++ b/pyasdf/tags/fits/tests/test_fits.py
@@ -3,14 +3,26 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.io import fits
-from astropy.utils.data import get_pkg_data_filename
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+
+import pytest
+
+import os
 
 from ....tests import helpers
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_complex_structure(tmpdir):
-    with fits.open(get_pkg_data_filename('data/complex.fits'), memmap=False) as hdulist:
+    from astropy.io import fits
+
+    with fits.open(os.path.join(
+            os.path.dirname(__file__), 'data', 'complex.fits'), memmap=False) as hdulist:
         tree = {
             'fits': hdulist
             }

--- a/pyasdf/tags/time/tests/test_time.py
+++ b/pyasdf/tags/time/tests/test_time.py
@@ -3,16 +3,26 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
-from astropy import time
+import six
+
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy import time
 
 import numpy as np
+
+import pytest
 
 from .... import asdf
 from .... import yamlutil
 from ....tests import helpers
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_time(tmpdir):
     time_array = time.Time(
         np.arange(100), format="unix")
@@ -24,6 +34,7 @@ def test_time(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_isot(tmpdir):
     tree = {
         'time': time.Time('2000-01-01T00:00:00.000')

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -7,9 +7,7 @@ import datetime
 
 import numpy as np
 
-from astropy.extern import six
-from astropy import time
-from astropy import units as u
+import six
 
 from ...asdftypes import AsdfType
 from ... import yamlutil
@@ -25,13 +23,15 @@ _astropy_format_to_asdf_format = {
 }
 
 
-
 class TimeType(AsdfType):
     name = 'time/time'
-    types = [time.core.Time, datetime.datetime]
+    types = ['astropy.time.core.Time', datetime.datetime]
+    requires = ['astropy']
 
     @classmethod
     def to_tree(cls, node, ctx):
+        from astropy import time
+
         if isinstance(node, datetime.datetime):
             node = time.Time(node)
 
@@ -78,6 +78,9 @@ class TimeType(AsdfType):
 
     @classmethod
     def from_tree(cls, node, ctx):
+        from astropy import time
+        from astropy import units as u
+
         if isinstance(node, (six.string_types, list, np.ndarray)):
             t = time.Time(node)
             format = _astropy_format_to_asdf_format.get(t.format, t.format)

--- a/pyasdf/tags/transform/basic.py
+++ b/pyasdf/tags/transform/basic.py
@@ -111,10 +111,12 @@ class IdentityType(TransformType):
 
 class ConstantType(TransformType):
     name = "transform/constant"
-    types = ['functional_models.Const1D']
+    types = ['astropy.modeling.functional_models.Const1D']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy.modeling import functional_models
+
         return functional_models.Const1D(node['value'])
 
     @classmethod

--- a/pyasdf/tags/transform/compound.py
+++ b/pyasdf/tags/transform/compound.py
@@ -3,10 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
-from astropy import modeling
-from astropy.modeling.core import _CompoundModel
-from astropy.modeling.models import Mapping, Identity
+import six
 
 from ... import tagged
 from ... import yamlutil
@@ -41,11 +38,13 @@ _tag_to_method_mapping = {
 
 class CompoundType(TransformType):
     name = ['transform/' + x for x in _tag_to_method_mapping.keys()]
-    types = [_CompoundModel]
+    types = ['astropy.modeling.core._CompoundModel']
     handle_dynamic_subclasses = True
 
     @classmethod
     def from_tree_tagged(cls, node, ctx):
+        from astropy import modeling
+
         tag = node._tag[node._tag.rfind('/')+1:]
 
         oper = _tag_to_method_mapping[tag]
@@ -108,10 +107,12 @@ class CompoundType(TransformType):
 
 class RemapAxesType(TransformType):
     name = 'transform/remap_axes'
-    types = [Mapping]
+    types = ['astropy.modeling.models.Mapping']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy.modeling.models import Identity, Mapping
+
         mapping = node['mapping']
         n_inputs = node.get('n_inputs')
         if all([isinstance(x, six.integer_types) for x in mapping]):

--- a/pyasdf/tags/transform/polynomial.py
+++ b/pyasdf/tags/transform/polynomial.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from astropy import modeling
-
 from ... import yamlutil
 
 from .basic import TransformType
@@ -18,10 +16,12 @@ __all__ = ['ShiftType', 'ScaleType', 'PolynomialType']
 
 class ShiftType(TransformType):
     name = "transform/shift"
-    types = [modeling.models.Shift]
+    types = ['astropy.modeling.models.Shift']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         offset = node['offset']
         if not np.isscalar(offset):
             raise NotImplementedError(
@@ -36,6 +36,8 @@ class ShiftType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy import modeling
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, modeling.models.Shift) and
@@ -45,10 +47,12 @@ class ShiftType(TransformType):
 
 class ScaleType(TransformType):
     name = "transform/scale"
-    types = [modeling.models.Scale]
+    types = ['astropy.modeling.models.Scale']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         factor = node['factor']
         if not np.isscalar(factor):
             raise NotImplementedError(
@@ -63,6 +67,8 @@ class ScaleType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy import modeling
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, modeling.models.Scale) and
@@ -72,10 +78,13 @@ class ScaleType(TransformType):
 
 class PolynomialType(TransformType):
     name = "transform/polynomial"
-    types = [modeling.models.Polynomial1D, modeling.models.Polynomial2D]
+    types = ['astropy.modeling.models.Polynomial1D',
+             'astropy.modeling.models.Polynomial2D']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         coefficients = np.asarray(node['coefficients'])
         n_dim = coefficients.ndim
 
@@ -102,6 +111,8 @@ class PolynomialType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
+        from astropy import modeling
+
         if isinstance(model, modeling.models.Polynomial1D):
             coefficients = np.array(model.parameters)
         elif isinstance(model, modeling.models.Polynomial2D):
@@ -117,6 +128,8 @@ class PolynomialType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy import modeling
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, (modeling.models.Polynomial1D, modeling.models.Polynomial2D)) and

--- a/pyasdf/tags/transform/projections.py
+++ b/pyasdf/tags/transform/projections.py
@@ -67,6 +67,8 @@ class Rotate2DType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy import modeling
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, modeling.rotations.Rotation2D) and

--- a/pyasdf/tags/transform/projections.py
+++ b/pyasdf/tags/transform/projections.py
@@ -3,10 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-import numpy as np
 from numpy.testing import assert_array_equal
-
-from astropy import modeling
 
 from ... import yamlutil
 
@@ -21,12 +18,14 @@ __all__ = ['AffineType', 'Rotate2DType', 'Rotate3DType', 'ZenithalPerspectiveTyp
 
 class AffineType(TransformType):
     name = "transform/affine"
-    types = [modeling.projections.AffineTransformation2D]
+    types = ['astropy.modeling.projections.AffineTransformation2D']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         matrix = node['matrix']
-        translation  = node['translation']
+        translation = node['translation']
         if matrix.shape != (2, 2):
             raise NotImplementedError(
                 "pyasdf currently only supports 2x2 (2D) rotation transformation "
@@ -54,10 +53,12 @@ class AffineType(TransformType):
 
 class Rotate2DType(TransformType):
     name = "transform/rotate2d"
-    types = [modeling.rotations.Rotation2D]
+    types = ['astropy.modeling.rotations.Rotation2D']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         return modeling.rotations.Rotation2D(node['angle'])
 
     @classmethod
@@ -75,12 +76,14 @@ class Rotate2DType(TransformType):
 
 class Rotate3DType(TransformType):
     name = "transform/rotate3d"
-    types = [modeling.rotations.RotateNative2Celestial,
-             modeling.rotations.RotateCelestial2Native,
-             modeling.rotations.EulerAngleRotation]
+    types = ['astropy.modeling.rotations.RotateNative2Celestial',
+             'astropy.modeling.rotations.RotateCelestial2Native',
+             'astropy.modeling.rotations.EulerAngleRotation']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         if node['direction'] == 'native2celestial':
             return modeling.rotations.RotateNative2Celestial(node["phi"],
                                                              node["theta"],
@@ -98,6 +101,8 @@ class Rotate3DType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
+        from astropy import modeling
+
         if isinstance(model, modeling.rotations.RotateNative2Celestial):
             return {"phi": model.lon.value,
                     "theta": model.lat.value,
@@ -156,7 +161,8 @@ class ZenithalType(TransformType):
 
 class ZenithalPerspectiveType(ZenithalType):
     name = "transform/zenithal_perspective"
-    types = [modeling.projections.Pix2Sky_AZP, modeling.projections.Sky2Pix_AZP]
+    types = ['astropy.modeling.projections.Pix2Sky_AZP',
+             'astropy.modeling.projections.Sky2Pix_AZP']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -191,17 +197,20 @@ class ZenithalPerspectiveType(ZenithalType):
 
 class GnomonicType(ZenithalType):
     name = "transform/gnomonic"
-    types = [modeling.projections.Pix2Sky_TAN, modeling.projections.Sky2Pix_TAN]
+    types = ['astropy.modeling.projections.Pix2Sky_TAN',
+             'astropy.modeling.projections.Sky2Pix_TAN']
 
 
 class StereographicType(ZenithalType):
     name = "transform/stereographic"
-    types = [modeling.projections.Pix2Sky_STG, modeling.projections.Sky2Pix_STG]
+    types = ['astropy.modeling.projections.Pix2Sky_STG',
+             'astropy.modeling.projections.Sky2Pix_STG']
 
 
 class SlantOrthographicType(ZenithalType):
     name = "transform/slant_orthographic"
-    types = [modeling.projections.Pix2Sky_SIN, modeling.projections.Sky2Pix_SIN]
+    types = ['astropy.modeling.projections.Pix2Sky_SIN',
+             'astropy.modeling.projections.Sky2Pix_SIN']
 
 
 class CylindricalType(TransformType):
@@ -228,7 +237,8 @@ class CylindricalType(TransformType):
 
 class CylindricalPerspectiveType(CylindricalType):
     name = "transform/cylindrical_perspective"
-    types = [modeling.projections.Pix2Sky_CYP, modeling.projections.Sky2Pix_CYP]
+    types = ['astropy.modeling.projections.Pix2Sky_CYP',
+             'astropy.modeling.projections.Sky2Pix_CYP']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -263,7 +273,8 @@ class CylindricalPerspectiveType(CylindricalType):
 
 class CylindricalEqualAreaType(CylindricalType):
     name = "transform/cylindrical_equal_area"
-    types = [modeling.projections.Pix2Sky_CEA, modeling.projections.Sky2Pix_CEA]
+    types = ['astropy.modeling.projections.Pix2Sky_CEA',
+             'astropy.modeling.projections.Sky2Pix_CEA']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -294,9 +305,11 @@ class CylindricalEqualAreaType(CylindricalType):
 
 class PlateCarreeType(CylindricalType):
     name = "transforms/plate_carree"
-    types = [modeling.projections.Pix2Sky_CAR, modeling.projections.Sky2Pix_CAR]
+    types = ['astropy.modeling.projections.Pix2Sky_CAR',
+             'astropy.modeling.projections.Sky2Pix_CAR']
 
 
 class MercatorType(CylindricalType):
     name = "transforms/mercator"
-    types = [modeling.projections.Pix2Sky_MER, modeling.projections.Sky2Pix_MER]
+    types = ['astropy.modeling.projections.Pix2Sky_MER',
+             'astropy.modeling.projections.Sky2Pix_MER']

--- a/pyasdf/tags/transform/tests/test_transform.py
+++ b/pyasdf/tags/transform/tests/test_transform.py
@@ -3,19 +3,26 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.modeling import models as astmodels
-from astropy.tests.helper import pytest
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+    test_models = []
+else:
+    HAS_ASTROPY = True
+    from astropy.modeling import models as astmodels
 
+    test_models = [astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
+                   astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3), astmodels.Shift(2.),
+                   astmodels.Scale(3.4), astmodels.RotateNative2Celestial(5.63, -72.5, 180),
+                   astmodels.RotateCelestial2Native(5.63, -72.5, 180),
+                   astmodels.EulerAngleRotation(23, 14, 2.3, axes_order='xzx')]
+
+import pytest
 from ....tests import helpers
 
 
-test_models = [astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
-               astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3), astmodels.Shift(2.),
-               astmodels.Scale(3.4), astmodels.RotateNative2Celestial(5.63, -72.5, 180),
-               astmodels.RotateCelestial2Native(5.63, -72.5, 180),
-               astmodels.EulerAngleRotation(23, 14, 2.3, axes_order='xzx')]
-
-
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_transforms_compound(tmpdir):
     tree = {
         'compound':
@@ -29,6 +36,7 @@ def test_transforms_compound(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_inverse_transforms(tmpdir):
     rotation = astmodels.Rotation2D(32)
     rotation.inverse = astmodels.Rotation2D(45)
@@ -46,12 +54,14 @@ def test_inverse_transforms(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 @pytest.mark.parametrize(('model'), test_models)
 def test_single_model(tmpdir, model):
     tree = {'single_model': model}
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_name(tmpdir):
     def check(ff):
         assert ff.tree['rot'].name == 'foo'
@@ -60,6 +70,7 @@ def test_name(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_domain(tmpdir):
     def check(ff):
         assert ff.tree['rot'].meta['domain'] == {
@@ -72,6 +83,7 @@ def test_domain(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_zenithal_with_arguments(tmpdir):
     tree = {
         'azp': astmodels.Sky2Pix_AZP(0.5, 0.3)
@@ -80,6 +92,7 @@ def test_zenithal_with_arguments(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_naming_of_compound_model(tmpdir):
     """Issue #87"""
     def asdf_check(ff):

--- a/pyasdf/tags/unit/tests/test_unit.py
+++ b/pyasdf/tags/unit/tests/test_unit.py
@@ -5,7 +5,15 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import io
 
-from astropy import units as u
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy import units as u
+
+import pytest
 
 from .... import asdf
 from ....tests import helpers
@@ -14,6 +22,7 @@ from ....tests import helpers
 # TODO: Implement defunit
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_unit():
     yaml = """
 unit: !unit/unit "2.1798721  10-18kg m2 s-2"

--- a/pyasdf/tags/unit/unit.py
+++ b/pyasdf/tags/unit/unit.py
@@ -4,18 +4,20 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 
-from astropy.extern import six
-from astropy import units as u
+import six
 
 from ...asdftypes import AsdfType
 
 
 class UnitType(AsdfType):
     name = 'unit/unit'
-    types = [u.UnitBase]
+    types = ['astropy.units.UnitBase']
+    requires = ['astropy']
 
     @classmethod
     def to_tree(cls, node, ctx):
+        from astropy import units as u
+
         if isinstance(node, six.string_types):
             node = u.Unit(node, format='vounit', parse_strict='warn')
         if isinstance(node, u.UnitBase):
@@ -24,4 +26,6 @@ class UnitType(AsdfType):
 
     @classmethod
     def from_tree(cls, node, ctx):
+        from astropy import units as u
+
         return u.Unit(node, format='vounit', parse_strict='silent')

--- a/pyasdf/tests/data/missing.yaml
+++ b/pyasdf/tests/data/missing.yaml
@@ -1,0 +1,5 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://nowhere.org/schemas/custom/1.0.0/missing"
+type: object

--- a/pyasdf/tests/extern/README
+++ b/pyasdf/tests/extern/README
@@ -1,0 +1,4 @@
+The files in this directory are testing utilities copied from astropy.
+
+Care is taken to not edit these files so they can be easily updated
+from the astropy repository in the future.

--- a/pyasdf/tests/extern/__init__.py
+++ b/pyasdf/tests/extern/__init__.py
@@ -1,0 +1,6 @@
+"""
+The files in this directory are testing utilities copied from astropy.
+
+Care is taken to not edit these files so they can be easily updated
+from the astropy repository in the future.
+"""

--- a/pyasdf/tests/extern/astropy_helper.py
+++ b/pyasdf/tests/extern/astropy_helper.py
@@ -1,0 +1,391 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module provides the tools used to internally run the astropy test suite
+from the installed astropy.  It makes use of the `pytest` testing framework.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import six
+
+import errno
+import shlex
+import sys
+import multiprocessing
+import os
+import types
+import warnings
+
+__all__ = ['enable_deprecations_as_exceptions', 'remote_data',
+           'treat_deprecations_as_exceptions', 'catch_warnings']
+
+try:
+    # Import pkg_resources to prevent it from issuing warnings upon being
+    # imported from within py.test.  See
+    # https://github.com/astropy/astropy/pull/537 for a detailed explanation.
+    import pkg_resources
+except ImportError:
+    pass
+
+from ... import test
+
+
+import pytest
+
+
+# Monkey-patch py.test to work around issue #811
+# https://github.com/astropy/astropy/issues/811
+from _pytest.assertion import rewrite as _rewrite
+_orig_write_pyc = _rewrite._write_pyc
+
+
+def _write_pyc_wrapper(*args):
+    """Wraps the internal _write_pyc method in py.test to recognize
+    PermissionErrors and just stop trying to cache its generated pyc files if
+    it can't write them to the __pycache__ directory.
+
+    When py.test scans for test modules, it actually rewrites the bytecode
+    of each test module it discovers--this is how it manages to add extra
+    instrumentation to the assert builtin.  Normally it caches these
+    rewritten bytecode files--``_write_pyc()`` is just a function that handles
+    writing the rewritten pyc file to the cache.  If it returns ``False`` for
+    any reason py.test will stop trying to cache the files altogether.  The
+    original function catches some cases, but it has a long-standing bug of
+    not catching permission errors on the ``__pycache__`` directory in Python
+    3.  Hence this patch.
+    """
+
+    try:
+        return _orig_write_pyc(*args)
+    except IOError as e:
+        if e.errno == errno.EACCES:
+            return False
+_rewrite._write_pyc = _write_pyc_wrapper
+
+
+# pytest marker to mark tests which get data from the web
+remote_data = pytest.mark.remote_data
+
+
+class TestRunner(object):
+    def __init__(self, base_path):
+        self.base_path = base_path
+
+    def run_tests(self, package=None, test_path=None, args=None, plugins=None,
+                  verbose=False, pastebin=None, remote_data=False, pep8=False,
+                  pdb=False, coverage=False, open_files=False, parallel=0,
+                  docs_path=None, skip_docs=False, repeat=None):
+        """
+        The docstring for this method lives in astropy/__init__.py:test
+        """
+        if coverage:
+            warnings.warn(
+                "The coverage option is ignored on run_tests, since it "
+                "can not be made to work in that context.  Use "
+                "'python setup.py test --coverage' instead.")
+
+        all_args = []
+
+        if package is None:
+            package_path = self.base_path
+        else:
+            package_path = os.path.join(self.base_path,
+                                        package.replace('.', os.path.sep))
+
+            if not os.path.isdir(package_path):
+                raise ValueError('Package not found: {0}'.format(package))
+
+        if docs_path is not None and not skip_docs:
+            if package is not None:
+                docs_path = os.path.join(
+                    docs_path, package.replace('.', os.path.sep))
+            if not os.path.exists(docs_path):
+                warnings.warn(
+                    "Can not test .rst docs, since docs path "
+                    "({0}) does not exist.".format(docs_path))
+                docs_path = None
+
+        if test_path:
+            base, ext = os.path.splitext(test_path)
+
+            if ext in ('.rst', ''):
+                if docs_path is None:
+                    # This shouldn't happen from "python setup.py test"
+                    raise ValueError(
+                        "Can not test .rst files without a docs_path "
+                        "specified.")
+
+                abs_docs_path = os.path.abspath(docs_path)
+                abs_test_path = os.path.abspath(
+                    os.path.join(abs_docs_path, os.pardir, test_path))
+
+                common = os.path.commonprefix((abs_docs_path, abs_test_path))
+
+                if os.path.exists(abs_test_path) and common == abs_docs_path:
+                    # Since we aren't testing any Python files within
+                    # the astropy tree, we need to forcibly load the
+                    # astropy py.test plugins, and then turn on the
+                    # doctest_rst plugin.
+                    all_args.extend(['-p', 'astropy.tests.pytest_plugins',
+                                     '--doctest-rst'])
+                    test_path = abs_test_path
+
+            if not (os.path.isdir(test_path) or ext in ('.py', '.rst')):
+                raise ValueError("Test path must be a directory or a path to "
+                                 "a .py or .rst file")
+
+            all_args.append(test_path)
+        else:
+            all_args.append(package_path)
+            if docs_path is not None and not skip_docs:
+                all_args.extend([docs_path, '--doctest-rst'])
+
+        # add any additional args entered by the user
+        if args is not None:
+            all_args.extend(
+                shlex.split(args, posix=not sys.platform.startswith('win')))
+
+        # add verbosity flag
+        if verbose:
+            all_args.append('-v')
+
+        # turn on pastebin output
+        if pastebin is not None:
+            if pastebin in ['failed', 'all']:
+                all_args.append('--pastebin={0}'.format(pastebin))
+            else:
+                raise ValueError("pastebin should be 'failed' or 'all'")
+
+        # run @remote_data tests
+        if remote_data:
+            all_args.append('--remote-data')
+
+        if pep8:
+            try:
+                import pytest_pep8
+            except ImportError:
+                raise ImportError('PEP8 checking requires pytest-pep8 plugin: '
+                                  'http://pypi.python.org/pypi/pytest-pep8')
+            else:
+                all_args.extend(['--pep8', '-k', 'pep8'])
+
+        # activate post-mortem PDB for failing tests
+        if pdb:
+            all_args.append('--pdb')
+
+        # check for opened files after each test
+        if open_files:
+            if parallel != 0:
+                raise SystemError(
+                    "open file detection may not be used in conjunction with "
+                    "parallel testing.")
+
+            try:
+                import psutil
+            except ImportError:
+                raise SystemError(
+                    "open file detection requested, but psutil package "
+                    "is not installed.")
+
+            all_args.append('--open-files')
+
+            print("Checking for unclosed files")
+
+        if parallel != 0:
+            try:
+                import xdist
+            except ImportError:
+                raise ImportError(
+                    'Parallel testing requires the pytest-xdist plugin '
+                    'https://pypi.python.org/pypi/pytest-xdist')
+
+            try:
+                parallel = int(parallel)
+            except ValueError:
+                raise ValueError(
+                    "parallel must be an int, got {0}".format(parallel))
+
+            if parallel < 0:
+                parallel = multiprocessing.cpu_count()
+            all_args.extend(['-n', six.text_type(parallel)])
+
+        if repeat:
+            all_args.append('--repeat={0}'.format(repeat))
+
+        if six.PY2:
+            all_args = [x.encode('utf-8') for x in all_args]
+
+        print(all_args)
+        return pytest.main(args=all_args, plugins=plugins)
+
+    run_tests.__doc__ = test.__doc__
+
+
+# This is for Python 2.x and 3.x compatibility.  distutils expects
+# options to all be byte strings on Python 2 and Unicode strings on
+# Python 3.
+def _fix_user_options(options):
+    def to_str_or_none(x):
+        if x is None:
+            return None
+        return str(x)
+
+    return [tuple(to_str_or_none(x) for x in y) for y in options]
+
+
+def _save_coverage(cov, result, rootdir, testing_path):
+    """
+    This method is called after the tests have been run in coverage mode
+    to cleanup and then save the coverage data and report.
+    """
+    from ..utils.console import color_print
+
+    if result != 0:
+        return
+
+    # The coverage report includes the full path to the temporary
+    # directory, so we replace all the paths with the true source
+    # path. This means that the coverage line-by-line report will only
+    # be correct for Python 2 code (since the Python 3 code will be
+    # different in the build directory from the source directory as
+    # long as 2to3 is needed). Therefore we only do this fix for
+    # Python 2.x.
+    if six.PY2:
+        d = cov.data
+        cov._harvest_data()
+        for key in d.lines.keys():
+            new_path = os.path.relpath(
+                os.path.realpath(key),
+                os.path.realpath(testing_path))
+            new_path = os.path.abspath(
+                os.path.join(rootdir, new_path))
+            d.lines[new_path] = d.lines.pop(key)
+
+    color_print('Saving coverage data in .coverage...', 'green')
+    cov.save()
+
+    color_print('Saving HTML coverage report in htmlcov...', 'green')
+    cov.html_report(directory=os.path.join(rootdir, 'htmlcov'))
+
+
+_deprecations_as_exceptions = False
+_include_astropy_deprecations = True
+
+def enable_deprecations_as_exceptions(include_astropy_deprecations=True):
+    """
+    Turn on the feature that turns deprecations into exceptions.
+    """
+
+    global _deprecations_as_exceptions
+    _deprecations_as_exceptions = True
+
+    global _include_astropy_deprecations
+    _include_astropy_deprecations = include_astropy_deprecations
+
+
+def treat_deprecations_as_exceptions():
+    """
+    Turn all DeprecationWarnings (which indicate deprecated uses of
+    Python itself or Numpy, but not within Astropy, where we use our
+    own deprecation warning class) into exceptions so that we find
+    out about them early.
+
+    This completely resets the warning filters and any "already seen"
+    warning state.
+    """
+    if not _deprecations_as_exceptions:
+        return
+
+    # First, totally reset the warning state
+    for module in list(six.itervalues(sys.modules)):
+        # We don't want to deal with six.MovedModules, only "real"
+        # modules.
+        if (isinstance(module, types.ModuleType) and
+            hasattr(module, '__warningregistry__')):
+            del module.__warningregistry__
+
+    warnings.resetwarnings()
+
+    # Hide the next couple of DeprecationWarnings
+    warnings.simplefilter('ignore', DeprecationWarning)
+    # Here's the wrinkle: a couple of our third-party dependencies
+    # (py.test and scipy) are still using deprecated features
+    # themselves, and we'd like to ignore those.  Fortunately, those
+    # show up only at import time, so if we import those things *now*,
+    # before we turn the warnings into exceptions, we're golden.
+    try:
+        # A deprecated stdlib module used by py.test
+        import compiler
+    except ImportError:
+        pass
+
+    # Now, start over again with the warning filters
+    warnings.resetwarnings()
+    # Now, turn DeprecationWarnings into exceptions
+    warnings.filterwarnings("error", ".*", DeprecationWarning)
+
+    if sys.version_info[:2] == (2, 6):
+        # py.test's warning.showwarning does not include the line argument
+        # on Python 2.6, so we need to explicitly ignore this warning.
+        warnings.filterwarnings(
+            "always",
+            r"functions overriding warnings\.showwarning\(\) must support "
+            r"the 'line' argument",
+            DeprecationWarning)
+
+    if sys.version_info[:2] >= (3, 4):
+        # py.test reads files with the 'U' flag, which is now
+        # deprecated in Python 3.4.
+        warnings.filterwarnings(
+            "always",
+            r"'U' mode is deprecated",
+            DeprecationWarning)
+
+        # BeautifulSoup4 triggers a DeprecationWarning in stdlib's
+        # html module.x
+        warnings.filterwarnings(
+            "always",
+            "The strict argument and mode are deprecated.",
+            DeprecationWarning)
+        warnings.filterwarnings(
+            "always",
+            "The value of convert_charrefs will become True in 3.5. "
+            "You are encouraged to set the value explicitly.",
+            DeprecationWarning)
+
+
+class catch_warnings(warnings.catch_warnings):
+    """
+    A high-powered version of warnings.catch_warnings to use for testing
+    and to make sure that there is no dependence on the order in which
+    the tests are run.
+
+    This completely blitzes any memory of any warnings that have
+    appeared before so that all warnings will be caught and displayed.
+
+    ``*args`` is a set of warning classes to collect.  If no arguments are
+    provided, all warnings are collected.
+
+    Use as follows::
+
+        with catch_warnings(MyCustomWarning) as w:
+            do.something.bad()
+        assert len(w) > 0
+    """
+    def __init__(self, *classes):
+        super(catch_warnings, self).__init__(record=True)
+        self.classes = classes
+
+    def __enter__(self):
+        warning_list = super(catch_warnings, self).__enter__()
+        treat_deprecations_as_exceptions()
+        if len(self.classes) == 0:
+            warnings.simplefilter('always')
+        else:
+            warnings.simplefilter('ignore')
+            for cls in self.classes:
+                warnings.simplefilter('always', cls)
+        return warning_list
+
+    def __exit__(self, type, value, traceback):
+        treat_deprecations_as_exceptions()

--- a/pyasdf/tests/extern/disable_internet.py
+++ b/pyasdf/tests/extern/disable_internet.py
@@ -1,0 +1,147 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import contextlib
+import socket
+
+from six.moves import urllib
+
+# save original socket method for restoration
+# These are global so that re-calling the turn_off_internet function doesn't
+# overwrite them again
+socket_original = socket.socket
+socket_create_connection = socket.create_connection
+socket_bind = socket.socket.bind
+socket_connect = socket.socket.connect
+
+
+INTERNET_OFF = False
+
+# urllib2 uses a global variable to cache its default "opener" for opening
+# connections for various protocols; we store it off here so we can restore to
+# the default after re-enabling internet use
+_orig_opener = None
+
+
+# ::1 is apparently another valid name for localhost?
+# it is returned by getaddrinfo when that function is given localhost
+
+def check_internet_off(original_function):
+    """
+    Wraps ``original_function``, which in most cases is assumed
+    to be a `socket.socket` method, to raise an `IOError` for any operations
+    on non-local AF_INET sockets.
+    """
+
+    def new_function(*args, **kwargs):
+        if isinstance(args[0], socket.socket):
+            if not args[0].family in (socket.AF_INET, socket.AF_INET6):
+                # Should be fine in all but some very obscure cases
+                # More to the point, we don't want to affect AF_UNIX
+                # sockets.
+                return original_function(*args, **kwargs)
+            host = args[1][0]
+            addr_arg = 1
+            valid_hosts = ('localhost', '127.0.0.1', '::1')
+        else:
+            # The only other function this is used to wrap currently is
+            # socket.create_connection, which should be passed a 2-tuple, but
+            # we'll check just in case
+            if not (isinstance(args[0], tuple) and len(args[0]) == 2):
+                return original_function(*args, **kwargs)
+
+            host = args[0][0]
+            addr_arg = 0
+            valid_hosts = ('localhost', '127.0.0.1')
+
+        hostname = socket.gethostname()
+        fqdn = socket.getfqdn()
+
+        if host in (hostname, fqdn):
+            host = 'localhost'
+            new_addr = (host, args[addr_arg][1])
+            args = args[:addr_arg] + (new_addr,) + args[addr_arg + 1:]
+
+        if any([h in host for h in valid_hosts]):
+            return original_function(*args, **kwargs)
+        else:
+            raise IOError("An attempt was made to connect to the internet "
+                          "by a test that was not marked `remote_data`.")
+    return new_function
+
+
+def turn_off_internet(verbose=False):
+    """
+    Disable internet access via python by preventing connections from being
+    created using the socket module.  Presumably this could be worked around by
+    using some other means of accessing the internet, but all default python
+    modules (urllib, requests, etc.) use socket [citation needed].
+    """
+
+    global INTERNET_OFF
+    global _orig_opener
+
+    if INTERNET_OFF:
+        return
+
+    INTERNET_OFF = True
+
+    __tracebackhide__ = True
+    if verbose:
+        print("Internet access disabled")
+
+    # Update urllib2 to force it not to use any proxies
+    # Must use {} here (the default of None will kick off an automatic search
+    # for proxies)
+    _orig_opener = urllib.request.build_opener()
+    no_proxy_handler = urllib.request.ProxyHandler({})
+    opener = urllib.request.build_opener(no_proxy_handler)
+    urllib.request.install_opener(opener)
+
+    socket.create_connection = check_internet_off(socket_create_connection)
+    socket.socket.bind = check_internet_off(socket_bind)
+    socket.socket.connect = check_internet_off(socket_connect)
+
+    return socket
+
+
+def turn_on_internet(verbose=False):
+    """
+    Restore internet access.  Not used, but kept in case it is needed.
+    """
+
+    global INTERNET_OFF
+    global _orig_opener
+
+    if not INTERNET_OFF:
+        return
+
+    INTERNET_OFF = False
+
+    if verbose:
+        print("Internet access enabled")
+
+    urllib.request.install_opener(_orig_opener)
+
+    socket.create_connection = socket_create_connection
+    socket.socket.bind = socket_bind
+    socket.socket.connect = socket_connect
+    return socket
+
+
+@contextlib.contextmanager
+def no_internet(verbose=False):
+    """Context manager to temporarily disable internet access (if not already
+    disabled).  If it was already disabled before entering the context manager
+    (i.e. `turn_off_internet` was called previously) then this is a no-op and
+    leaves internet access disabled until a manual call to `turn_on_internet`.
+    """
+
+    already_disabled = INTERNET_OFF
+
+    turn_off_internet(verbose=verbose)
+    try:
+        yield
+    finally:
+        if not already_disabled:
+            turn_on_internet(verbose=verbose)

--- a/pyasdf/tests/extern/output_checker.py
+++ b/pyasdf/tests/extern/output_checker.py
@@ -1,0 +1,168 @@
+"""
+Implements a replacement for `doctest.OutputChecker` that handles certain
+normalizations of Python expression output.  See the docstring on
+`AstropyOutputChecker` for more details.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import doctest
+import re
+
+# Much of this code, particularly the parts of floating point handling, is
+# borrowed from the SymPy project with permission.  See licenses/SYMPY.rst
+# for the full SymPy license.
+
+FIX = doctest.register_optionflag('FIX')
+FLOAT_CMP = doctest.register_optionflag('FLOAT_CMP')
+
+
+class AstropyOutputChecker(doctest.OutputChecker):
+    """
+    - Removes u'' prefixes on string literals
+    - Ignores the 'L' suffix on long integers
+    - In Numpy dtype strings, removes the leading pipe, i.e. '|S9' ->
+      'S9'.  Numpy 1.7 no longer includes it in display.
+    - Supports the FLOAT_CMP flag, which parses floating point values
+      out of the output and compares their numerical values rather than their
+      string representation.  This naturally supports complex numbers as well
+      (simply by comparing their real and imaginary parts separately).
+    """
+
+    _original_output_checker = doctest.OutputChecker
+
+    _str_literal_re = re.compile(
+        r"(\W|^)[uU]([rR]?[\'\"])", re.UNICODE)
+    _byteorder_re = re.compile(
+        r"([\'\"])[|<>]([biufcSaUV][0-9]+)([\'\"])", re.UNICODE)
+    _fix_32bit_re = re.compile(
+        r"([\'\"])([iu])[48]([\'\"])", re.UNICODE)
+    _long_int_re = re.compile(
+        r"([0-9]+)L", re.UNICODE)
+
+    def __init__(self):
+        # NOTE OutputChecker is an old-style class with no __init__ method,
+        # so we can't call the base class version of __init__ here
+
+        exp = r'(?:e[+-]?\d+)'
+
+        got_floats = r'(\d+\.\d*%s?|\.\d+%s?|\d+%s)' % (exp, exp, exp)
+
+        # floats in the 'want' string may contain ellipses
+        want_floats = got_floats + r'(\.{3})?'
+
+        front_sep = r'\s|[+*,(<=-]'
+        back_sep = front_sep + r'|[)>j]'
+
+        fbeg = r'^%s(?=%s|$)' % (got_floats, back_sep)
+        fmidend = r'(?<=%s)%s(?=%s|$)' % (front_sep, got_floats, back_sep)
+        self.num_got_rgx = re.compile(r'(%s|%s)' %(fbeg, fmidend))
+
+        fbeg = r'^%s(?=%s|$)' % (want_floats, back_sep)
+        fmidend = r'(?<=%s)%s(?=%s|$)' % (front_sep, want_floats, back_sep)
+        self.num_want_rgx = re.compile(r'(%s|%s)' %(fbeg, fmidend))
+
+    def do_fixes(self, want, got):
+        want = re.sub(self._str_literal_re, r'\1\2', want)
+        want = re.sub(self._byteorder_re, r'\1\2\3', want)
+        want = re.sub(self._fix_32bit_re, r'\1\2\3', want)
+        want = re.sub(self._long_int_re, r'\1', want)
+
+        got = re.sub(self._str_literal_re, r'\1\2', got)
+        got = re.sub(self._byteorder_re, r'\1\2\3', got)
+        got = re.sub(self._fix_32bit_re, r'\1\2\3', got)
+        got = re.sub(self._long_int_re, r'\1', got)
+
+        return want, got
+
+    def normalize_floats(self, want, got, flags):
+        """
+        Alternative to the built-in check_output that also handles parsing
+        float values and comparing their numeric values rather than their
+        string representations.
+
+        This requires rewriting enough of the basic check_output that, when
+        FLOAT_CMP is enabled, it totally takes over for check_output.
+        """
+
+        # Handle the common case first, for efficiency:
+        # if they're string-identical, always return true.
+        if got == want:
+            return True
+
+        # TODO parse integers as well ?
+        # Parse floats and compare them. If some of the parsed floats contain
+        # ellipses, skip the comparison.
+        matches = self.num_got_rgx.finditer(got)
+        numbers_got = [match.group(1) for match in matches]  # list of strs
+        matches = self.num_want_rgx.finditer(want)
+        numbers_want = [match.group(1) for match in matches]  # list of strs
+        if len(numbers_got) != len(numbers_want):
+            return False
+
+        if len(numbers_got) > 0:
+            nw_ = []
+            for ng, nw in zip(numbers_got, numbers_want):
+                if '...' in nw:
+                    nw_.append(ng)
+                    continue
+                else:
+                    nw_.append(nw)
+
+                if abs(float(ng)-float(nw)) > 1e-5:
+                    return False
+
+            got = self.num_got_rgx.sub(r'%s', got)
+            got = got % tuple(nw_)
+
+        # <BLANKLINE> can be used as a special sequence to signify a
+        # blank line, unless the DONT_ACCEPT_BLANKLINE flag is used.
+        if not (flags & doctest.DONT_ACCEPT_BLANKLINE):
+            # Replace <BLANKLINE> in want with a blank line.
+            want = re.sub('(?m)^%s\s*?$' % re.escape(doctest.BLANKLINE_MARKER),
+                          '', want)
+            # If a line in got contains only spaces, then remove the
+            # spaces.
+            got = re.sub('(?m)^\s*?$', '', got)
+            if got == want:
+                return True
+
+        # This flag causes doctest to ignore any differences in the
+        # contents of whitespace strings. Note that this can be used
+        # in conjunction with the ELLIPSIS flag.
+        if flags & doctest.NORMALIZE_WHITESPACE:
+            got = ' '.join(got.split())
+            want = ' '.join(want.split())
+            if got == want:
+                return True
+
+        # The ELLIPSIS flag says to let the sequence "..." in `want`
+        # match any substring in `got`.
+        if flags & doctest.ELLIPSIS:
+            if doctest._ellipsis_match(want, got):
+                return True
+
+        # We didn't find any match; return false.
+        return False
+
+    def check_output(self, want, got, flags):
+        if flags & FIX:
+            want, got = self.do_fixes(want, got)
+
+        if flags & FLOAT_CMP:
+            return self.normalize_floats(want, got, flags)
+
+        # Can't use super here because doctest.OutputChecker is not a
+        # new-style class.
+        return self._original_output_checker.check_output(
+            self, want, got, flags)
+
+    def output_difference(self, want, got, flags):
+        if flags & FIX:
+            want, got = self.do_fixes(want, got)
+
+        # Can't use super here because doctest.OutputChecker is not a
+        # new-style class.
+        return self._original_output_checker.output_difference(
+            self, want, got, flags)

--- a/pyasdf/tests/extern/pytest_plugins.py
+++ b/pyasdf/tests/extern/pytest_plugins.py
@@ -1,0 +1,735 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+These plugins modify the behavior of py.test and are meant to be imported
+into conftest.py in the root directory.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import __future__
+
+import six
+from six.moves import filter
+
+import pytest
+
+import ast
+import doctest
+import fnmatch
+import imp
+import io
+import locale
+import math
+import os
+import re
+import sys
+import types
+
+from .astropy_helper import (treat_deprecations_as_exceptions,
+                             enable_deprecations_as_exceptions)
+from .disable_internet import turn_off_internet, turn_on_internet
+from .output_checker import AstropyOutputChecker, FIX, FLOAT_CMP
+from ...compat.odict import OrderedDict
+
+# Needed for Python 2.6 compatibility
+try:
+    import importlib.machinery as importlib_machinery
+except ImportError:
+    importlib_machinery = None
+
+# these pytest hooks allow us to mark tests and run the marked tests with
+# specific command line options.
+
+
+def pytest_addoption(parser):
+    parser.addoption("--remote-data", action="store_true",
+                     help="run tests with online data")
+    parser.addoption("--open-files", action="store_true",
+                     help="fail if any test leaves files open")
+
+    parser.addoption("--doctest-plus", action="store_true",
+                     help="enable running doctests with additional "
+                     "features not found in the normal doctest "
+                     "plugin")
+
+    parser.addoption("--doctest-rst", action="store_true",
+                     help="enable running doctests in .rst documentation")
+
+    parser.addini("doctest_plus", "enable running doctests with additional "
+                  "features not found in the normal doctest plugin")
+
+    parser.addini("doctest_norecursedirs",
+                  "like the norecursedirs option but applies only to doctest "
+                  "collection", type="args", default=())
+
+    parser.addini("doctest_rst",
+                  "Run the doctests in the rst documentation",
+                  default=False)
+
+    parser.addini("open_files_ignore",
+                  "when used with the --open-files option, allows "
+                  "specifying names of files that may be ignored when "
+                  "left open between tests--files in this list are matched "
+                  "may be specified by their base name (ignoring their full "
+                  "path) or by absolute path", type="args", default=())
+
+    parser.addoption('--repeat', action='store',
+                     help='Number of times to repeat each test')
+
+
+def pytest_generate_tests(metafunc):
+
+    # If the repeat option is set, we add a fixture for the repeat count and
+    # parametrize the tests over the repeats. Solution adapted from:
+    # http://stackoverflow.com/q/21764473/180783
+
+    if metafunc.config.option.repeat is not None:
+        count = int(metafunc.config.option.repeat)
+        metafunc.fixturenames.append('tmp_ct')
+        metafunc.parametrize('tmp_ct', range(count))
+
+# We monkey-patch in our replacement doctest OutputChecker.  Not
+# great, but there isn't really an API to replace the checker when
+# using doctest.testfile, unfortunately.
+doctest.OutputChecker = AstropyOutputChecker
+
+
+REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
+
+
+def pytest_configure(config):
+    treat_deprecations_as_exceptions()
+
+    # Monkeypatch to deny access to remote resources unless explicitly told
+    # otherwise
+    if not config.getoption('remote_data'):
+        turn_off_internet(verbose=config.option.verbose)
+
+    doctest_plugin = config.pluginmanager.getplugin('doctest')
+    if (doctest_plugin is None or config.option.doctestmodules or not
+            (config.getini('doctest_plus') or config.option.doctest_plus)):
+        return
+
+    # These are the default doctest options we use for everything.
+    # There shouldn't be any need to manually put them in doctests
+    # themselves.
+    opts = (doctest.ELLIPSIS |
+            doctest.NORMALIZE_WHITESPACE |
+            FIX)
+
+    class DocTestModulePlus(doctest_plugin.DoctestModule):
+        # pytest 2.4.0 defines "collect".  Prior to that, it defined
+        # "runtest".  The "collect" approach is better, because we can
+        # skip modules altogether that have no doctests.  However, we
+        # need to continue to override "runtest" so that the built-in
+        # behavior (which doesn't do whitespace normalization or
+        # handling __doctest_skip__) doesn't happen.
+        def collect(self):
+            if self.fspath.basename == "conftest.py":
+                module = self.config._conftest.importconftest(self.fspath)
+            else:
+                try:
+                    module = self.fspath.pyimport()
+                    # Just ignore searching modules that can't be imported when
+                    # collecting doctests
+                except ImportError:
+                    raise StopIteration
+
+            # uses internal doctest module parsing mechanism
+            finder = DocTestFinderPlus()
+            runner = doctest.DebugRunner(verbose=False, optionflags=opts)
+            for test in finder.find(module):
+                if test.examples:  # skip empty doctests
+                    if not config.getvalue("remote_data"):
+                        for example in test.examples:
+                            if example.options.get(REMOTE_DATA):
+                                example.options[doctest.SKIP] = True
+
+                    yield doctest_plugin.DoctestItem(
+                        test.name, self, runner, test)
+
+        # This is for py.test prior to 2.4.0
+        def runtest(self):
+            return
+
+    class DocTestTextfilePlus(doctest_plugin.DoctestTextfile):
+        def runtest(self):
+            # satisfy `FixtureRequest` constructor...
+            self.funcargs = {}
+            self._fixtureinfo = doctest_plugin.FuncFixtureInfo((), [], {})
+            fixture_request = doctest_plugin.FixtureRequest(self)
+            failed, tot = doctest.testfile(
+                str(self.fspath), module_relative=False,
+                optionflags=opts, parser=DocTestParserPlus(),
+                extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
+                raise_on_error=True, verbose=False, encoding='utf-8')
+
+    class DocTestParserPlus(doctest.DocTestParser):
+        """
+        An extension to the builtin DocTestParser that handles the
+        special directives for skipping tests.
+
+        The directives are:
+
+           - ``.. doctest-skip::``: Skip the next doctest chunk.
+
+           - ``.. doctest-requires:: module1, module2``: Skip the next
+             doctest chunk if the given modules/packages are not
+             installed.
+
+           - ``.. doctest-skip-all``: Skip all subsequent doctests.
+        """
+
+        def parse(self, s, name=None):
+            result = doctest.DocTestParser.parse(self, s, name=name)
+
+            # result is a sequence of alternating text chunks and
+            # doctest.Example objects.  We need to look in the text
+            # chunks for the special directives that help us determine
+            # whether the following examples should be skipped.
+
+            required = []
+            skip_next = False
+            skip_all = False
+
+            for entry in result:
+                if isinstance(entry, six.string_types) and entry:
+                    required = []
+                    skip_next = False
+                    lines = entry.strip().splitlines()
+
+                    if '.. doctest-skip-all' in (x.strip() for x in lines):
+                        skip_all = True
+                        continue
+
+                    if not len(lines):
+                        continue
+
+                    last_line = lines[-1]
+                    match = re.match(
+                        r'\.\.\s+doctest-skip\s*::(\s+.*)?', last_line)
+                    if match:
+                        marker = match.group(1)
+                        if (marker is None or
+                                (marker.strip() == 'win32' and
+                                 sys.platform == 'win32')):
+                            skip_next = True
+                            continue
+
+                    match = re.match(
+                        r'\.\.\s+doctest-requires\s*::\s+(.*)',
+                        last_line)
+                    if match:
+                        required = re.split(r'\s*,?\s*', match.group(1))
+                elif isinstance(entry, doctest.Example):
+                    if (skip_all or skip_next or
+                        not DocTestFinderPlus.check_required_modules(required)):
+                        entry.options[doctest.SKIP] = True
+
+                    if (not config.getvalue('remote_data') and
+                        entry.options.get(REMOTE_DATA)):
+                        entry.options[doctest.SKIP] = True
+
+            return result
+
+    config.pluginmanager.register(
+        DoctestPlus(DocTestModulePlus, DocTestTextfilePlus,
+                    config.getini('doctest_rst') or config.option.doctest_rst),
+        'doctestplus')
+
+    # Remove the doctest_plugin, or we'll end up testing the .rst
+    # files twice.
+    config.pluginmanager.unregister(doctest_plugin)
+
+
+class DoctestPlus(object):
+    def __init__(self, doctest_module_item_cls, doctest_textfile_item_cls,
+                 run_rst_doctests):
+        """
+        doctest_module_item_cls should be a class inheriting
+        `pytest.doctest.DoctestItem` and `pytest.File`.  This class handles
+        running of a single doctest found in a Python module.  This is passed
+        in as an argument because the actual class to be used may not be
+        available at import time, depending on whether or not the doctest
+        plugin for py.test is available.
+        """
+        self._doctest_module_item_cls = doctest_module_item_cls
+        self._doctest_textfile_item_cls = doctest_textfile_item_cls
+        self._run_rst_doctests = run_rst_doctests
+
+        # Directories to ignore when adding doctests
+        self._ignore_paths = []
+
+        if run_rst_doctests and six.PY3:
+            self._run_rst_doctests = False
+
+    def pytest_ignore_collect(self, path, config):
+        """Skip paths that match any of the doctest_norecursedirs patterns."""
+
+        for pattern in config.getini("doctest_norecursedirs"):
+            if path.check(fnmatch=pattern):
+                # Apparently pytest_ignore_collect causes files not to be
+                # collected by any test runner; for DoctestPlus we only want to
+                # avoid creating doctest nodes for them
+                self._ignore_paths.append(path)
+                break
+
+        return False
+
+    def pytest_collect_file(self, path, parent):
+        """Implements an enhanced version of the doctest module from py.test
+        (specifically, as enabled by the --doctest-modules option) which
+        supports skipping all doctests in a specific docstring by way of a
+        special ``__doctest_skip__`` module-level variable.  It can also skip
+        tests that have special requirements by way of
+        ``__doctest_requires__``.
+
+        ``__doctest_skip__`` should be a list of functions, classes, or class
+        methods whose docstrings should be ignored when collecting doctests.
+
+        This also supports wildcard patterns.  For example, to run doctests in
+        a class's docstring, but skip all doctests in its modules use, at the
+        module level::
+
+            __doctest_skip__ = ['ClassName.*']
+
+        You may also use the string ``'.'`` in ``__doctest_skip__`` to refer
+        to the module itself, in case its module-level docstring contains
+        doctests.
+
+        ``__doctest_requires__`` should be a dictionary mapping wildcard
+        patterns (in the same format as ``__doctest_skip__``) to a list of one
+        or more modules that should be *importable* in order for the tests to
+        run.  For example, if some tests require the scipy module to work they
+        will be skipped unless ``import scipy`` is possible.  It is also
+        possible to use a tuple of wildcard patterns as a key in this dict::
+
+            __doctest_requires__ = {('func1', 'func2'): ['scipy']}
+
+        """
+
+        for ignore_path in self._ignore_paths:
+            if ignore_path.common(path) == ignore_path:
+                return None
+
+        if path.ext == '.py':
+            if path.basename == 'conf.py':
+                return None
+
+            # Don't override the built-in doctest plugin
+            return self._doctest_module_item_cls(path, parent)
+        elif self._run_rst_doctests and path.ext == '.rst':
+            # Ignore generated .rst files
+            parts = bytes(path).split(os.path.sep)
+            if (path.basename.startswith(b'_') or
+                any(x.startswith(b'_') for x in parts) or
+                any(x == b'api' for x in parts)):
+                return None
+
+            # TODO: Get better names on these items when they are
+            # displayed in py.test output
+            return self._doctest_textfile_item_cls(path, parent)
+
+
+class DocTestFinderPlus(doctest.DocTestFinder):
+    """Extension to the default `doctest.DoctestFinder` that supports
+    ``__doctest_skip__`` magic.  See `pytest_collect_file` for more details.
+    """
+
+    # Caches the results of import attempts
+    _import_cache = {}
+
+    @classmethod
+    def check_required_modules(cls, mods):
+        for mod in mods:
+            if mod in cls._import_cache:
+                if not cls._import_cache[mod]:
+                    return False
+            try:
+                imp.find_module(mod)
+            except ImportError:
+                cls._import_cache[mod] = False
+                return False
+            else:
+                cls._import_cache[mod] = True
+        return True
+
+    def find(self, obj, name=None, module=None, globs=None,
+             extraglobs=None):
+        tests = doctest.DocTestFinder.find(self, obj, name, module, globs,
+                                           extraglobs)
+        if (hasattr(obj, '__doctest_skip__') or
+                hasattr(obj, '__doctest_requires__')):
+            if name is None and hasattr(obj, '__name__'):
+                name = obj.__name__
+            else:
+                raise ValueError("DocTestFinder.find: name must be given "
+                                 "when obj.__name__ doesn't exist: %r" %
+                                 (type(obj),))
+
+            def test_filter(test):
+                for pat in getattr(obj, '__doctest_skip__', []):
+                    if pat == '*':
+                        return False
+                    elif pat == '.' and test.name == name:
+                        return False
+                    elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
+                        return False
+
+                reqs = getattr(obj, '__doctest_requires__', {})
+                for pats, mods in list(six.iteritems(reqs)):
+                    if not isinstance(pats, tuple):
+                        pats = (pats,)
+                    for pat in pats:
+                        if not fnmatch.fnmatch(test.name,
+                                               '.'.join((name, pat))):
+                            continue
+                        if not self.check_required_modules(mods):
+                            return False
+                return True
+
+            tests = list(filter(test_filter, tests))
+
+        return tests
+
+
+# Open file detection.
+#
+# This works by calling out to psutil to get the list of open files
+# held by the process both before and after the test.  If something is
+# still open after the test that wasn't open before the test, an
+# AssertionError is raised.
+#
+# This is not thread-safe.  We're not currently running our tests
+# multi-threaded, but that is worth noting.
+
+
+def _get_open_file_list():
+    import psutil
+    files = []
+    p = psutil.Process()
+
+    if importlib_machinery is not None:
+        suffixes = tuple(importlib_machinery.all_suffixes())
+    else:
+        suffixes = tuple(info[0] for info in imp.get_suffixes())
+
+    files = [x.path for x in p.open_files() if not x.path.endswith(suffixes)]
+
+    return set(files)
+
+
+def pytest_runtest_setup(item):
+    # Store a list of the currently opened files so we can compare
+    # against them when the test is done.
+    if item.config.getvalue('open_files'):
+        item.open_files = _get_open_file_list()
+
+    if ('remote_data' in item.keywords and
+            not item.config.getvalue("remote_data")):
+        pytest.skip("need --remote-data option to run")
+
+
+def pytest_runtest_teardown(item, nextitem):
+    # a "skipped" test will not have been called with
+    # pytest_runtest_setup, so therefore won't have an
+    # "open_files" member
+    if (not item.config.getvalue('open_files') or
+            not hasattr(item, 'open_files')):
+        return
+
+    start_open_files = item.open_files
+    del item.open_files
+
+    open_files = _get_open_file_list()
+
+    # This works in tandem with the test_open_file_detection test to
+    # ensure that it creates one extra open file.
+    if item.name == 'test_open_file_detection':
+        assert len(start_open_files) + 1 == len(open_files)
+        return
+
+    not_closed = set()
+    open_files_ignore = item.config.getini('open_files_ignore')
+    for filename in open_files:
+        ignore = False
+
+        for ignored in open_files_ignore:
+            if not os.path.isabs(ignored):
+                if os.path.basename(filename) == ignored:
+                    ignore = True
+                    break
+            else:
+                if filename == ignored:
+                    ignore = True
+                    break
+
+        if ignore:
+            continue
+
+        if filename not in start_open_files:
+            not_closed.add(filename)
+
+    if len(not_closed):
+        msg = ['File(s) not closed:']
+        for name in not_closed:
+            msg.append('  {0}'.format(name))
+        raise AssertionError('\n'.join(msg))
+
+
+PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
+                                     ('Scipy', 'scipy'),
+                                     ('Matplotlib', 'matplotlib'),
+                                     ('h5py', 'h5py')])
+
+# This always returns with Astropy's version
+from ... import __version__
+
+TESTED_VERSIONS = OrderedDict([('Astropy', __version__)])
+
+
+def pytest_report_header(config):
+
+    stdoutencoding = getattr(sys.stdout, 'encoding') or 'ascii'
+
+    if six.PY2:
+        args = [x.decode('utf-8') for x in config.args]
+    elif six.PY3:
+        args = config.args
+
+    # TESTED_VERSIONS can contain the affiliated package version, too
+    if len(TESTED_VERSIONS) > 1:
+        for pkg, version in TESTED_VERSIONS.items():
+            if pkg != 'Astropy':
+                s = "\nRunning tests with {0} version {1}.\n".format(
+                    pkg, version)
+    else:
+        s = "\nRunning tests with Astropy version {0}.\n".format(
+            TESTED_VERSIONS['Astropy'])
+
+    s += "Running tests in {0}.\n\n".format(" ".join(args))
+
+    from platform import platform
+    plat = platform()
+    if isinstance(plat, bytes):
+        plat = plat.decode(stdoutencoding, 'replace')
+    s += "Platform: {0}\n\n".format(plat)
+    s += "Executable: {0}\n\n".format(sys.executable)
+    s += "Full Python Version: \n{0}\n\n".format(sys.version)
+
+    s += "encodings: sys: {0}, locale: {1}, filesystem: {2}".format(
+        sys.getdefaultencoding(),
+        locale.getpreferredencoding(),
+        sys.getfilesystemencoding())
+    if sys.version_info < (3, 3, 0):
+        s += ", unicode bits: {0}".format(
+            int(math.log(sys.maxunicode, 2)))
+    s += '\n'
+
+    s += "byteorder: {0}\n".format(sys.byteorder)
+    s += "float info: dig: {0.dig}, mant_dig: {0.dig}\n\n".format(
+        sys.float_info)
+
+    for module_display, module_name in six.iteritems(PYTEST_HEADER_MODULES):
+        try:
+            module = __import__(module_name)
+        except ImportError:
+            s += "{0}: not available\n".format(module_display)
+        else:
+            try:
+                version = module.__version__
+            except AttributeError:
+                version = 'unknown (no __version__ attribute)'
+            s += "{0}: {1}\n".format(module_display, version)
+
+    special_opts = ["remote_data", "pep8"]
+    opts = []
+    for op in special_opts:
+        if getattr(config.option, op, None):
+            opts.append(op)
+    if opts:
+        s += "Using Astropy options: {0}.\n".format(" ".join(opts))
+
+    if six.PY3 and (config.getini('doctest_rst') or config.option.doctest_rst):
+        s += "Running doctests in .rst files is not supported on Python 3.x\n"
+
+    if not six.PY3:
+        s = s.encode(stdoutencoding, 'replace')
+
+    return s
+
+
+def pytest_pycollect_makemodule(path, parent):
+    # This is where we set up testing both with and without
+    # from __future__ import unicode_literals
+
+    # On Python 3, just do the regular thing that py.test does
+    if six.PY3:
+        return pytest.Module(path, parent)
+    elif six.PY2:
+        return Pair(path, parent)
+
+
+class Pair(pytest.File):
+    """
+    This class treats a given test .py file as a pair of .py files
+    where one has __future__ unicode_literals and the other does not.
+    """
+    def collect(self):
+        # First, just do the regular import of the module to make
+        # sure it's sane and valid.  This block is copied directly
+        # from py.test
+        try:
+            mod = self.fspath.pyimport(ensuresyspath=True)
+        except SyntaxError:
+            import py
+            excinfo = py.code.ExceptionInfo()
+            raise self.CollectError(excinfo.getrepr(style="short"))
+        except self.fspath.ImportMismatchError:
+            e = sys.exc_info()[1]
+            raise self.CollectError(
+                "import file mismatch:\n"
+                "imported module %r has this __file__ attribute:\n"
+                "  %s\n"
+                "which is not the same as the test file we want to collect:\n"
+                "  %s\n"
+                "HINT: remove __pycache__ / .pyc files and/or use a "
+                "unique basename for your test file modules"
+                % e.args
+            )
+
+        # Now get the file's content.
+        with io.open(six.text_type(self.fspath), 'rb') as fd:
+            content = fd.read()
+
+        # If the file contains the special marker, only test it both ways.
+        if b'TEST_UNICODE_LITERALS' in content:
+            # Return the file in both unicode_literal-enabled and disabled forms
+            return [
+                UnicodeLiteralsModule(mod.__name__, content, self.fspath, self),
+                NoUnicodeLiteralsModule(mod.__name__, content, self.fspath, self)
+            ]
+        else:
+            return [pytest.Module(self.fspath, self)]
+
+
+_RE_FUTURE_IMPORTS = re.compile(br'from __future__ import ((\(.*?\))|([^\n]+))',
+                                flags=re.DOTALL)
+
+
+class ModifiedModule(pytest.Module):
+    def __init__(self, mod_name, content, path, parent):
+        self.mod_name = mod_name
+        self.content = content
+        super(ModifiedModule, self).__init__(path, parent)
+
+    def _importtestmodule(self):
+        # We have to remove the __future__ statements *before* parsing
+        # with compile, otherwise the flags are ignored.
+        content = re.sub(_RE_FUTURE_IMPORTS, b'\n', self.content)
+
+        new_mod = types.ModuleType(self.mod_name)
+        new_mod.__file__ = six.text_type(self.fspath)
+
+        if hasattr(self, '_transform_ast'):
+            # ast.parse doesn't let us hand-select the __future__
+            # statements, but built-in compile, with the PyCF_ONLY_AST
+            # flag does.
+            tree = compile(
+                content, six.text_type(self.fspath), 'exec',
+                self.flags | ast.PyCF_ONLY_AST, True)
+            tree = self._transform_ast(tree)
+            # Now that we've transformed the tree, recompile it
+            code = compile(
+                tree, six.text_type(self.fspath), 'exec')
+        else:
+            # If we don't need to transform the AST, we can skip
+            # parsing/compiling in two steps
+            code = compile(
+                content, six.text_type(self.fspath), 'exec',
+                self.flags, True)
+
+        pwd = os.getcwd()
+        try:
+            os.chdir(os.path.dirname(six.text_type(self.fspath)))
+            six.exec_(code, new_mod.__dict__)
+        finally:
+            os.chdir(pwd)
+        self.config.pluginmanager.consider_module(new_mod)
+        return new_mod
+
+
+class UnicodeLiteralsModule(ModifiedModule):
+    flags = (
+        __future__.absolute_import.compiler_flag |
+        __future__.division.compiler_flag |
+        __future__.print_function.compiler_flag |
+        __future__.unicode_literals.compiler_flag
+    )
+
+
+class NoUnicodeLiteralsModule(ModifiedModule):
+    flags = (
+        __future__.absolute_import.compiler_flag |
+        __future__.division.compiler_flag |
+        __future__.print_function.compiler_flag
+    )
+
+    def _transform_ast(self, tree):
+        # When unicode_literals is disabled, we still need to convert any
+        # byte string containing non-ascii characters into a Unicode string.
+        # If it doesn't decode as utf-8, we assume it's some other kind
+        # of byte string and just ultimately leave it alone.
+
+        # Note that once we drop support for Python 3.2, we should be
+        # able to remove this transformation and just put explicit u''
+        # prefixes in the test source code.
+
+        class NonAsciiLiteral(ast.NodeTransformer):
+            def visit_Str(self, node):
+                s = node.s
+                if isinstance(s, bytes):
+                    try:
+                        s.decode('ascii')
+                    except UnicodeDecodeError:
+                        try:
+                            s = s.decode('utf-8')
+                        except UnicodeDecodeError:
+                            pass
+                        else:
+                            return ast.copy_location(ast.Str(s=s), node)
+                return node
+        return NonAsciiLiteral().visit(tree)
+
+
+def pytest_unconfigure():
+    """
+    Cleanup post-testing
+    """
+    # restore internet connectivity (only lost if remote_data=False and
+    # turn_off_internet previously called)
+    # this is harmless / does nothing if socket connections were never disabled
+    turn_on_internet()
+
+
+def pytest_terminal_summary(terminalreporter):
+    """Output a warning to IPython users in case any tests failed."""
+
+    try:
+        get_ipython()
+    except NameError:
+        return
+
+    if not terminalreporter.stats.get('failed'):
+        # Only issue the warning when there are actually failures
+        return
+
+    terminalreporter.ensure_newline()
+    terminalreporter.write_line(
+        'Some tests are known to fail when run from the IPython prompt; '
+        'especially, but not limited to tests involving logging and warning '
+        'handling.  Unless you are certain as to the cause of the failure, '
+        'please check that the failure occurs outside IPython as well.  See '
+        'http://docs.astropy.org/en/stable/known_issues.html#failing-logging-'
+        'tests-when-running-the-tests-in-ipython for more information.',
+        yellow=True, bold=True)

--- a/pyasdf/tests/helpers.py
+++ b/pyasdf/tests/helpers.py
@@ -7,7 +7,7 @@ import io
 import os
 import sys
 
-from astropy.extern import six
+import six
 
 from ..asdf import AsdfFile, get_asdf_library_info
 from ..conftest import RangeHTTPServer

--- a/pyasdf/tests/setup_package.py
+++ b/pyasdf/tests/setup_package.py
@@ -6,4 +6,4 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 def get_package_data():  # pragma: no cover
     return {
-        str(_ASTROPY_PACKAGE_NAME_ + '.tests'): ['coveragerc', 'data/*.yaml']}
+        str(_PACKAGE_NAME_ + '.tests'): ['coveragerc', 'data/*.yaml']}

--- a/pyasdf/tests/test_compression.py
+++ b/pyasdf/tests/test_compression.py
@@ -8,7 +8,7 @@ import os
 
 import numpy as np
 
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import asdf
 from .. import generic_io

--- a/pyasdf/tests/test_fits_embed.py
+++ b/pyasdf/tests/test_fits_embed.py
@@ -5,17 +5,26 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import os
 
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy.io import fits
+    from .. import fits_embed
+
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from astropy.io import fits
+import pytest
 
 from .. import asdf
-from .. import fits_embed
 
 from .helpers import assert_tree_match, close_fits
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_embed_asdf_in_fits_file(tmpdir):
     hdulist = fits.HDUList()
     hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='SCI'))
@@ -58,6 +67,7 @@ def test_embed_asdf_in_fits_file(tmpdir):
         close_fits(hdulist2)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
     hdulist = fits.HDUList()
     hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
@@ -104,6 +114,7 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
         close_fits(hdulist2)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_create_in_tree_first(tmpdir):
     tree = {
         'model': {

--- a/pyasdf/tests/test_generic_io.py
+++ b/pyasdf/tests/test_generic_io.py
@@ -7,9 +7,10 @@ import io
 import os
 import sys
 
-from astropy.extern import six
-import astropy.extern.six.moves.urllib.request as urllib_request
-from astropy.tests.helper import pytest, remote_data
+import pytest
+
+import six
+import six.moves.urllib.request as urllib_request
 
 import numpy as np
 

--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -6,11 +6,12 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import io
 import os
 
-from astropy.extern import six
-from astropy.tests.helper import pytest
-
 import numpy as np
 from numpy.testing import assert_array_equal
+
+import pytest
+
+import six
 
 from .. import asdf
 from .. import block

--- a/pyasdf/tests/test_reference.py
+++ b/pyasdf/tests/test_reference.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import asdf
 from .. import reference

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -6,13 +6,20 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import io
 import os
 
-import numpy as np
-
-from astropy.extern import six
-from astropy.tests.helper import pytest
-from astropy import units as u
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
 
 from jsonschema import ValidationError
+
+import numpy as np
+
+import pytest
+
+import six
 
 import yaml
 
@@ -24,6 +31,7 @@ from .. import schema
 from .. import treeutil
 from .. import util
 
+from .extern.astropy_helper import catch_warnings
 from . import helpers
 
 
@@ -60,6 +68,7 @@ def test_violate_toplevel_schema():
         ff.write_to(buff)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_tagging_scalars():
     yaml = """
 unit: !unit/unit
@@ -395,3 +404,29 @@ def test_large_literals():
     with pytest.raises(ValidationError):
         ff.write_to(buff)
         print(buff.getvalue())
+
+
+def test_type_missing_dependencies():
+    class MissingType(asdftypes.AsdfType):
+        name = 'missing'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+        types = ['asdfghjkl12345.foo']
+        requires = ["ASDFGHJKL12345"]
+
+    class DefaultTypeExtension(CustomExtension):
+        @property
+        def types(self):
+            return [MissingType]
+
+    yaml = """
+custom: !<tag:nowhere.org:custom/1.0.0/missing>
+  b: {foo: 42}
+    """
+    buff = helpers.yaml_to_asdf(yaml)
+    with catch_warnings() as w:
+        with asdf.AsdfFile.open(buff, extensions=[DefaultTypeExtension()]) as ff:
+            assert ff.tree['custom']['b']['foo'] == 42
+
+    assert len(w) == 1

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -76,6 +76,7 @@ unit: !unit/unit
 not_unit:
   m
     """
+    from astropy import units as u
 
     buff = helpers.yaml_to_asdf(yaml)
     with asdf.AsdfFile.open(buff) as ff:

--- a/pyasdf/tests/test_stream.py
+++ b/pyasdf/tests/test_stream.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import io
 import os
 
-from astropy.tests.helper import pytest
-
 import numpy as np
 from numpy.testing import assert_array_equal
+
+import pytest
 
 from .. import asdf
 from .. import generic_io

--- a/pyasdf/tests/test_suite.py
+++ b/pyasdf/tests/test_suite.py
@@ -10,7 +10,7 @@ from .. import open
 
 from .helpers import assert_tree_match
 
-from astropy.tests.helper import pytest
+import pytest
 
 
 def test_reference_files():

--- a/pyasdf/tests/test_yaml.py
+++ b/pyasdf/tests/test_yaml.py
@@ -5,16 +5,23 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import io
 
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+
 import numpy as np
 
-from astropy.extern import six
-from astropy import units as u
-from astropy.utils.compat.odict import OrderedDict
-from astropy.tests.helper import pytest
+import pytest
+
+import six
 
 import yaml
 
 from .. import asdf
+from ..compat.odict import OrderedDict
 from .. import tagged
 from .. import treeutil
 
@@ -121,6 +128,7 @@ def test_tags_removed_after_load(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check_asdf)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_explicit_tags():
 
     yaml = """#ASDF 0.1.0

--- a/pyasdf/tests/test_yaml.py
+++ b/pyasdf/tests/test_yaml.py
@@ -137,6 +137,8 @@ def test_explicit_tags():
 unit: !<tag:stsci.edu:asdf/0.1.0/unit/unit> m
 ...
     """
+    from astropy import units as u
+
     # Check that fully-qualified explicit tags work
 
     buff = helpers.yaml_to_asdf(yaml, yaml_headers=False)

--- a/pyasdf/treeutil.py
+++ b/pyasdf/treeutil.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import inspect
 
-from astropy.extern import six
+import six
 
 from .tagged import tag_object
 

--- a/pyasdf/util.py
+++ b/pyasdf/util.py
@@ -4,15 +4,16 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-import itertools
+import inspect
 import math
 import struct
+import types
 
-from astropy.extern import six
-from astropy.extern.six.moves.urllib.parse import urljoin
-from astropy.extern.six.moves.urllib.request import pathname2url
-from astropy.extern.six.moves.urllib import parse as urlparse
-from astropy.extern.six.moves import zip as izip
+import six
+from six.moves.urllib.parse import urljoin
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib import parse as urlparse
+from six.moves import zip as izip
 
 import numpy as np
 
@@ -207,3 +208,173 @@ class HashableDict(dict):
     """
     def __hash__(self):
         return hash(frozenset(self.items()))
+
+
+def resolve_name(name):
+    """Resolve a name like ``module.object`` to an object and return it.
+
+    This ends up working like ``from module import object`` but is easier
+    to deal with than the `__import__` builtin and supports digging into
+    submodules.
+
+    Parameters
+    ----------
+
+    name : `str`
+        A dotted path to a Python object--that is, the name of a function,
+        class, or other object in a module with the full path to that module,
+        including parent modules, separated by dots.  Also known as the fully
+        qualified name of the object.
+
+    Examples
+    --------
+
+    >>> resolve_name('pyasdf.util.resolve_name')
+    <function resolve_name at 0x...>
+
+    Raises
+    ------
+    `ImportError`
+        If the module or named object is not found.
+    """
+
+    # Note: On python 2 these must be str objects and not unicode
+    parts = [str(part) for part in name.split('.')]
+
+    if len(parts) == 1:
+        # No dots in the name--just a straight up module import
+        cursor = 1
+        attr_name = str('')  # Must not be unicode on Python 2
+    else:
+        cursor = len(parts) - 1
+        attr_name = parts[-1]
+
+    module_name = parts[:cursor]
+
+    while cursor > 0:
+        try:
+            ret = __import__(str('.'.join(module_name)), fromlist=[attr_name])
+            break
+        except ImportError:
+            if cursor == 0:
+                raise
+            cursor -= 1
+            module_name = parts[:cursor]
+            attr_name = parts[cursor]
+            ret = ''
+
+    for part in parts[cursor:]:
+        try:
+            ret = getattr(ret, part)
+        except AttributeError:
+            raise ImportError(name)
+
+    return ret
+
+
+def minversion(module, version, inclusive=True, version_path='__version__'):
+    """
+    Returns `True` if the specified Python module satisfies a minimum version
+    requirement, and `False` if not.
+
+    By default this uses `pkg_resources.parse_version` to do the version
+    comparison if available.  Otherwise it falls back on
+    `distutils.version.LooseVersion`.
+
+    Parameters
+    ----------
+
+    module : module or `str`
+        An imported module of which to check the version, or the name of
+        that module (in which case an import of that module is attempted--
+        if this fails `False` is returned).
+
+    version : `str`
+        The version as a string that this module must have at a minimum (e.g.
+        ``'0.12'``).
+
+    inclusive : `bool`
+        The specified version meets the requirement inclusively (i.e. ``>=``)
+        as opposed to strictly greater than (default: `True`).
+
+    version_path : `str`
+        A dotted attribute path to follow in the module for the version.
+        Defaults to just ``'__version__'``, which should work for most Python
+        modules.
+    """
+
+    if isinstance(module, types.ModuleType):
+        module_name = module.__name__
+    elif isinstance(module, six.string_types):
+        module_name = module
+        try:
+            module = resolve_name(module_name)
+        except ImportError:
+            return False
+    else:
+        raise ValueError('module argument must be an actual imported '
+                         'module, or the import name of the module; '
+                         'got {0!r}'.format(module))
+
+    if '.' not in version_path:
+        have_version = getattr(module, version_path)
+    else:
+        have_version = resolve_name('.'.join([module.__name__, version_path]))
+
+    try:
+        from pkg_resources import parse_version
+    except ImportError:
+        from distutils.version import LooseVersion as parse_version
+
+    if inclusive:
+        return parse_version(have_version) >= parse_version(version)
+    else:
+        return parse_version(have_version) > parse_version(version)
+
+
+class InheritDocstrings(type):
+    """
+    This metaclass makes methods of a class automatically have their
+    docstrings filled in from the methods they override in the base
+    class.
+
+    If the class uses multiple inheritance, the docstring will be
+    chosen from the first class in the bases list, in the same way as
+    methods are normally resolved in Python.  If this results in
+    selecting the wrong docstring, the docstring will need to be
+    explicitly included on the method.
+
+    For example::
+
+        >>> from pyasdf.util import InheritDocstrings
+        >>> import six
+        >>> @six.add_metaclass(InheritDocstrings)
+        ... class A(object):
+        ...     def wiggle(self):
+        ...         "Wiggle the thingamajig"
+        ...         pass
+        >>> class B(A):
+        ...     def wiggle(self):
+        ...         pass
+        >>> B.wiggle.__doc__
+        u'Wiggle the thingamajig'
+    """
+
+    def __init__(cls, name, bases, dct):
+        def is_public_member(key):
+            return (
+                (key.startswith('__') and key.endswith('__')
+                 and len(key) > 4) or
+                not key.startswith('_'))
+
+        for key, val in six.iteritems(dct):
+            if (inspect.isfunction(val) and
+                is_public_member(key) and
+                val.__doc__ is None):
+                for base in cls.__mro__[1:]:
+                    super_method = getattr(base, key, None)
+                    if super_method is not None:
+                        val.__doc__ = super_method.__doc__
+                        break
+
+        super(InheritDocstrings, cls).__init__(name, bases, dct)

--- a/pyasdf/versioning.py
+++ b/pyasdf/versioning.py
@@ -8,7 +8,7 @@ of the ASDF spec.
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
+import six
 
 from . import util
 

--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -3,13 +3,13 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
-from astropy.utils.compat.odict import OrderedDict
-
 import numpy as np
+
+import six
 
 import yaml
 
+from . compat.odict import OrderedDict
 from . constants import YAML_TAG_PREFIX
 from . import schema
 from . import tagged

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,17 @@ if sys.version_info[0] >= 3:
     import builtins
 else:
     import __builtin__ as builtins
-builtins._ASTROPY_SETUP_ = True
+builtins._PYASDF_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (
     register_commands, adjust_compiler, get_debug_option, get_package_info)
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
+
+from astropy_helpers import test_helpers
+def _null_validate(self):
+    pass
+test_helpers.AstropyTest._validate_required_deps = _null_validate
 
 # Get some values from the setup.cfg
 from distutils import config
@@ -27,11 +32,11 @@ conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 
 PACKAGENAME = metadata.get('package_name', 'packagename')
-DESCRIPTION = metadata.get('description', 'Astropy affiliated package')
+DESCRIPTION = metadata.get('description', 'package description')
 AUTHOR = metadata.get('author', '')
 AUTHOR_EMAIL = metadata.get('author_email', '')
 LICENSE = metadata.get('license', 'unknown')
-URL = metadata.get('url', 'http://astropy.org')
+URL = metadata.get('url', '')
 
 # Get the long description from the package's docstring
 __import__(PACKAGENAME)
@@ -40,7 +45,7 @@ LONG_DESCRIPTION = package.__doc__
 
 # Store the package name in a built-in variable so it's easy
 # to get from other parts of the setup infrastructure
-builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
+builtins._PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 VERSION = '0.0.dev'
@@ -120,9 +125,11 @@ setup(name=PACKAGENAME,
       description=DESCRIPTION,
       scripts=scripts,
       install_requires=[
-          'astropy>=1.0',
           'pyyaml>=3.10',
-          'jsonschema>=2.3.0'],
+          'jsonschema>=2.3.0',
+          'six>=1.9.0',
+          'pytest>=2.7.2'
+      ],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,


### PR DESCRIPTION
This makes astropy a soft dependency -- only required for time, units, wcs or transform support.

This is a bit of a hack at the moment and involved copy-and-pasting large chunks of the astropy testing infrastructure into pyasdf.  Once I've settled on what pieces are required, then I'll focus on doing this the "right way" by making those pieces at least usable-without-changes, if not as a separately installable package or something.  @embray's thoughts and advice on how best to handle that would be helpful...
