### PR TITLE
Added wrapper class for astropy.core.Time, TaggedTime

### DIFF
--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -35,8 +35,8 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import six
 
+from astropy import time
 from .compat import UserDict, UserList, UserString
-
 
 __all__ = ['tag_object', 'get_tag']
 
@@ -98,6 +98,15 @@ class TaggedString(Tagged, UserString, six.text_type):
                 self._tag == other._tag)
 
 
+class TaggedTime(Tagged, time.Time):
+    """
+    An Astropy time object with a tag attached.
+    """
+    def __new__(cls, instance, tag):
+        self = time.Time.__new__(type(instance), instance)
+        self._tag = tag
+        return self
+
 def tag_object(tag, instance):
     """
     Tag an object by wrapping it in a ``Tagged`` instance.
@@ -109,6 +118,8 @@ def tag_object(tag, instance):
         return TaggedDict(instance, tag)
     elif isinstance(instance, list):
         return TaggedList(instance, tag)
+    elif isinstance(instance, time.Time):
+        return TaggedTime(instance, tag)
     elif isinstance(instance, six.string_types):
         instance = TaggedString(instance)
         instance._tag = tag


### PR DESCRIPTION
When the asdf validator compares tree nodes against the schema and the
schema contains a tag field, it requres that the node contain the same
tag, or alse the validation fails. Asdf handles this by creating nodes
of type Tagged and its subtypes, all which contain a _tag field that
holds the value matched against the schema. However, only a limited
number of subtypes have been implemented: TaggedDict, TaggedList, and
TaggedString. This commit adds a new type, TaggedTime, to support time
values contained in a tree node.