### PR TITLE
Bring transforms up-to-date with astropy 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ matrix:
           env: NUMPY_VERSION=1.8 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/asdf/tags/transform/basic.py
+++ b/asdf/tags/transform/basic.py
@@ -51,9 +51,9 @@ class TransformType(AsdfType):
 
     @classmethod
     def _to_tree_base_transform_members(cls, model, node, ctx):
-        if getattr(model, '_custom_inverse', None) is not None:
+        if getattr(model, '_user_inverse', None) is not None:
             node['inverse'] = yamlutil.custom_tree_to_tagged_tree(
-                model._custom_inverse, ctx)
+                model._user_inverse, ctx)
 
         if model.name is not None:
             node['name'] = model.name

--- a/asdf/tags/transform/projections.py
+++ b/asdf/tags/transform/projections.py
@@ -102,17 +102,31 @@ class Rotate3DType(TransformType):
         from astropy import modeling
 
         if isinstance(model, modeling.rotations.RotateNative2Celestial):
-            return {"phi": model.lon.value,
-                    "theta": model.lat.value,
-                    "psi": model.lon_pole.value,
-                    "direction": "native2celestial"
-                    }
+            try:
+                return {"phi": model.lon.value,
+                        "theta": model.lat.value,
+                        "psi": model.lon_pole.value,
+                        "direction": "native2celestial"
+                        }
+            except AttributeError:
+                return {"phi": model.lon,
+                        "theta": model.lat,
+                        "psi": model.lon_pole,
+                        "direction": "native2celestial"
+                        }
         elif isinstance(model, modeling.rotations.RotateCelestial2Native):
-            return {"phi": model.lon.value,
-                    "theta": model.lat.value,
-                    "psi": model.lon_pole.value,
-                    "direction": "celestial2native"
-                    }
+            try:
+                return {"phi": model.lon.value,
+                        "theta": model.lat.value,
+                        "psi": model.lon_pole.value,
+                        "direction": "celestial2native"
+                        }
+            except AttributeError:
+                return {"phi": model.lon,
+                        "theta": model.lat,
+                        "psi": model.lon_pole,
+                        "direction": "celestial2native"
+                        }
         else:
             return {"phi": model.phi.value,
                     "theta": model.theta.value,


### PR DESCRIPTION
This PR reflects changes made in astropy/modeling v.1.2.

- `Model._custom_inverse` was renamed to `Model._user_inverse` in astropy 1.2.
- Sky rotations were implemented as subclasses of `EulerAngleRotations`. This had the side effect that the model parameters now are the Euler angles `phi`, `theta` ,`psi` and the user parameters which initialize the rotations `lon`, `lat`, and `lon_pole` are returns by properties and are numbers. This is unfortunate but I don't see a simple way around it.

This also removes `numpy 1.6` from the CI matrix.