### PR TITLE
Fixed a memory leak when reading wcs that grew memory to over 10 Gb

### DIFF
--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -19,6 +19,7 @@ import platform
 import re
 import sys
 import tempfile
+import array as array_class
 
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 
@@ -800,12 +801,12 @@ class MemoryIO(RandomAccessFile):
         fd.seek(tell, 0)
 
     def read_into_array(self, size):
-        result = np.frombuffer(
-            self._fd.getvalue(), np.uint8, size, self._fd.tell())
-        # When creating an array from a buffer, it is read-only.
-        # If we need a read/write array, we have to copy it.
-        if 'w' in self._mode:
-            result = result.copy()
+        buf = self._fd.getvalue()
+        offset = self._fd.tell()
+        if size == -1:
+            result = array_class.array(str("B"), buf[offset:])
+        else:
+            result = array_class.array(str("B"), buf[offset:offset+size])
         self.seek(size, SEEK_CUR)
         return result
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -19,7 +19,6 @@ import platform
 import re
 import sys
 import tempfile
-import array as array_class
 
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 
@@ -803,10 +802,9 @@ class MemoryIO(RandomAccessFile):
     def read_into_array(self, size):
         buf = self._fd.getvalue()
         offset = self._fd.tell()
-        if size == -1:
-            result = array_class.array(str("B"), buf[offset:])
-        else:
-            result = array_class.array(str("B"), buf[offset:offset+size])
+        result = np.frombuffer(buf, np.uint8, size, offset)
+        # Copy the buffer so the original memory can be released.
+        result = result.copy()
         self.seek(size, SEEK_CUR)
         return result
 

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -303,7 +303,7 @@ def test_http_connection_range(tree, rhttpserver):
         if len(tree) == 4:
             assert connection[0]._nreads == 0
         else:
-            assert connection[0]._nreads == 6
+            assert connection[0]._nreads == 5
 
         assert len(list(ff.blocks.internal_blocks)) == 2
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)


### PR DESCRIPTION
User reported a that when asdf was used to read an image with multiple
spectra, each with its own wcs, memory use grew until it crashed the
program. The error was traced to the code which read the binary wcs
coefficients stored in the image. That code opened a pseudo file
descriptor which did a seek on the underlying image and called the
numpy frombuffer method to read the coefficients. Each time this
operation was performed memory use grew by 6 Mb, and it was done
almost 1500 times. I believe the cause of the problem is due to an
optimization in the numpy code that allows a slice of an array to use
the same data as the underlying array. The pseudo file descriptor
allocates a large buffer for the image data but never returns it, as
the slice keeps the reference count of the underlying buffer from
going to zero, even though the slice is typically much smaller than
the buffer it is extracted from. The fix replaces the call to
numpy.frombuffer with a call to array.array, which performs the same,
but lacks the optimization in numpy which causes problems in this
case. A test shows the change eliminates the memory leak mentioned,
although there may still be further memory leaks and speed
optimizations in the asdf code.