### PR TITLE
Replace array class code with ndarray class plus copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
-1.1.0 (Unreleased)
+1.0.5 (Unreleased)
 ------------------
 
-- No changes yet.
+- Fixed a memory leak when reading wcs that grew memory to over 10 Gb
 
 1.0.4 (2016-05-25)
 ------------------

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -19,6 +19,7 @@ import platform
 import re
 import sys
 import tempfile
+import array as array_class
 
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 
@@ -800,12 +801,12 @@ class MemoryIO(RandomAccessFile):
         fd.seek(tell, 0)
 
     def read_into_array(self, size):
-        result = np.frombuffer(
-            self._fd.getvalue(), np.uint8, size, self._fd.tell())
-        # When creating an array from a buffer, it is read-only.
-        # If we need a read/write array, we have to copy it.
-        if 'w' in self._mode:
-            result = result.copy()
+        buf = self._fd.getvalue()
+        offset = self._fd.tell()
+        if size == -1:
+            result = array_class.array(str("B"), buf[offset:])
+        else:
+            result = array_class.array(str("B"), buf[offset:offset+size])
         self.seek(size, SEEK_CUR)
         return result
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -19,7 +19,6 @@ import platform
 import re
 import sys
 import tempfile
-import array as array_class
 
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 
@@ -803,10 +802,9 @@ class MemoryIO(RandomAccessFile):
     def read_into_array(self, size):
         buf = self._fd.getvalue()
         offset = self._fd.tell()
-        if size == -1:
-            result = array_class.array(str("B"), buf[offset:])
-        else:
-            result = array_class.array(str("B"), buf[offset:offset+size])
+        result = np.frombuffer(buf, np.uint8, size, offset)
+        # Copy the buffer so the original memory can be released.
+        result = result.copy()
         self.seek(size, SEEK_CUR)
         return result
 

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -303,7 +303,7 @@ def test_http_connection_range(tree, rhttpserver):
         if len(tree) == 4:
             assert connection[0]._nreads == 0
         else:
-            assert connection[0]._nreads == 6
+            assert connection[0]._nreads == 5
 
         assert len(list(ff.blocks.internal_blocks)) == 2
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -303,7 +303,7 @@ def test_http_connection_range(tree, rhttpserver):
         if len(tree) == 4:
             assert connection[0]._nreads == 0
         else:
-            assert connection[0]._nreads == 5
+            assert connection[0]._nreads == 6
 
         assert len(list(ff.blocks.internal_blocks)) == 2
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)


### PR DESCRIPTION
While my previous fix for the memory leak problem fixed that issue, other code in generic_io.py and its tests expects that the returned object be an ndarray. Since using the frombuffer call followed by a copy to break the reference achieves the same result as using array, I've replaced my previous change to MemoryIO with this new change.
