### PR TITLE
Rewrite code which tags complex objects

### DIFF
--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -460,7 +460,7 @@ class AsdfType(object):
         `to_tree`, allows types to customize how the result is tagged.
         """
         obj = cls.to_tree(node, ctx)
-        return tagged.tag_object(cls.yaml_tag, obj)
+        return tagged.tag_object(cls.yaml_tag, obj, ctx=ctx)
 
     @classmethod
     def from_tree(cls, tree, ctx):

--- a/asdf/tags/transform/basic.py
+++ b/asdf/tags/transform/basic.py
@@ -62,7 +62,8 @@ class TransformType(AsdfType):
         # domains, get this from somewhere else.
         domain = model.meta.get('domain')
         if domain:
-            domain = [tagged.tag_object(DomainType.yaml_tag, x) for x in domain]
+            domain = [tagged.tag_object(DomainType.yaml_tag, x, ctx=ctx)
+                      for x in domain]
             node['domain'] = domain
 
     @classmethod

--- a/asdf/tags/transform/compound.py
+++ b/asdf/tags/transform/compound.py
@@ -87,7 +87,7 @@ class CompoundType(TransformType):
         except KeyError:
             raise ValueError("Unknown operator '{0}'".format(tree.value))
 
-        node = tagged.tag_object(cls.make_yaml_tag(tag_name), node)
+        node = tagged.tag_object(cls.make_yaml_tag(tag_name), node, ctx=ctx)
         return node
 
     @classmethod

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -303,7 +303,7 @@ def test_http_connection_range(tree, rhttpserver):
         if len(tree) == 4:
             assert connection[0]._nreads == 0
         else:
-            assert connection[0]._nreads == 5
+            assert connection[0]._nreads == 6
 
         assert len(list(ff.blocks.internal_blocks)) == 2
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)


### PR DESCRIPTION
Part of the validation of an asdf tree against a schema is checking
tags in the schema against tags embedded in the data. Function
tagged.tag_objects has code supplies these tags, but orignally was
only coded to handle dctionaries, lists, and strings. This proved a
problem when checking the tags of times in the asdf tree, as times are
none of these types. I previously wrote a function specifically to
handle times, but his code had two problems. First, it created an
extra dependency on the astropy time code and second, the fix was
limited to time fields.

After becoming more familiar with the code I saw that the
functionality for handling more complex data objects was already in
asdf, in yamlutil.custom_tree_to_tagged_tree. So I removed the code I
had written to handle Time objects and replaced it with that
function. That code takes a new argument, ctx, which is an asdf
object, preferable the one associated with the asdf tree being
validated. It is needed to access any extensions that might be used
with the asdf tree. Since this is a new argument, the argument list to
tagged.tag_object was modified to include it as an optional argument
and code in asdf which invokes tagged.tag_object has been modified to
pass it where it is available. If ctx is not passed, the code creates
a new asdf object, which means that extensions cannot be used.