### PR TITLE
update rtd-pip-requirements to allow doc build

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,5 +1,8 @@
+asdf
 numpy
 Cython
-git+http://github.com/astropy/astropy.git#egg=astropy
+astropy
+astropy-helpers
 jsonschema
 pyyaml
+sphinx>=1.4.2


### PR DESCRIPTION
sometheing the docs are doing requires sphinx>=1.4.2.  There
was a bug in 1.4.1 that caused an error if a caption was not
supplied to TOC.  https://github.com/sphinx-doc/sphinx/issues/2465

added other requirements such that local build worked installing just
from rtd-pip-requirements from a blank conda env.