### PR TITLE
fix a bug in versioning, change package version to 1.1.1.dev

### DIFF
--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -36,6 +36,7 @@ def get_version_map(version):
                 version_map = yaml.load(
                     fd, Loader=_yaml_base_loader)
         except:
+            version_string = version_to_string(version)
             raise ValueError(
                 "Could not load version map for version {0}".format(version_string))
         _version_map[version] = version_map

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._PACKAGE_NAME_ = 'asdf'
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.0.6'
+VERSION = '1.1.1.dev'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
Fix a bug in reporting versions from  #210.
Changed the VERSION string to `1.1.1.dev` with next release set to be `1.1.1` for now.