### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Installation
 
 - `numpy <http://www.numpy.org/>`__ 1.6 or later
 
-- `jsonschema <http://python-jsonschema.readthedocs.org/>`__ 2.3.0 or later
+- `jsonschema <https://python-jsonschema.readthedocs.io/>`__ 2.3.0 or later
 
 - `pyyaml <http://pyyaml.org>`__ 3.10 or later
 
@@ -81,7 +81,7 @@ See also
 --------
 
 - The `Advanced Scientific Data Format (ASDF) standard
-  <http://asdf-standard.readthedocs.org/>`__
+  <https://asdf-standard.readthedocs.io/>`__
 
 Reference/API
 -------------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.