### PR TITLE
Handle importing configparser on Python 3.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ test_helpers.AstropyTest._validate_required_deps = _null_validate
 # Get some values from the setup.cfg
 try:
     from ConfigParser import ConfigParser
-except ImportError:
+except ImportError or AttributeError:
     from configparser import ConfigParser
 conf = ConfigParser()
 conf.read(['setup.cfg'])


### PR DESCRIPTION
In my case I get an AttributeError for attempting to import ConfigParser, let the except block catch it  
`AttributeError: module 'distutils.config' has no attribute 'ConfigParser'`

Tested with `pip install git+https://github.com/DavidLutton/asdf.git@patch-1` worked in a venv.