### PR TITLE
Force new blocks to be contiguous

### DIFF
--- a/asdf/block.py
+++ b/asdf/block.py
@@ -757,12 +757,10 @@ class Block(object):
     ])
 
     def __init__(self, data=None, uri=None, array_storage='internal'):
-        if data is None:
-            self._data = data
-        elif data.flags.c_contiguous:
-            self._data = data
-        else:
+        if isinstance(data, np.ndarray) and not data.flags.c_contiguous:
             self._data = np.ascontiguousarray(data)
+        else:
+            self._data = data
         self._uri = uri
         self._array_storage = array_storage
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -757,7 +757,10 @@ class Block(object):
     ])
 
     def __init__(self, data=None, uri=None, array_storage='internal'):
-        self._data = data
+        if data is None:
+            self._data = data
+        else:
+            self._data = np.ascontiguousarray(data)
         self._uri = uri
         self._array_storage = array_storage
 
@@ -791,7 +794,7 @@ class Block(object):
     @allocated.setter
     def allocated(self, allocated):
         self._allocated = allocated
-
+        
     @property
     def header_size(self):
         return self._header.size + constants.BLOCK_HEADER_BOILERPLATE_SIZE

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -759,6 +759,8 @@ class Block(object):
     def __init__(self, data=None, uri=None, array_storage='internal'):
         if data is None:
             self._data = data
+        elif data.flags.c_contiguous:
+            self._data = data
         else:
             self._data = np.ascontiguousarray(data)
         self._uri = uri


### PR DESCRIPTION
The code in asdf assumes a block will be a contiguous block of memory. But recent versions of numpy have used views more heavily and now there are cases when an object instantiated as a bock is not contiguous, which leads to errors when the block is used. The modified code calls numpy.ascontiguousarray to make sure the block memory is contiguous.

This is a revised version of the branch, as several other irrelevant changes were put in the previous version of the branch.