### PR TITLE
Rewrite code which tags complex objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,14 @@
-1.1.0 (Unreleased)
+1.1.1(Unreleased)
+-----------------
+
+- Added Tabular model. [#214]
+
+- Rewrite code which tags complex objects [#223]
+
+1.0.5 (2016-06-28)
 ------------------
 
-- Replaced wrapper class for Time with call to custom_tree_to_tagged_tree. [#223]
+- Fixed a memory leak when reading wcs that grew memory to over 10 Gb. [#200]
 
 1.0.4 (2016-05-25)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,6 @@
 
 - Added Tabular model. [#214]
 
-- Rewrite code which tags complex objects [#223]
-
 1.0.5 (2016-06-28)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 1.1.0 (Unreleased)
 ------------------
 
-- No changes yet.
+- Replaced wrapper class for Time with call to custom_tree_to_tagged_tree. [#223]
 
 1.0.4 (2016-05-25)
 ------------------

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -460,7 +460,7 @@ class AsdfType(object):
         `to_tree`, allows types to customize how the result is tagged.
         """
         obj = cls.to_tree(node, ctx)
-        return tagged.tag_object(cls.yaml_tag, obj)
+        return tagged.tag_object(cls.yaml_tag, obj, ctx=ctx)
 
     @classmethod
     def from_tree(cls, tree, ctx):

--- a/asdf/tags/transform/basic.py
+++ b/asdf/tags/transform/basic.py
@@ -62,7 +62,8 @@ class TransformType(AsdfType):
         # domains, get this from somewhere else.
         domain = model.meta.get('domain')
         if domain:
-            domain = [tagged.tag_object(DomainType.yaml_tag, x) for x in domain]
+            domain = [tagged.tag_object(DomainType.yaml_tag, x, ctx=ctx)
+                      for x in domain]
             node['domain'] = domain
 
     @classmethod

--- a/asdf/tags/transform/compound.py
+++ b/asdf/tags/transform/compound.py
@@ -87,7 +87,7 @@ class CompoundType(TransformType):
         except KeyError:
             raise ValueError("Unknown operator '{0}'".format(tree.value))
 
-        node = tagged.tag_object(cls.make_yaml_tag(tag_name), node)
+        node = tagged.tag_object(cls.make_yaml_tag(tag_name), node, ctx=ctx)
         return node
 
     @classmethod

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -303,7 +303,7 @@ def test_http_connection_range(tree, rhttpserver):
         if len(tree) == 4:
             assert connection[0]._nreads == 0
         else:
-            assert connection[0]._nreads == 5
+            assert connection[0]._nreads == 6
 
         assert len(list(ff.blocks.internal_blocks)) == 2
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)

--- a/asdf/tests/test_tagged.py
+++ b/asdf/tests/test_tagged.py
@@ -1,0 +1,120 @@
+import io
+import six
+import datetime
+from astropy.time import Time
+from collections import OrderedDict
+
+from .. import tagged
+from .. import yamlutil
+from .. import AsdfFile
+from .. import schema as asdf_schema
+from jsonschema import ValidationError
+
+def walk_schema(schema, callback, ctx={}):
+    def recurse(schema, path, combiner, ctx):
+        if callback(schema, path, combiner, ctx, recurse):
+            return
+
+        for c in ['allOf', 'not']:
+            for sub in schema.get(c, []):
+                recurse(sub, path, c, ctx)
+
+        for c in ['anyOf', 'oneOf']:
+            for i, sub in enumerate(schema.get(c, [])):
+                recurse(sub, path + [i], c, ctx)
+
+        if schema.get('type') == 'object':
+            for key, val in six.iteritems(schema.get('properties', {})):
+                recurse(val, path + [key], combiner, ctx)
+
+        if schema.get('type') == 'array':
+            items = schema.get('items', {})
+            if isinstance(items, list):
+                for i, item in enumerate(items):
+                    recurse(item, path + [i], combiner, ctx)
+            elif len(items):
+                recurse(items, path + ['items'], combiner, ctx)
+
+    recurse(schema, [], None, ctx)
+
+
+def flatten_combiners(schema):
+    newschema = OrderedDict()
+
+    def add_entry(path, schema, combiner):
+        # TODO: Simplify?
+        cursor = newschema
+        for i in range(len(path)):
+            part = path[i]
+            if isinstance(part, int):
+                cursor = cursor.setdefault('items', [])
+                while len(cursor) <= part:
+                    cursor.append({})
+                cursor = cursor[part]
+            elif part == 'items':
+                cursor = cursor.setdefault('items', OrderedDict())
+            else:
+                cursor = cursor.setdefault('properties', OrderedDict())
+                if i < len(path) - 1 and isinstance(path[i+1], int):
+                    cursor = cursor.setdefault(part, [])
+                else:
+                    cursor = cursor.setdefault(part, OrderedDict())
+
+        cursor.update(schema)
+
+    def callback(schema, path, combiner, ctx, recurse):
+        type = schema.get('type')
+        schema = OrderedDict(schema)
+        if type == 'object':
+            del schema['properties']
+        elif type == 'array':
+            del schema['items']
+        if 'allOf' in schema:
+            del schema['allOf']
+        if 'anyOf' in schema:
+            del schema['anyOf']
+
+        add_entry(path, schema, combiner)
+
+    walk_schema(schema, callback)
+
+    return newschema
+
+
+def test_time_tag():
+    schema = asdf_schema.load_schema('http://stsci.edu/schemas/asdf/time/time-1.0.0',
+                                     resolve_references=True)
+    schema = flatten_combiners(schema)
+
+    date = Time(datetime.datetime.now())
+    tree = {'date': date}
+    asdf = AsdfFile(tree=tree)
+    instance = yamlutil.custom_tree_to_tagged_tree(tree, asdf)
+    
+    try:
+        asdf_schema.validate(instance, schema=schema)
+    except ValidationError:
+        fail = True
+    else:
+        fail = False
+        
+    assert fail, True
+    
+    tag = 'tag:stsci.edu:asdf/time/time-1.0.0'
+    date = tagged.tag_object(tag, date)
+    tree = {'date': date}
+    instance = yamlutil.custom_tree_to_tagged_tree(tree, asdf)
+    
+    try:
+        asdf_schema.validate(instance, schema=schema)
+    except ValidationError:
+        fail = True
+    else:
+        fail = False
+
+    assert fail, False
+
+if __name__ == "__main__":
+    import pdb
+    pdb.set_trace()
+    test_time_tag()


### PR DESCRIPTION
Part of the validation of an asdf tree against a schema is checking
tags in the schema against tags embedded in the data. Function
tagged.tag_objects has code supplies these tags, but orignally was
only coded to handle dctionaries, lists, and strings. This proved a
problem when checking the tags of times in the asdf tree, as times are
none of these types. I previously wrote a function specifically to
handle times, but his code had two problems. First, it created an
extra dependency on the astropy time code and second, the fix was
limited to time fields.

After becoming more familiar with the code I saw that the
functionality for handling more complex data objects was already in
asdf, in yamlutil.custom_tree_to_tagged_tree. So I removed the code I
had written to handle Time objects and replaced it with that
function. That code takes a new argument, ctx, which is an asdf
object, preferable the one associated with the asdf tree being
validated. It is needed to access any extensions that might be used
with the asdf tree. Since this is a new argument, the argument list to
tagged.tag_object was modified to include it as an optional argument
and code in asdf which invokes tagged.tag_object has been modified to
pass it where it is available. If ctx is not passed, the code creates
a new asdf object, which means that extensions cannot be used.