### PR TITLE
Fix version error message

### DIFF
--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -36,6 +36,7 @@ def get_version_map(version):
                 version_map = yaml.load(
                     fd, Loader=_yaml_base_loader)
         except:
+            version_string = version_to_string(version)
             raise ValueError(
                 "Could not load version map for version {0}".format(version_string))
         _version_map[version] = version_map


### PR DESCRIPTION
Asdf throws an error message when it fails to read the version map file. The error message includes the version being searched for in the form of an undefined variable, version_string. I added a line defining this variable so that the exception doesn't throw another exception.
    
Please note that the most likely reason for the version map file not to be found is that the asdf-standard package has not been installed, as that is where the file is found in the distribution.