### PR TITLE
make astropy use conditional to include old versions of astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,12 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION=1.10 SETUP_CMD='test'
 
+        # try older astropy versions
+        - python: 3.5
+          env: NUMPY_VERSION=1.11 ASTROPY_VERSION=1.2.1 SETUP_CMD='test'
+        - python: 3.5
+          env: NUMPY_VERSION=1.11 ASTROPY_VERSION=1.1.2 SETUP_CMD='test'
+
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,8 @@
-1.2.1(Unreleased)
+1.2.1(2016-11-07)
 -----------------
+
+- Make asdf conditionally dependent on the version of astropy to allow
+  running it with older versions of astropy. [#228]
 
 1.2.0(2016-10-04)
 -----------------

--- a/asdf/tags/transform/__init__.py
+++ b/asdf/tags/transform/__init__.py
@@ -8,3 +8,5 @@ from .compound import *
 from .projections import *
 from .polynomial import *
 from .tabular import *
+
+    

--- a/asdf/tags/transform/basic.py
+++ b/asdf/tags/transform/basic.py
@@ -10,6 +10,8 @@ except ImportError:
 else:
     HAS_ASTROPY = True
     from astropy.modeling import mappings
+    from astropy.utils import minversion
+    ASTROPY_12 = minversion(astropy, "1.2")
 
 from ...asdftypes import AsdfType
 from ... import tagged
@@ -51,9 +53,14 @@ class TransformType(AsdfType):
 
     @classmethod
     def _to_tree_base_transform_members(cls, model, node, ctx):
-        if getattr(model, '_user_inverse', None) is not None:
-            node['inverse'] = yamlutil.custom_tree_to_tagged_tree(
+        if ASTROPY_12:
+            if getattr(model, '_user_inverse', None) is not None:
+                node['inverse'] = yamlutil.custom_tree_to_tagged_tree(
                 model._user_inverse, ctx)
+        else:
+            if getattr(model, '_custom_inverse', None) is not None:
+                node['inverse'] = yamlutil.custom_tree_to_tagged_tree(
+                model._custom_inverse, ctx)
 
         if model.name is not None:
             node['name'] = model.name

--- a/asdf/tags/transform/tabular.py
+++ b/asdf/tags/transform/tabular.py
@@ -6,18 +6,31 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import numpy as np
 from numpy.testing import assert_array_equal
 from ... import yamlutil
-
 from .basic import TransformType
 
-__all__ = ['TabularType']
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy.utils import minversion
+    ASTROPY_13 = minversion(astropy, "1.3")
+
+if HAS_ASTROPY and ASTROPY_13:
+    __all__ = ['TabularType']
+else:
+    __all__ = []
 
 
 class TabularType(TransformType):
-    import astropy
     name = "transform/tabular"
-    types = [astropy.modeling.models.Tabular2D,
-             astropy.modeling.models.Tabular1D
-             ]
+    if HAS_ASTROPY and ASTROPY_13:
+        types = [astropy.modeling.models.Tabular2D,
+                 astropy.modeling.models.Tabular1D
+                ]
+    else:
+        types = []
 
     @classmethod
     def from_tree_transform(cls, node, ctx):

--- a/asdf/tags/transform/tests/test_transform.py
+++ b/asdf/tags/transform/tests/test_transform.py
@@ -12,6 +12,8 @@ except ImportError:
     test_models = []
 else:
     HAS_ASTROPY = True
+    from astropy.utils import minversion
+    ASTROPY_13 = minversion(astropy, "1.3")
     from astropy.modeling import models as astmodels
 
     test_models = [astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
@@ -131,6 +133,7 @@ def test_generic_projections(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_ASTROPY')
+@pytest.mark.skipif('not ASTROPY_13')
 def test_tabular_model(tmpdir):
     points = np.arange(0, 5)
     values = [1., 10, 2, 45, -3]


### PR DESCRIPTION
Allow ASDF to run with older astropy versions by conditionally enabling parts which require newer versions. 
- In astropy 1.2 `Model._custom_inverse` was renamed to `Model._user_inverse`.
- astropy 1.3 will release a `Tabular` model which is already in asdf and is conditionally imported.

Also added testing with two older astropy versions on travis.
