### PR TITLE
Implements v 1.1.0 and bounding_box

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 - Fixed a bug in reading data from an "http:" url. [#231]
 
-- Implements v 1.1.0 of the asdf-standard. [#233]
+- Implements v 1.1.0 of the asdf schemas. [#233]
 
 
 1.2.1(2016-11-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Fixed a bug in reading data from an "http:" url. [#231]
 
+- Implements v 1.1.0 of the asdf-standard. [#233]
+
+
 1.2.1(2016-11-07)
 -----------------
 

--- a/asdf/tags/transform/basic.py
+++ b/asdf/tags/transform/basic.py
@@ -33,8 +33,7 @@ class TransformType(AsdfType):
         if 'name' in node:
             model = model.rename(node['name'])
 
-        ## TODO: When astropy.modeling has built-in support for
-        ## domains, save this somewhere else.
+        # TODO: Remove domain in a later version.
         if 'domain' in node:
             model.bounding_box = cls._domain_to_bounding_box(node['domain'])
         elif 'bounding_box' in node:

--- a/asdf/tags/transform/tests/test_transform.py
+++ b/asdf/tags/transform/tests/test_transform.py
@@ -80,20 +80,6 @@ def test_name(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_ASTROPY')
-def test_domain(tmpdir):
-    def check(ff):
-        assert ff.tree['rot'].meta['domain'][0] == {
-            'lower': 0, 'upper': 1, 'includes_lower': True,
-            'includes_upper': False}
-
-    model = astmodels.Rotation2D(23)
-    model.meta['domain'] = [
-        {'lower': 0, 'upper': 1, 'includes_lower': True}]
-    tree = {'rot': model}
-    helpers.assert_roundtrip_tree(tree, tmpdir, check)
-
-
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_zenithal_with_arguments(tmpdir):
     tree = {
         'azp': astmodels.Sky2Pix_AZP(0.5, 0.3)

--- a/asdf/tags/transform/tests/test_transform.py
+++ b/asdf/tags/transform/tests/test_transform.py
@@ -134,3 +134,11 @@ def test_tabular_model(tmpdir):
                                  fill_value=None, method='nearest')
     tree = {'model': model2}
     helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+@pytest.mark.skipif('not HAS_ASTROPY')
+def test_bounding_box(tmpdir):
+    model = astmodels.Shift(1) & astmodels.Shift(2)
+    model.bounding_box = ((1, 3), (2, 4))
+    tree = {'model': model}
+    helpers.assert_roundtrip_tree(tree, tmpdir)

--- a/asdf/tests/data/missing-1.1.0.yaml
+++ b/asdf/tests/data/missing-1.1.0.yaml
@@ -1,5 +1,5 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "http://nowhere.org/schemas/custom/missing-1.0.0"
+id: "http://nowhere.org/schemas/custom/missing-1.1.0"
 type: object

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -194,7 +194,7 @@ def yaml_to_asdf(yaml_content, yaml_headers=True):
 %TAG ! tag:stsci.edu:asdf/
 --- !core/asdf-{0}
 """.format(
-    versioning.version_to_string(versioning.default_version)).encode('ascii'))
+    versioning.version_to_string((1, 0, 0))).encode('ascii'))
     buff.write(yaml_content)
     if yaml_headers:
         buff.write(b"\n...\n")

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -415,7 +415,7 @@ def test_type_missing_dependencies():
     class MissingType(asdftypes.AsdfType):
         name = 'missing'
         organization = 'nowhere.org'
-        version = (1, 0, 0)
+        version = (1, 1, 0)
         standard = 'custom'
         types = ['asdfghjkl12345.foo']
         requires = ["ASDFGHJKL12345"]
@@ -426,7 +426,7 @@ def test_type_missing_dependencies():
             return [MissingType]
 
     yaml = """
-custom: !<tag:nowhere.org:custom/missing-1.0.0>
+custom: !<tag:nowhere.org:custom/missing-1.1.0>
   b: {foo: 42}
     """
     buff = helpers.yaml_to_asdf(yaml)

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -55,11 +55,12 @@ def version_to_string(ver):
         raise TypeError("Bad type for version {0}".format(ver))
 
 
-default_version = semver.parse('1.0.0')
+default_version = semver.parse('1.1.0')
 
 
 supported_versions = [
-    '1.0.0'
+    '1.0.0',
+    '1.1.0'
 ]
 
 


### PR DESCRIPTION
This resolves spacetelescope/asdf-standard#137.  Should be merged after spacetelescope/asdf-standard#138

[ ] Add tests for `bounding_box` and reading/writing different versions.
[ ] Update the pointer to the asdf-standard 
