### PR TITLE
add is_asdf test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Implements v 1.1.0 of the asdf schemas. [#233]
 
+- Added a function ``is_asdf_file`` which inspects the input and
+  returns ``True`` or ``False``. [#239]
 
 1.2.1(2016-11-07)
 -----------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -423,14 +423,12 @@ class AsdfFile(versioning.VersionedMixin):
                    validate_checksums=False,
                    do_not_fill_defaults=False,
                    _get_yaml_content=False):
-        fd = generic_io.get_file(fd, mode=mode, uri=uri)
-
-        self._fd = fd
-
-        try:
-            header_line = fd.read_until(b'\r?\n', 2, "newline", include=True)
-        except ValueError:
+        if not generic_io.is_asdf_file(fd):
             raise ValueError("Does not appear to be a ASDF file.")
+
+        fd = generic_io.get_file(fd, mode=mode, uri=uri)
+        self._fd = fd
+        header_line = fd.read_until(b'\r?\n', 2, "newline", include=True)
         self._file_format_version = cls._parse_header_line(header_line)
         self.version = self._file_format_version
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -517,10 +517,8 @@ class GenericFile(object):
             delimiter, readahead_bytes, delimiter_name=delimiter_name,
             include=include, initial_content=initial_content,
             exception=exception)
-        print('reader', reader)
         while True:
             content = reader.read(self.block_size)
-            print('content', content)
             buff.write(content)
             if len(content) < self.block_size:
                 break
@@ -880,10 +878,6 @@ class InputStream(GenericFile):
             if 'w' in self._mode:
                 result = result.copy()
             return result
-
-    #def seek(self, offset, whence=0):
-        #""" Does not support seek."""
-        #return NotImplementedError
 
 
 class OutputStream(GenericFile):

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -32,7 +32,7 @@ import numpy as np
 from .extern import atomicfile
 
 from . import util
-from .constants import ASDF_MAGIC
+
 
 __all__ = ['get_file', 'resolve_uri', 'relative_uri']
 
@@ -1281,33 +1281,3 @@ def get_file(init, mode='r', uri=None):
 
     raise ValueError("Can't handle '{0}' as a file for mode '{1}'".format(
         init, mode))
-
-
-def is_asdf_file(fd):
-    """
-    Determine if fd is an ASDF file.
-
-    Reads the first five bytes and looks for the ``#ASDF`` string.
-
-    Parameters
-    ----------
-    fd : str, `~asdf.generic_io.GenericFile`
-
-    """
-    if isinstance(fd, InputStream):
-        # If it's an InputStream let ASDF deal with it.
-        return True
-
-    to_close = False
-    if not isinstance(fd, GenericFile):
-        to_close = True
-        fd = get_file(fd, mode='r', uri=None)
-    asdf_magic = fd.read(5)
-    if fd.seekable():
-        fd.seek(0)
-    if to_close:
-        fd.close()
-    if asdf_magic == ASDF_MAGIC:
-        return True
-    else:
-        return False

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -20,6 +20,12 @@ from .. import util
 
 from . import helpers
 
+try:
+    from astropy.io import fits
+    HAS_ASTRPOPY = True
+except ImportError:
+    HAS_ASTROPY = False
+
 
 def _get_small_tree():
     x = np.arange(0, 10, dtype=np.float)
@@ -778,3 +784,17 @@ def test_truncated_reader():
     assert tr.read(99) == (init + content[:95])
     assert tr.read(50) == content[95:105]
     assert tr.read() == b''
+
+
+@pytest.mark.skipif('not HAS_ASTROPY')
+def test_is_asdf(tmpdir):
+    # test fits
+    hdul = fits.HDUList()
+    phdu=fits.PrimaryHDU()
+    imhdu=fits.ImageHDU(data=np.arange(24).reshape((4,6)))
+    hdul.append(phdu)
+    hdul.append(imhdu)
+    path = os.path.join(str(tmpdir), 'test.fits')
+    hdul.writeto(path)
+    assert not asdf.is_asdf_file(path)
+    assert asdf.is_asdf_file(asdf.AsdfFile())


### PR DESCRIPTION
Added a function which checks if the input is an ASDF file.
There was a check in `AsdfFile.open_impl` before. However, the approach there was to read until `\n` character and then check for the existence of the ASDF magic constant. This approach fails in some cases. In the case which  prompted this change, the input was a large FITS file which led to Memory Error after it took a long time to read the entire file.
The new `is_asdf_file` function reads only the first 5 bytes.