### PR TITLE
Better handling of AsdfInFits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@
 - The ``open`` method of ``AsdfInFits`` now accepts URIs and open file handles
   in addition to HDULists. The ``open`` method of ``AsdfFile`` will now try to
   parse the given URI or file handle as ``AsdfInFits`` if it is not obviously a
-  regular ASDF file. [#182]
+  regular ASDF file. [#241]
 
 1.2.1(2016-11-07)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 - Added a function ``is_asdf_file`` which inspects the input and
   returns ``True`` or ``False``. [#239]
 
+- The ``open`` method of ``AsdfInFits`` now accepts URIs and open file handles
+  in addition to HDULists. The ``open`` method of ``AsdfFile`` will now try to
+  parse the given URI or file handle as ``AsdfInFits`` if it is not obviously a
+  regular ASDF file. [#182]
+
 1.2.1(2016-11-07)
 -----------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1005,14 +1005,13 @@ def is_asdf_file(fd):
         return True
     elif isinstance(fd, generic_io.GenericFile):
         pass
-    elif isinstance(fd, io.IOBase):
+    else:
         try:
             fd = generic_io.get_file(fd, mode='r', uri=None)
+            if not isinstance(fd, io.IOBase):
+                to_close = True
         except ValueError:
             return False
-    else:
-        to_close = True
-        fd = generic_io.get_file(fd, mode='r', uri=None)
     asdf_magic = fd.read(5)
     if fd.seekable():
         fd.seek(0)
@@ -1020,5 +1019,4 @@ def is_asdf_file(fd):
         fd.close()
     if asdf_magic == constants.ASDF_MAGIC:
         return True
-    else:
-        return False
+    return False

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -483,7 +483,10 @@ class AsdfFile(versioning.VersionedMixin):
         return self
 
     @classmethod
-    def _open_impl(cls, self, fd, **kwargs):
+    def _open_impl(cls, self, fd, uri=None, mode='r',
+                   validate_checksums=False,
+                   do_not_fill_defaults=False,
+                   _get_yaml_content=False):
         """Attempt to open file-like object as either AsdfFile or AsdfInFits"""
         if not is_asdf_file(fd):
             try:
@@ -491,12 +494,17 @@ class AsdfFile(versioning.VersionedMixin):
                 # introduces another dependency on astropy which may not be
                 # desireable.
                 from . import fits_embed
-                return fits_embed.AsdfInFits.open(fd, kwargs)
+                return fits_embed.AsdfInFits.open(fd, uri=uri,
+                            validate_checksums=validate_checksums,
+                            extensions=self._extensions)
             except ValueError:
                 msg = "Input object does not appear to be ASDF file or " \
                       "FITS ASDF extension"
-                raise IOError(msg)
-        return cls._open_asdf(self, fd, kwargs)
+                raise ValueError(msg)
+        return cls._open_asdf(self, fd, uri=uri, mode=mode,
+                validate_checksums=validate_checksums,
+                do_not_fill_defaults=do_not_fill_defaults,
+                _get_yaml_content=_get_yaml_content)
 
     @classmethod
     def open(cls, fd, uri=None, mode='r',

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -200,7 +200,7 @@ class AsdfInFits(asdf.AsdfFile):
             return self
 
         buff = io.BytesIO(asdf_extension.data)
-        return cls._open_impl(self, buff, uri=uri, mode='r',
+        return cls._open_asdf(self, buff, uri=uri, mode='r',
                               validate_checksums=validate_checksums)
 
     def _update_asdf_extension(self, all_array_storage=None,

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -16,6 +16,7 @@ import six
 from . import asdf
 from . import block
 from . import util
+from . import generic_io
 
 try:
     from astropy.io import fits
@@ -156,16 +157,49 @@ class AsdfInFits(asdf.AsdfFile):
         self._tree = {}
 
     @classmethod
-    def open(cls, hdulist, uri=None, validate_checksums=False, extensions=None):
+    def open(cls, fd, uri=None, validate_checksums=False, extensions=None):
+        """Creates a new AsdfInFits object based on given input data
+
+        Parameters
+        ----------
+        fd : FITS HDUList instance, URI string, or file-like object
+            May be an already opened instance of a FITS HDUList instance,
+            string ``file`` or ``http`` URI, or a Python file-like object.
+
+        uri : str, optional
+            The URI for this ASDF file.  Used to resolve relative
+            references against.  If not provided, will be
+            automatically determined from the associated file object,
+            if possible and if created from `AsdfFile.open`.
+
+        validate_checksums : bool, optional
+            If `True`, validate the blocks against their checksums.
+            Requires reading the entire file, so disabled by default.
+
+        extensions : list of AsdfExtension, optional
+            A list of extensions to the ASDF to support when reading
+            and writing ASDF files.  See `asdftypes.AsdfExtension` for
+            more information.
+        """
+        if isinstance(fd, fits.hdu.hdulist.HDUList):
+            hdulist = fd
+        else:
+            file_obj = generic_io.get_file(fd)
+            try:
+                hdulist = fits.open(file_obj)
+            except IOError:
+                msg = "Failed to parse given file '{}'. Is it FITS?"
+                raise ValueError(msg.format(file_obj.uri))
+
         self = cls(hdulist, uri=uri, extensions=extensions)
 
         try:
             asdf_extension = hdulist[ASDF_EXTENSION_NAME]
         except (KeyError, IndexError, AttributeError):
+            # This means there is no ASDF extension
             return self
 
         buff = io.BytesIO(asdf_extension.data)
-
         return cls._open_impl(self, buff, uri=uri, mode='r',
                               validate_checksums=validate_checksums)
 

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -177,6 +177,11 @@ def test_asdf_in_fits_open(tmpdir):
     with fits_embed.AsdfInFits.open(tmpfile) as ff:
         compare_asdfs(asdf_in_fits, ff)
 
+    # Test open/close without context handler
+    ff = fits_embed.AsdfInFits.open(tmpfile)
+    compare_asdfs(asdf_in_fits, ff)
+    ff.close()
+
     # Test reading in the file from an already-opened file handle
     with open(tmpfile, 'rb') as handle:
         with fits_embed.AsdfInFits.open(handle) as ff:
@@ -198,6 +203,11 @@ def test_asdf_open(tmpdir):
     # Test opening the file directly from the URI
     with asdf_open(tmpfile) as ff:
         compare_asdfs(asdf_in_fits, ff)
+
+    # Test open/close without context handler
+    ff = asdf_open(tmpfile)
+    compare_asdfs(asdf_in_fits, ff)
+    ff.close()
 
     # Test reading in the file from an already-opened file handle
     with open(tmpfile, 'rb') as handle:


### PR DESCRIPTION
Issue #182 proposed more intelligent handling of FITS files with ASDF extensions. This branch allows ``AsdfInFits.open`` to handle URIs, open file handles, and HDULists, whereas previously it only handled HDULists. Also, ``AsdfFile.open`` now attempts to handle FITS files with ASDF extensions if the given file-like object is not obviously ASDF. Comments on implementation, code style, documentation, etc. welcome.