### PR TITLE
Asdf frame update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,10 @@
 
 - Updated WCS frame fields ``obsgeoloc`` and ``obsgeovel`` to reflect recent
   updates in ``astropy`` that changed representation from ``Quantity`` to
-  ``CartesianRepresentation``. [#212]
+  ``CartesianRepresentation``. Updated to reflect ``astropy`` change that
+  combines ``galcen_ra`` and ``galcen_dec`` into ``galcen_coord``. Added
+  support for new field ``galcen_v_sun``. Added support for required module
+  versions for tag classes. [#244]
 
 1.2.1(2016-11-07)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 - Added a function ``is_asdf_file`` which inspects the input and
   returns ``True`` or ``False``. [#239]
 
+- Updated WCS frame fields ``obsgeoloc`` and ``obsgeovel`` to reflect recent
+  updates in ``astropy`` that changed representation from ``Quantity`` to
+  ``CartesianRepresentation``. [#212]
+
 1.2.1(2016-11-07)
 -----------------
 

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -4,8 +4,9 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import bisect
-import imp
+import importlib
 import warnings
+import re
 
 import six
 
@@ -24,6 +25,9 @@ __all__ = ['format_tag', 'AsdfTypeIndex', 'AsdfType']
 _BASIC_PYTHON_TYPES = set(list(six.string_types) +
                           list(six.integer_types) +
                           [float, list, dict, tuple])
+
+# regex used to parse module name from optional version string
+MODULE_RE = re.compile(r'([a-zA-Z]+)(-(\d.\d.\d))?')
 
 
 def format_tag(organization, standard, version, tag_name):
@@ -325,17 +329,24 @@ class AsdfTypeMeta(type):
 
     @classmethod
     def _has_required_modules(cls, requires):
-        for mod in requires:
-            if mod in cls._import_cache:
-                if not cls._import_cache[mod]:
+        for string in requires:
+            has_module = True
+            match = MODULE_RE.match(string)
+            modname, _, version = match.groups()
+            if modname in cls._import_cache:
+                if not cls._import_cache[modname]:
                     return False
             try:
-                imp.find_module(mod)
+                module = importlib.import_module(modname)
+                if version and hasattr(module, '__version__'):
+                    if module.__version__ < version:
+                        has_module = False
             except ImportError:
-                cls._import_cache[mod] = False
-                return False
-            else:
-                cls._import_cache[mod] = True
+                has_module = False
+            finally:
+                cls._import_cache[modname] = has_module
+                if not has_module:
+                    return False
         return True
 
     @classmethod

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -27,7 +27,7 @@ _BASIC_PYTHON_TYPES = set(list(six.string_types) +
                           [float, list, dict, tuple])
 
 # regex used to parse module name from optional version string
-MODULE_RE = re.compile(r'([a-zA-Z]+)(-(\d.\d.\d))?')
+MODULE_RE = re.compile(r'([a-zA-Z]+)(-(\d+\.\d+\.\d+))?')
 
 
 def format_tag(organization, standard, version, tag_name):

--- a/asdf/tags/unit/__init__.py
+++ b/asdf/tags/unit/__init__.py
@@ -4,3 +4,4 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 from .unit import UnitType
+from .quantity import QuantityType

--- a/asdf/tags/unit/quantity.py
+++ b/asdf/tags/unit/quantity.py
@@ -13,6 +13,7 @@ class QuantityType(AsdfType):
     name = 'unit/quantity'
     types = ['astropy.units.Quantity']
     requires = ['astropy']
+    version = '1.1.0'
 
     @classmethod
     def to_tree(cls, quantity, ctx):
@@ -22,7 +23,7 @@ class QuantityType(AsdfType):
         node = {}
         if isinstance(quantity, Quantity):
             value = quantity.value
-            node['value'] = [value] if isscalar(value) else value
+            node['value'] = [value] if isscalar(value) else list(value)
             node['unit'] = UnitType.to_tree(quantity.unit, ctx)
             return node
         raise TypeError("'{0}' is not a valid Quantity".format(quantity))

--- a/asdf/tags/unit/quantity.py
+++ b/asdf/tags/unit/quantity.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import six
+
+from ...asdftypes import AsdfType
+from . import UnitType
+
+
+class QuantityType(AsdfType):
+    name = 'unit/quantity'
+    types = ['astropy.units.Quantity']
+    requires = ['astropy']
+
+    @classmethod
+    def to_tree(cls, quantity, ctx):
+        from numpy import isscalar
+        from astropy.units import Quantity
+
+        node = {}
+        if isinstance(quantity, Quantity):
+            value = quantity.value
+            node['value'] = [value] if isscalar(value) else value
+            node['unit'] = UnitType.to_tree(quantity.unit, ctx)
+            return node
+        raise TypeError("'{0}' is not a valid Quantity".format(quantity))
+
+    @classmethod
+    def from_tree(cls, node, ctx):
+        from astropy.units import Quantity
+
+        if isinstance(node, Quantity):
+            return node
+
+        unit = UnitType.from_tree(node['unit'], ctx)
+        return Quantity(node['value'], unit=unit)

--- a/asdf/tags/unit/quantity.py
+++ b/asdf/tags/unit/quantity.py
@@ -23,7 +23,8 @@ class QuantityType(AsdfType):
         node = {}
         if isinstance(quantity, Quantity):
             value = quantity.value
-            node['value'] = [value] if isscalar(value) else list(value)
+            # We currently can't handle NDArrays directly, so convert to list
+            node['value'] = value if isscalar(value) else list(value)
             node['unit'] = UnitType.to_tree(quantity.unit, ctx)
             return node
         raise TypeError("'{0}' is not a valid Quantity".format(quantity))

--- a/asdf/tags/unit/tests/test_quantity.py
+++ b/asdf/tags/unit/tests/test_quantity.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import io
+
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy import units
+
+import pytest
+
+from .... import asdf
+
+
+@pytest.mark.skipif('not HAS_ASTROPY')
+def test_quantity_roundtrip(tmpdir):
+    from ....tests import helpers
+    yaml = """
+quantity: !unit/quantity-1.1.0
+    value: [3.14159]
+    unit: kg
+"""
+    quantity = units.Quantity(3.14159, unit=units.kg)
+    buff = helpers.yaml_to_asdf(yaml)
+    with asdf.AsdfFile.open(buff) as ff:
+        assert ff.tree['quantity'] == quantity
+        buff2 = io.BytesIO()
+        ff.write_to(buff2)
+
+    buff2.seek(0)
+    with asdf.AsdfFile.open(buff2) as ff:
+        assert ff.tree['quantity'] == quantity

--- a/asdf/tags/unit/unit.py
+++ b/asdf/tags/unit/unit.py
@@ -16,16 +16,16 @@ class UnitType(AsdfType):
 
     @classmethod
     def to_tree(cls, node, ctx):
-        from astropy import units as u
+        from astropy.units import Unit, UnitBase
 
         if isinstance(node, six.string_types):
-            node = u.Unit(node, format='vounit', parse_strict='warn')
-        if isinstance(node, u.UnitBase):
+            node = Unit(node, format='vounit', parse_strict='warn')
+        if isinstance(node, UnitBase):
             return node.to_string(format='vounit')
         raise TypeError("'{0}' is not a valid unit".format(node))
 
     @classmethod
     def from_tree(cls, node, ctx):
-        from astropy import units as u
+        from astropy.units import Unit
 
-        return u.Unit(node, format='vounit', parse_strict='silent')
+        return Unit(node, format='vounit', parse_strict='silent')

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -3,36 +3,23 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-
-try:
-    import astropy
-except ImportError:
-    HAS_ASTROPY = False
-else:
-    HAS_ASTROPY = True
-
-    from astropy.modeling import models
-    from astropy import coordinates as coord
-    from astropy import units as u
-    from astropy import time
-
-try:
-    import gwcs
-except ImportError:
-    HAS_GWCS = False
-else:
-    HAS_GWCS = True
-
-    from gwcs import coordinate_frames as cf
-    from gwcs import wcs
-
 import pytest
 import warnings
+
+gwcs = pytest.importorskip('gwcs')
+astropy = pytest.importorskip('astropy', minversion='1.3.3')
+
+from astropy.modeling import models
+from astropy import coordinates as coord
+from astropy import units as u
+from astropy import time
+
+from gwcs import coordinate_frames as cf
+from gwcs import wcs
 
 from ....tests import helpers
 
 
-@pytest.mark.skipif('not HAS_GWCS')
 def test_create_wcs(tmpdir):
     m1 = models.Shift(12.4) & models.Shift(-2)
     m2 = models.Scale(2) & models.Scale(-2)
@@ -51,7 +38,6 @@ def test_create_wcs(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
-@pytest.mark.skipif('not HAS_GWCS')
 def test_composite_frame(tmpdir):
     icrs = coord.ICRS()
     fk5 = coord.FK5()
@@ -134,7 +120,6 @@ def create_test_frames():
 
     return frames
 
-@pytest.mark.skipif('not HAS_GWCS')
 def test_frames(tmpdir):
 
     tree = {

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -105,11 +105,11 @@ def test_frames(tmpdir):
                 roll=3*u.deg)
             ),
 
-        #cf.CelestialFrame(
-        #    reference_frame=coord.GCRS(
-        #        obstime=time.Time('2010-01-01'),
-        #        obsgeoloc=[1, 3, 2000] * u.pc,
-        #        obsgeovel=[2, 1, 8] * (u.m/u.s))),
+        cf.CelestialFrame(
+            reference_frame=coord.GCRS(
+                obstime=time.Time('2010-01-01'),
+                obsgeoloc=[1, 3, 2000] * u.pc,
+                obsgeovel=[2, 1, 8] * (u.m/u.s))),
 
         cf.CelestialFrame(
             reference_frame=coord.CIRS(
@@ -119,11 +119,11 @@ def test_frames(tmpdir):
             reference_frame=coord.ITRS(
                 obstime=time.Time('2022-01-03'))),
 
-        #cf.CelestialFrame(
-        #    reference_frame=coord.PrecessedGeocentric(
-        #        obstime=time.Time('2010-01-01'),
-        #        obsgeoloc=[1, 3, 2000] * u.pc,
-        #        obsgeovel=[2, 1, 8] * (u.m/u.s)))
+        cf.CelestialFrame(
+            reference_frame=coord.PrecessedGeocentric(
+                obstime=time.Time('2010-01-01'),
+                obsgeoloc=[1, 3, 2000] * u.pc,
+                obsgeovel=[2, 1, 8] * (u.m/u.s)))
     ]
 
     tree = {

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -105,9 +105,8 @@ def create_test_frames():
 
         cf.CelestialFrame(
             reference_frame=coord.Galactocentric(
+                # A default galcen_coord is used since none is provided here
                 galcen_distance=5.0*u.m,
-                galcen_ra=45*u.deg,
-                galcen_dec=1*u.rad,
                 z_sun=3*u.pc,
                 roll=3*u.deg)
             ),

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -27,6 +27,7 @@ else:
     from gwcs import wcs
 
 import pytest
+import warnings
 
 from ....tests import helpers
 
@@ -75,6 +76,13 @@ def test_composite_frame(tmpdir):
 
 @pytest.mark.skipif('not HAS_GWCS')
 def test_frames(tmpdir):
+
+    # Suppress warnings from astropy that are caused by having 'dubious' dates
+    # that are too far in the future. It's not a concern for the purposes of
+    # unit tests. See issue #5809 on the astropy GitHub for discussion.
+    from astropy._erfa import ErfaWarning
+    warnings.simplefilter("ignore", ErfaWarning)
+
     frames = [
         cf.CelestialFrame(reference_frame=coord.ICRS()),
 

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -73,9 +73,8 @@ def test_composite_frame(tmpdir):
 
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
-
-@pytest.mark.skipif('not HAS_GWCS')
-def test_frames(tmpdir):
+def create_test_frames():
+    """Creates an array of frames to be used for testing."""
 
     # Suppress warnings from astropy that are caused by having 'dubious' dates
     # that are too far in the future. It's not a concern for the purposes of
@@ -134,8 +133,13 @@ def test_frames(tmpdir):
                 obsgeovel=[2, 1, 8] * (u.m/u.s)))
     ]
 
+    return frames
+
+@pytest.mark.skipif('not HAS_GWCS')
+def test_frames(tmpdir):
+
     tree = {
-        'frames': frames
+        'frames': create_test_frames()
     }
 
     helpers.assert_roundtrip_tree(tree, tmpdir)

--- a/asdf/tags/wcs/wcs.py
+++ b/asdf/tags/wcs/wcs.py
@@ -112,7 +112,8 @@ class FrameType(AsdfType):
     @classmethod
     def _from_tree(cls, node, ctx):
         from ..unit import QuantityType
-        from astropy.coordinates import CartesianRepresentation
+        from astropy.coordinates import (CartesianRepresentation,
+            CartesianDifferential)
 
         kwargs = {}
 
@@ -137,6 +138,11 @@ class FrameType(AsdfType):
                         y = QuantityType.from_tree(val[1], ctx)
                         z = QuantityType.from_tree(val[2], ctx)
                         val = CartesianRepresentation(x, y, z)
+                    elif name == 'galcen_v_sun':
+                        d_x = QuantityType.from_tree(val[0], ctx)
+                        d_y = QuantityType.from_tree(val[1], ctx)
+                        d_z = QuantityType.from_tree(val[2], ctx)
+                        val = CartesianDifferential(d_x, d_y, d_z)
                     else:
                         val = yamlutil.tagged_tree_to_custom_tree(val, ctx)
                     frame_kwargs[name] = val
@@ -156,7 +162,8 @@ class FrameType(AsdfType):
     def _to_tree(cls, frame, ctx):
         import numpy as np
         from ..unit import QuantityType
-        from astropy.coordinates import CartesianRepresentation
+        from astropy.coordinates import (CartesianRepresentation,
+            CartesianDifferential)
 
         node = {}
 
@@ -179,6 +186,9 @@ class FrameType(AsdfType):
                 # coordinates with associated units
                 if isinstance(frameval, CartesianRepresentation):
                     value = [frameval.x, frameval.y, frameval.z]
+                    frameval = value
+                elif isinstance(frameval, CartesianDifferential):
+                    value = [frameval.d_x, frameval.d_y, frameval.d_z]
                     frameval = value
                 yamlval = yamlutil.custom_tree_to_tagged_tree(frameval, ctx)
                 reference_frame[name] = yamlval

--- a/asdf/tags/wcs/wcs.py
+++ b/asdf/tags/wcs/wcs.py
@@ -70,6 +70,7 @@ class StepType(dict, AsdfType):
 
 class FrameType(AsdfType):
     name = "wcs/frame"
+    version = '1.1.0'
     requires = _REQUIRES
     types = ['gwcs.Frame2D']
 

--- a/asdf/tags/wcs/wcs.py
+++ b/asdf/tags/wcs/wcs.py
@@ -71,7 +71,9 @@ class StepType(dict, AsdfType):
 class FrameType(AsdfType):
     name = "wcs/frame"
     version = '1.1.0'
-    requires = _REQUIRES
+    # We require a specific version of astropy in order to make use of
+    # CartesianDifferential
+    requires = ['gwcs', 'astropy-1.3.3']
     types = ['gwcs.Frame2D']
 
     @classmethod

--- a/asdf/tags/wcs/wcs.py
+++ b/asdf/tags/wcs/wcs.py
@@ -319,7 +319,7 @@ class ICRSCoord(AsdfType):
     name = "wcs/icrs_coord"
     types = ['astropy.coordinates.ICRS']
     requires = ['astropy']
-    version = "1.0.0"
+    version = "1.1.0"
 
     @classmethod
     def from_tree(cls, node, ctx):

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -15,7 +15,8 @@ except ImportError:
     HAS_ASTROPY = False
 else:
     from astropy.coordinates import ICRS
-    from astropy.coordinates.representation import CartesianRepresentation
+    from astropy.coordinates.representation import (CartesianRepresentation,
+        CartesianDifferential)
     HAS_ASTROPY = True
 
 from ..asdf import AsdfFile, get_asdf_library_info
@@ -86,15 +87,18 @@ def assert_tree_match(old_tree, new_tree, ctx=None,
             assert len(old) == len(new)
             for a, b in zip(old, new):
                 recurse(a, b)
+        # The astropy classes CartesianRepresentation, CartesianDifferential,
+        # and ICRS do not define equality in a way that is meaningful for unit
+        # tests. We explicitly compare the fields that we care about in order
+        # to enable our unit testing. It is possible that in the future it will
+        # be necessary or useful to account for fields that are not currently
+        # compared.
         elif HAS_ASTROPY and isinstance(old, CartesianRepresentation):
-            # CartesianRepresentation from astropy does not define equality in
-            # a meaningful way, but we want to be able to use it in unit tests
             assert old.x == new.x and old.y == new.y and old.z == new.z
+        elif HAS_ASTROPY and isinstance(old, CartesianDifferential):
+            assert old.d_x == new.d_x and old.d_y == new.d_y and \
+                old.d_z == new.d_z
         elif HAS_ASTROPY and isinstance(old, ICRS):
-            # ICRS from astropy does not define equality in a meaningful way,
-            # but we want to be able to use it in unit tests. For now we only
-            # compare RA and dec, but other fields may be important in the
-            # future
             assert old.ra == new.ra and old.dec == new.dec
         else:
             assert old == new

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     HAS_ASTROPY = False
 else:
+    from astropy.coordinates import ICRS
     from astropy.coordinates.representation import CartesianRepresentation
     HAS_ASTROPY = True
 
@@ -89,6 +90,12 @@ def assert_tree_match(old_tree, new_tree, ctx=None,
             # CartesianRepresentation from astropy does not define equality in
             # a meaningful way, but we want to be able to use it in unit tests
             assert old.x == new.x and old.y == new.y and old.z == new.z
+        elif HAS_ASTROPY and isinstance(old, ICRS):
+            # ICRS from astropy does not define equality in a meaningful way,
+            # but we want to be able to use it in unit tests. For now we only
+            # compare RA and dec, but other fields may be important in the
+            # future
+            assert old.ra == new.ra and old.dec == new.dec
         else:
             assert old == new
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -9,6 +9,14 @@ import sys
 
 import six
 
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    from astropy.coordinates.representation import CartesianRepresentation
+    HAS_ASTROPY = True
+
 from ..asdf import AsdfFile, get_asdf_library_info
 from ..conftest import RangeHTTPServer
 from ..extension import _builtin_extension_list
@@ -77,6 +85,10 @@ def assert_tree_match(old_tree, new_tree, ctx=None,
             assert len(old) == len(new)
             for a, b in zip(old, new):
                 recurse(a, b)
+        elif HAS_ASTROPY and isinstance(old, CartesianRepresentation):
+            # CartesianRepresentation from astropy does not define equality in
+            # a meaningful way, but we want to be able to use it in unit tests
+            assert old.x == new.x and old.y == new.y and old.z == new.z
         else:
             assert old == new
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -10,14 +10,19 @@ import sys
 import six
 
 try:
-    import astropy
-except ImportError:
-    HAS_ASTROPY = False
-else:
     from astropy.coordinates import ICRS
-    from astropy.coordinates.representation import (CartesianRepresentation,
-        CartesianDifferential)
-    HAS_ASTROPY = True
+except ImportError:
+    ICRS = None
+
+try:
+    from astropy.coordinates.representation import CartesianRepresentation
+except ImportError:
+    CartesianRepresentation = None
+
+try:
+    from astropy.coordinates.representation import CartesianDifferential
+except ImportError:
+    CartesianDifferential = None
 
 from ..asdf import AsdfFile, get_asdf_library_info
 from ..conftest import RangeHTTPServer
@@ -93,12 +98,14 @@ def assert_tree_match(old_tree, new_tree, ctx=None,
         # to enable our unit testing. It is possible that in the future it will
         # be necessary or useful to account for fields that are not currently
         # compared.
-        elif HAS_ASTROPY and isinstance(old, CartesianRepresentation):
+        elif CartesianRepresentation is not None and \
+                isinstance(old, CartesianRepresentation):
             assert old.x == new.x and old.y == new.y and old.z == new.z
-        elif HAS_ASTROPY and isinstance(old, CartesianDifferential):
+        elif CartesianDifferential is not None and \
+                isinstance(old, CartesianDifferential):
             assert old.d_x == new.d_x and old.d_y == new.d_y and \
                 old.d_z == new.d_z
-        elif HAS_ASTROPY and isinstance(old, ICRS):
+        elif ICRS is not None and isinstance(old, ICRS):
             assert old.ra == new.ra and old.dec == new.dec
         else:
             assert old == new


### PR DESCRIPTION
 This update addresses issue #212. Astropy updated the representation of the ``obsgeoloc`` and ``obsgeovel`` fields of WCS frames to be ``CartesianRepresentation`` objects where previously they were ``Quantity`` objects. This update brings the ASDF WCS frame implementation in line with   those changes. It relies on a change to the schema of WCS frames in ``asdf-standard`` (currently pending pull request: https://github.com/spacetelescope/asdf-standard/pull/142).

**Note**: The ``CartesianRepresentation`` class from ``astropy`` does not currently define equality. Our unit tests depend on being able to compare an original object with the object resulting from a round-trip tree operation, so they currently will not pass with these changes. I was able to test the changes in the interim by modifying a local checkout of ``astropy``.
