### PR TITLE
Mitigate and/or suppress pytest warnings

### DIFF
--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -27,6 +27,7 @@ else:
     from gwcs import wcs
 
 import pytest
+import warnings
 
 from ....tests import helpers
 
@@ -75,6 +76,13 @@ def test_composite_frame(tmpdir):
 
 @pytest.mark.skipif('not HAS_GWCS')
 def test_frames(tmpdir):
+
+    # Suppress warnings from astropy that are caused by having 'dubious' dates
+    # that are too far in the future. It's not a concern for the purposes of
+    # unit tests. See issue #5809 on the astropy GitHub for discussion.
+    from astropy._erfa import ErfaWarning
+    warnings.simplefilter("ignore", ErfaWarning)
+
     frames = [
         cf.CelestialFrame(reference_frame=coord.ICRS()),
 

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -22,7 +22,7 @@ from . import helpers
 
 try:
     from astropy.io import fits
-    HAS_ASTRPOPY = True
+    HAS_ASTROPY = True
 except ImportError:
     HAS_ASTROPY = False
 

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -60,6 +60,12 @@ def _roundtrip(tree, get_write_fd, get_read_fd,
                write_options={}, read_options={}):
     with get_write_fd() as fd:
         asdf.AsdfFile(tree).write_to(fd, **write_options)
+        # Work around the fact that generic_io's get_file doesn't have a way of
+        # determining whether or not the underlying file handle should be
+        # closed as part of the exit handler
+        if (six.PY3 and isinstance(fd._fd, io.FileIO)) or \
+                (six.PY2 and isinstance(fd._fd, file)):
+            fd._fd.close()
 
     with get_read_fd() as fd:
         ff = asdf.AsdfFile.open(fd, **read_options)

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -16,12 +16,10 @@ else:
 from jsonschema import ValidationError
 
 import numpy as np
-
 import pytest
-
 import six
-
 import yaml
+import warnings
 
 from .. import asdf
 from .. import asdftypes
@@ -30,6 +28,7 @@ from .. import resolver
 from .. import schema
 from .. import treeutil
 from .. import util
+
 
 from . import helpers
 
@@ -134,6 +133,7 @@ def test_schema_example(filename, example):
 
     # Fake an external file
     ff2 = asdf.AsdfFile({'data': np.empty((1024*1024*8), dtype=np.uint8)})
+
     ff._external_asdf_by_uri[
         util.filepath_to_url(
             os.path.abspath(
@@ -148,6 +148,11 @@ def test_schema_example(filename, example):
     b._array_storage = "streamed"
 
     try:
+        # Ignore warnings that result from examples from schemas that have
+        # versions higher than the current standard version.
+        # TODO: this should no longer be necessary once the library can
+        # actually account for higher versions
+        warnings.simplefilter('ignore', UserWarning)
         ff._open_impl(ff, buff)
     except:
         print("From file:", filename)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled


### PR DESCRIPTION
There were quite a few issues that were causing warnings when running pytests (see issue #243). Some of these were due to deprecated functionality in pytests itself. Others indicate potential issues that need to be addressed, but can be suppressed for the time being.

This addresses issue 