### PR TITLE
Make default behavior of AsdfFile.open to fail on ASDF in FITS ...

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -487,11 +487,11 @@ class AsdfFile(versioning.VersionedMixin):
                    validate_checksums=False,
                    do_not_fill_defaults=False,
                    _get_yaml_content=False,
-                  try_asdf_in_fits=False):
+                  accept_asdf_in_fits=True):
         """Attempt to open file-like object as either AsdfFile or AsdfInFits"""
         if not is_asdf_file(fd):
             msg = "Input object does not appear to be ASDF file"
-            if try_asdf_in_fits:
+            if accept_asdf_in_fits:
                 try:
                     # TODO: this feels a bit circular, try to clean up. Also
                     # this introduces another dependency on astropy which may
@@ -513,7 +513,7 @@ class AsdfFile(versioning.VersionedMixin):
              validate_checksums=False,
              extensions=None,
              do_not_fill_defaults=False,
-             try_asdf_in_fits=False):
+             accept_asdf_in_fits=True):
         """
         Open an existing ASDF file.
 
@@ -543,10 +543,10 @@ class AsdfFile(versioning.VersionedMixin):
         do_not_fill_defaults : bool, optional
             When `True`, do not fill in missing default values.
 
-        try_asdf_in_fits : bool, optional
-            When `True`, also try to automatically handle FITS files with ASDF
-            extensions. This is set to `False` by default in order to preserve
-            backwards compatibility.
+        accept_asdf_in_fits : bool, optional
+            When `True`, try to automatically process FITS files with ASDF
+            extensions. If backwards compatibility with old behavior is
+            required, set this flag to `False`.
 
         Returns
         -------
@@ -559,7 +559,7 @@ class AsdfFile(versioning.VersionedMixin):
             self, fd, uri=uri, mode=mode,
             validate_checksums=validate_checksums,
             do_not_fill_defaults=do_not_fill_defaults,
-            try_asdf_in_fits=try_asdf_in_fits)
+            accept_asdf_in_fits=accept_asdf_in_fits)
 
     def _write_tree(self, tree, fd, pad_blocks):
         fd.write(constants.ASDF_MAGIC)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -219,3 +219,31 @@ def test_asdf_open(tmpdir):
     with fits.open(tmpfile) as hdulist:
         with asdf_open(hdulist) as ff:
             compare_asdfs(asdf_in_fits, ff)
+
+@pytest.mark.skipif('not HAS_ASTROPY')
+def test_bad_input(tmpdir):
+    """Make sure these functions behave properly with bad input"""
+    text_file = os.path.join(str(tmpdir), 'test.txt')
+    fits_file = os.path.join(str(tmpdir), 'test.fits')
+    asdf_in_fits = create_asdf_in_fits()
+    asdf_in_fits.write_to(fits_file)
+
+    with open(text_file, 'w') as fh:
+        fh.write('I <3 ASDF!!!!!')
+
+    with pytest.raises(ValueError):
+        asdf_open(text_file)
+
+    with pytest.raises(ValueError):
+        asdf_open(text_file, accept_asdf_in_fits=False)
+
+    with pytest.raises(ValueError):
+        asdf_open(fits_file, accept_asdf_in_fits=False)
+
+    with pytest.raises(ValueError):
+        with open(fits_file, 'rb') as handle:
+            asdf_open(handle, accept_asdf_in_fits=False)
+
+    with pytest.raises(ValueError):
+        with fits.open(fits_file) as hdulist:
+            asdf_open(hdulist, accept_asdf_in_fits=False)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -140,8 +140,9 @@ def test_create_in_tree_first(tmpdir):
     hdulist.append(fits.ImageHDU(tree['model']['dq']['data']))
     hdulist.append(fits.ImageHDU(tree['model']['err']['data']))
 
+    tmpfile = os.path.join(str(tmpdir), 'test.fits')
     with fits_embed.AsdfInFits(hdulist, tree) as ff:
-        ff.write_to(os.path.join(str(tmpdir), 'test.fits'))
+        ff.write_to(tmpfile)
 
     with asdf.AsdfFile(tree) as ff:
         ff.write_to(os.path.join(str(tmpdir), 'plain.asdf'))
@@ -152,7 +153,7 @@ def test_create_in_tree_first(tmpdir):
 
     # This tests the changes that allow FITS files with ASDF extensions to be
     # opened directly by the top-level AsdfFile.open API
-    with asdf_open(os.path.join(str(tmpdir), 'test.fits')) as ff:
+    with asdf_open(tmpfile, try_asdf_in_fits=True) as ff:
         assert_array_equal(ff.tree['model']['sci']['data'],
                            np.arange(512, dtype=np.float))
 
@@ -201,20 +202,20 @@ def test_asdf_open(tmpdir):
     asdf_in_fits.write_to(tmpfile)
 
     # Test opening the file directly from the URI
-    with asdf_open(tmpfile) as ff:
+    with asdf_open(tmpfile, try_asdf_in_fits=True) as ff:
         compare_asdfs(asdf_in_fits, ff)
 
     # Test open/close without context handler
-    ff = asdf_open(tmpfile)
+    ff = asdf_open(tmpfile, try_asdf_in_fits=True)
     compare_asdfs(asdf_in_fits, ff)
     ff.close()
 
     # Test reading in the file from an already-opened file handle
     with open(tmpfile, 'rb') as handle:
-        with asdf_open(handle) as ff:
+        with asdf_open(handle, try_asdf_in_fits=True) as ff:
             compare_asdfs(asdf_in_fits, ff)
 
     # Test opening the file as a FITS file first and passing the HDUList
     with fits.open(tmpfile) as hdulist:
-        with asdf_open(hdulist) as ff:
+        with asdf_open(hdulist, try_asdf_in_fits=True) as ff:
             compare_asdfs(asdf_in_fits, ff)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -153,7 +153,7 @@ def test_create_in_tree_first(tmpdir):
 
     # This tests the changes that allow FITS files with ASDF extensions to be
     # opened directly by the top-level AsdfFile.open API
-    with asdf_open(tmpfile, try_asdf_in_fits=True) as ff:
+    with asdf_open(tmpfile) as ff:
         assert_array_equal(ff.tree['model']['sci']['data'],
                            np.arange(512, dtype=np.float))
 
@@ -202,20 +202,20 @@ def test_asdf_open(tmpdir):
     asdf_in_fits.write_to(tmpfile)
 
     # Test opening the file directly from the URI
-    with asdf_open(tmpfile, try_asdf_in_fits=True) as ff:
+    with asdf_open(tmpfile) as ff:
         compare_asdfs(asdf_in_fits, ff)
 
     # Test open/close without context handler
-    ff = asdf_open(tmpfile, try_asdf_in_fits=True)
+    ff = asdf_open(tmpfile)
     compare_asdfs(asdf_in_fits, ff)
     ff.close()
 
     # Test reading in the file from an already-opened file handle
     with open(tmpfile, 'rb') as handle:
-        with asdf_open(handle, try_asdf_in_fits=True) as ff:
+        with asdf_open(handle) as ff:
             compare_asdfs(asdf_in_fits, ff)
 
     # Test opening the file as a FITS file first and passing the HDUList
     with fits.open(tmpfile) as hdulist:
-        with asdf_open(hdulist, try_asdf_in_fits=True) as ff:
+        with asdf_open(hdulist) as ff:
             compare_asdfs(asdf_in_fits, ff)


### PR DESCRIPTION
Originally the intent was to have AsdfFile.open transparently open both
ASDF files and FITS files with ASDF extensions. However, clients (namely
the jwst pipeline) expected AsdfFile.open to fail with a ValueError if any
kind of FITS file was provided. In order to preseve backwards compatibility
for now, the default behavior is to be strict about accepting only ASDF
files but clients can use the try_asdf_in_fits parameter to change this
behavior.