### PR TITLE
Fix changing the compression codec

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -346,16 +346,19 @@ class AsdfFile(versioning.VersionedMixin):
             the tree, only the most recent compression setting will be
             used, since all views share a single block.
 
-        array_compression : str or None
+        compression : str or None
             Must be one of:
+
+            - ``''`` or `None`: no compression
 
             - ``zlib``: Use zlib compression
 
             - ``bzp2``: Use bzip2 compression
 
-            - ``''`` or `None`: no compression
+            - ``input``: Use the same compression as in the file read.
+              If there is no prior file, acts as None.
         """
-        self.blocks[arr].compression = compression
+        self.blocks[arr].output_compression = compression
 
     def get_array_compression(self, arr):
         """
@@ -369,7 +372,7 @@ class AsdfFile(versioning.VersionedMixin):
         -------
         compression : str or None
         """
-        return self.blocks[arr].compression
+        return self.blocks[arr].output_compression
 
     @classmethod
     def _parse_header_line(cls, line):
@@ -638,7 +641,7 @@ class AsdfFile(versioning.VersionedMixin):
         if hasattr(self, '_auto_inline'):
             del self._auto_inline
 
-    def update(self, all_array_storage=None, all_array_compression=None,
+    def update(self, all_array_storage=None, all_array_compression='input',
                auto_inline=None, pad_blocks=False, include_block_index=True,
                version=None):
         """
@@ -662,11 +665,14 @@ class AsdfFile(versioning.VersionedMixin):
             If provided, set the compression type on all binary blocks
             in the file.  Must be one of:
 
-            - ``''``: No compression.
+            - ``''`` or `None`: No compression.
 
             - ``zlib``: Use zlib compression.
 
             - ``bzp2``: Use bzip2 compression.
+
+            - ``input``: Use the same compression as in the file read.
+              If there is no prior file, acts as None.
 
         auto_inline : int, optional
             When the number of elements in an array is less than this
@@ -763,7 +769,7 @@ class AsdfFile(versioning.VersionedMixin):
         finally:
             self._post_write(fd)
 
-    def write_to(self, fd, all_array_storage=None, all_array_compression=None,
+    def write_to(self, fd, all_array_storage=None, all_array_compression='input',
                  auto_inline=None, pad_blocks=False, include_block_index=True,
                  version=None):
         """
@@ -796,11 +802,14 @@ class AsdfFile(versioning.VersionedMixin):
             If provided, set the compression type on all binary blocks
             in the file.  Must be one of:
 
-            - ``''``: No compression.
+            - ``''`` or `None`: No compression.
 
             - ``zlib``: Use zlib compression.
 
             - ``bzp2``: Use bzip2 compression.
+
+            - ``input``: Use the same compression as in the file read.
+              If there is no prior file, acts as None.
 
         auto_inline : int, optional
             When the number of elements in an array is less than this

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -25,18 +25,15 @@ def validate(compression):
     ------
     ValueError
     """
-    if not compression:
-        return None
-
-    if compression == b'\0\0\0\0':
+    if not compression or compression == b'\0\0\0\0':
         return None
 
     if isinstance(compression, bytes):
         compression = compression.decode('ascii')
 
-    if compression not in ('zlib', 'bzp2'):
+    if compression not in ('zlib', 'bzp2', 'input'):
         raise ValueError(
-            "Supported compression types are: 'zlib' and 'bzp2'")
+            "Supported compression types are: 'zlib', 'bzp2' or 'input'")
 
     return compression
 
@@ -72,8 +69,8 @@ def _get_encoder(compression):
         except ImportError:
             raise ImportError(
                 "Your Python does not have the zlib library, "
-                "therefore the compressed block in this ASDF file "
-                "can not be decompressed.")
+                "therefore the block in this ASDF file "
+                "can not be compressed.")
         return zlib.compressobj()
     elif compression == 'bzp2':
         try:
@@ -81,8 +78,8 @@ def _get_encoder(compression):
         except ImportError:
             raise ImportError(
                 "Your Python does not have the bz2 library, "
-                "therefore the compressed block in this ASDF file "
-                "can not be decompressed.")
+                "therefore the block in this ASDF file "
+                "can not be compressed.")
         return bz2.BZ2Compressor()
     else:
         raise ValueError(
@@ -166,7 +163,7 @@ def compress(fd, data, compression, block_size=1 << 16):
         The type of compression to use.
 
     block_size : int, optional
-        The size of blocks (in raw data) to process at a time.
+        Input data will be split into blocks of this size (in bytes) before the compression.
     """
     compression = validate(compression)
     encoder = _get_encoder(compression)
@@ -187,6 +184,9 @@ def get_compressed_size(data, compression, block_size=1 << 16):
 
     compression : str
         The type of compression to use.
+
+    block_size : int, optional
+        Input data will be split into blocks of this size (in bytes) before the compression.
 
     Returns
     -------

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import pytest
 
-from .. import asdf
+from .. import asdf, compression
 from .. import generic_io
 from ..tests import helpers
 
@@ -78,6 +78,29 @@ def test_invalid_compression():
     ff = asdf.AsdfFile(tree)
     with pytest.raises(ValueError):
         ff.set_array_compression(tree['science_data'], 'foo')
+    with pytest.raises(ValueError):
+        compression._get_decoder('foo')
+    with pytest.raises(ValueError):
+        compression._get_encoder('foo')
+
+
+def test_get_compressed_size():
+    assert compression.get_compressed_size(b'0' * 1024, 'zlib') < 1024
+
+
+def test_decompress_too_long_short():
+    fio = io.BytesIO()
+    compression.compress(fio, b'0' * 1024, 'zlib')
+    size = fio.tell()
+    fio.seek(0)
+    fio.read_blocks = lambda us: [fio.read(us)]
+    compression.decompress(fio, size, 1024, 'zlib')
+    fio.seek(0)
+    with pytest.raises(ValueError):
+        compression.decompress(fio, size, 1025, 'zlib')
+    fio.seek(0)
+    with pytest.raises(ValueError):
+        compression.decompress(fio, size, 1023, 'zlib')
 
 
 def test_zlib(tmpdir):
@@ -90,3 +113,55 @@ def test_bzp2(tmpdir):
     tree = _get_large_tree()
 
     _roundtrip(tmpdir, tree, 'bzp2')
+
+
+def test_recompression(tmpdir):
+    tree = _get_large_tree()
+    tmpfile = os.path.join(str(tmpdir), 'test1.asdf')
+    afile = asdf.AsdfFile(tree)
+    afile.write_to(tmpfile, all_array_compression='zlib')
+    afile.close()
+    afile = asdf.AsdfFile.open(tmpfile)
+    tmpfile = os.path.join(str(tmpdir), 'test2.asdf')
+    afile.write_to(tmpfile, all_array_compression='bzp2')
+    afile.close()
+    afile = asdf.AsdfFile.open(tmpfile)
+    helpers.assert_tree_match(tree, afile.tree)
+    afile.close()
+
+
+def test_input(tmpdir):
+    tree = _get_large_tree()
+    tmpfile = os.path.join(str(tmpdir), 'test1.asdf')
+    afile = asdf.AsdfFile(tree)
+    afile.write_to(tmpfile, all_array_compression='zlib')
+    afile.close()
+    afile = asdf.AsdfFile.open(tmpfile)
+    tmpfile = os.path.join(str(tmpdir), 'test2.asdf')
+    afile.write_to(tmpfile)
+    afile.close()
+    afile = asdf.AsdfFile.open(tmpfile)
+    helpers.assert_tree_match(tree, afile.tree)
+    assert afile.get_array_compression(afile.tree['science_data']) == 'zlib'
+    afile.close()
+
+
+def test_none(tmpdir):
+    tree = _get_large_tree()
+    tmpfile1 = os.path.join(str(tmpdir), 'test1.asdf')
+    afile = asdf.AsdfFile(tree)
+    afile.write_to(tmpfile1)
+    afile.close()
+    afile = asdf.AsdfFile.open(tmpfile1)
+    assert afile.get_array_compression(afile.tree['science_data']) is None
+    tmpfile2 = os.path.join(str(tmpdir), 'test2.asdf')
+    afile.write_to(tmpfile2, all_array_compression='zlib')
+    assert afile.get_array_compression(afile.tree['science_data']) == 'zlib'
+    afile.close()
+    afile = asdf.AsdfFile.open(tmpfile2)
+    afile.write_to(tmpfile1, all_array_compression=None)
+    afile.close()
+    afile = asdf.AsdfFile.open(tmpfile1)
+    helpers.assert_tree_match(tree, afile.tree)
+    assert afile.get_array_compression(afile.tree['science_data']) is None
+    afile.close()

--- a/docs/sphinxext/example.py
+++ b/docs/sphinxext/example.py
@@ -109,8 +109,8 @@ class AsdfDirective(Directive):
                             human_flags.append(val)
                     if len(human_flags):
                         lines.append('    flags: {0}'.format(' | '.join(human_flags)))
-                    if block.compression:
-                        lines.append('    compression: {0}'.format(block.compression))
+                    if block.input_compression:
+                        lines.append('    compression: {0}'.format(block.input_compression))
                     lines.append('    allocated_size: {0}'.format(allocated))
                     lines.append('    used_size: {0}'.format(size))
                     lines.append('    data_size: {0}'.format(data_size))


### PR DESCRIPTION
See test_recompression() in asdf/tests/test_compression.py

So we should distinguish the input compression type from the output one. Otherwise, loading a file with zlib-ed arrays and saving it with bzip2-ed arrays fails, as the compression is overridden.

This involves careful observation of every `Block.compression` usage and deciding if it should be "input" or "output". Besides, i removed the ambiguous property `is_compressed`. So yeah, this breaks the public API.

Another notice is that opening a zlib file and saving it with `write_to` without specifying `all_array_compression` changed it's behavior. Before: file is saved with the same output compression codec as the input one. After: file is saved without any compression.