### PR TITLE
Add lz4 compression type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.11
         - ASTROPY_VERSION=development
-        - CONDA_DEPENDENCIES='jsonschema pyyaml six'
+        - CONDA_DEPENDENCIES='jsonschema pyyaml six lz4'
         - PIP_DEPENDENCIES_FLAGS='--no-deps --force'
         - PIP_DEPENDENCIES='git+http://github.com/spacetelescope/gwcs.git#egg=gwcs'
         - SETUP_CMD='test --remote-data'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
       MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       ASTROPY_VERSION: "development"
-      CONDA_DEPENDENCIES: "jsonschema pyyaml six"
+      CONDA_DEPENDENCIES: "jsonschema pyyaml six lz4"
       PIP_DEPENDENCIES: "git+http://github.com/spacetelescope/gwcs.git#egg=gwcs"
 
   matrix:

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -353,6 +353,8 @@ class AsdfFile(versioning.VersionedMixin):
 
             - ``bzp2``: Use bzip2 compression
 
+            - ``lz4``: Use lz4 compression
+
             - ``''`` or `None`: no compression
         """
         self.blocks[arr].compression = compression
@@ -668,6 +670,8 @@ class AsdfFile(versioning.VersionedMixin):
 
             - ``bzp2``: Use bzip2 compression.
 
+            - ``lz4``: Use lz4 compression.
+
         auto_inline : int, optional
             When the number of elements in an array is less than this
             threshold, store the array as inline YAML, rather than a
@@ -801,6 +805,8 @@ class AsdfFile(versioning.VersionedMixin):
             - ``zlib``: Use zlib compression.
 
             - ``bzp2``: Use bzip2 compression.
+
+            - ``lz4``: Use lz4 compression.
 
         auto_inline : int, optional
             When the number of elements in an array is less than this

--- a/asdf/commands/defragment.py
+++ b/asdf/commands/defragment.py
@@ -35,8 +35,8 @@ class Defragment(Command):
             the output file.""")
         parser.add_argument(
             "--compress", "-c", type=str, nargs="?",
-            choices=['zlib', 'bzp2'],
-            help="""Compress blocks using one of "zlib" or "bzp2".""")
+            choices=['zlib', 'bzp2', 'lz4'],
+            help="""Compress blocks using one of "zlib", "bzp2" or "lz4".""")
 
         parser.set_defaults(func=cls.run)
 

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -2,10 +2,14 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, unicode_literals, print_function
+import struct
 
 import numpy as np
 
 import six
+
+
+DEFAULT_BLOCK_SIZE = 1 << 22  #: Decompressed block size in bytes, 4MiB
 
 
 def validate(compression):
@@ -14,7 +18,7 @@ def validate(compression):
 
     Parameters
     ----------
-    compression : str or None
+    compression : str, bytes or None
 
     Returns
     -------
@@ -34,11 +38,55 @@ def validate(compression):
     if isinstance(compression, bytes):
         compression = compression.decode('ascii')
 
-    if compression not in ('zlib', 'bzp2'):
+    compression = compression.strip('\0')
+
+    if compression not in ('zlib', 'bzp2', 'lz4'):
         raise ValueError(
-            "Supported compression types are: 'zlib' and 'bzp2'")
+            "Supported compression types are: 'zlib', 'bzp2' and 'lz4', got %s"
+            % compression)
 
     return compression
+
+
+class Lz4Compressor(object):
+    def __init__(self, block_api):
+        self._api = block_api
+
+    def compress(self, data):
+        output = self._api.compress(data, mode='high_compression')
+        header = struct.pack('!I', len(output))
+        return header + output
+
+
+class Lz4Decompressor(object):
+    def __init__(self, block_api):
+        self._api = block_api
+        self._size = 0
+        self._pos = 0
+        self._buffer = b''
+
+    def decompress(self, data):
+        if not self._size:
+            data = self._buffer + data
+            if len(data) < 4:
+                self._buffer += data
+                return b''
+            self._size = struct.unpack('!I', data[:4])[0]
+            data = data[4:]
+            self._buffer = bytearray(self._size)
+        if self._pos + len(data) < self._size:
+            self._buffer[self._pos:self._pos + len(data)] = data
+            self._pos += len(data)
+            return b''
+        else:
+            offset = self._size - self._pos
+            self._buffer[self._pos:] = data[:offset]
+            data = data[offset:]
+            self._size = 0
+            self._pos = 0
+            output = self._api.decompress(self._buffer)
+            self._buffer = b''
+            return output + self.decompress(data)
 
 
 def _get_decoder(compression):
@@ -60,6 +108,15 @@ def _get_decoder(compression):
                 "therefore the compressed block in this ASDF file "
                 "can not be decompressed.")
         return bz2.BZ2Decompressor()
+    elif compression == 'lz4':
+        try:
+            import lz4.block
+        except ImportError:
+            raise ImportError(
+                "lz4 library in not installed in your Python environment, "
+                "therefore the compressed block in this ASDF file "
+                "can not be decompressed.")
+        return Lz4Decompressor(lz4.block)
     else:
         raise ValueError(
             "Unknown compression type: '{0}'".format(compression))
@@ -84,6 +141,15 @@ def _get_encoder(compression):
                 "therefore the compressed block in this ASDF file "
                 "can not be decompressed.")
         return bz2.BZ2Compressor()
+    elif compression == 'lz4':
+        try:
+            import lz4.block
+        except ImportError:
+            raise ImportError(
+                "lz4 library in not installed in your Python environment, "
+                "therefore the block in this ASDF file "
+                "can not be compressed.")
+        return Lz4Compressor(lz4.block)
     else:
         raise ValueError(
             "Unknown compression type: '{0}'".format(compression))
@@ -150,7 +216,7 @@ def decompress(fd, used_size, data_size, compression):
     return buffer
 
 
-def compress(fd, data, compression, block_size=1 << 16):
+def compress(fd, data, compression, block_size=DEFAULT_BLOCK_SIZE):
     """
     Compress array data and write to a file.
 
@@ -160,23 +226,30 @@ def compress(fd, data, compression, block_size=1 << 16):
         The file to write to.
 
     data : buffer
-        The buffer of uncompressed data
+        The buffer of uncompressed data.
 
     compression : str
         The type of compression to use.
 
     block_size : int, optional
-        The size of blocks (in raw data) to process at a time.
+        The size of blocks (in bytes) to process at a time.
     """
     compression = validate(compression)
     encoder = _get_encoder(compression)
 
+    # We can have numpy arrays here. While compress() will work with them,
+    # it is impossible to split them into fixed size blocks without converting
+    # them to bytes.
+    if isinstance(data, np.ndarray):
+        data = data.tobytes()
+
     for i in range(0, len(data), block_size):
         fd.write(encoder.compress(data[i:i+block_size]))
-    fd.write(encoder.flush())
+    if hasattr(encoder, "flush"):
+        fd.write(encoder.flush())
 
 
-def get_compressed_size(data, compression, block_size=1 << 16):
+def get_compressed_size(data, compression, block_size=DEFAULT_BLOCK_SIZE):
     """
     Returns the number of bytes required when the given data is
     compressed.
@@ -198,6 +271,7 @@ def get_compressed_size(data, compression, block_size=1 << 16):
     l = 0
     for i in range(0, len(data), block_size):
         l += len(encoder.compress(data[i:i+block_size]))
-    l += len(encoder.flush())
+    if hasattr(encoder, "flush"):
+        l += len(encoder.flush())
 
     return l

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -223,3 +223,17 @@ def get_file_sizes(dirname):
         if os.path.isfile(path):
             files[filename] = os.stat(path).st_size
     return files
+
+
+def has_package(name):
+    """
+    Determine if a specific package is installed.
+
+    :param name: Name of the package.
+    :return: True if it is installed, otherwise, False.
+    """
+    try:
+        __import__(name)
+        return True
+    except ImportError:
+        return False

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -223,17 +223,3 @@ def get_file_sizes(dirname):
         if os.path.isfile(path):
             files[filename] = os.stat(path).st_size
     return files
-
-
-def has_package(name):
-    """
-    Determine if a specific package is installed.
-
-    :param name: Name of the package.
-    :return: True if it is installed, otherwise, False.
-    """
-    try:
-        __import__(name)
-        return True
-    except ImportError:
-        return False

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -92,8 +92,8 @@ def test_bzp2(tmpdir):
     _roundtrip(tmpdir, tree, 'bzp2')
 
 
-@pytest.mark.skipif(not helpers.has_package('lz4'), reason='lz4 is not installed')
 def test_lz4(tmpdir):
+    pytest.importorskip('lz4')
     tree = _get_large_tree()
 
     _roundtrip(tmpdir, tree, 'lz4')

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -90,3 +90,10 @@ def test_bzp2(tmpdir):
     tree = _get_large_tree()
 
     _roundtrip(tmpdir, tree, 'bzp2')
+
+
+@pytest.mark.skipif(not helpers.has_package('lz4'), reason='lz4 is not installed')
+def test_lz4(tmpdir):
+    tree = _get_large_tree()
+
+    _roundtrip(tmpdir, tree, 'lz4')

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,10 @@ entry_points['console_scripts'] = [
     'asdftool = asdf.commands.main:main',
 ]
 
+# Add the dependencies which are not strictly needed but enable otherwise skipped tests
+extra_requires = []
+if os.getenv('CI'):
+    extra_requires.extend(['lz4>=0.10'])
 
 # Note that requires and provides should not be included in the call to
 # ``setup``, since these are now deprecated. See this link for more details:
@@ -119,8 +123,8 @@ setup(name=PACKAGENAME,
           'jsonschema>=2.3.0',
           'six>=1.9.0',
           'pytest>=2.7.2',
-          'numpy>=1.8'
-      ],
+          'numpy>=1.8',
+      ] + extra_requires,
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,


### PR DESCRIPTION
Fixes #254

Using [python-lz4](https://github.com/python-lz4/python-lz4) here. I had to implement the custom stream wrapper as we read the file in blocks of fixed, small size and need to accumulate them. Unfortunately, `lz4` does not contain the stream implementation yet.

Additional notes:

* The default block size is in bytes now, not in numpy array rows (wtf? I guess it was a bug), and I set it to 4 MiB. Does not change anything for zlib and bzip2 (we use streams), but improves the efficiency of lz4.
* I increased the data size in test_defragment(), otherwise bzip2 does not pass - likely because of the headr overhead.
* I allowed compression objects to miss the `flush()` method.