### PR TITLE
Remove unused parameter from asdf.open

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -486,23 +486,22 @@ class AsdfFile(versioning.VersionedMixin):
     def _open_impl(cls, self, fd, uri=None, mode='r',
                    validate_checksums=False,
                    do_not_fill_defaults=False,
-                   _get_yaml_content=False,
-                  accept_asdf_in_fits=True):
+                   _get_yaml_content=False):
         """Attempt to open file-like object as either AsdfFile or AsdfInFits"""
         if not is_asdf_file(fd):
-            msg = "Input object does not appear to be ASDF file"
-            if accept_asdf_in_fits:
-                try:
-                    # TODO: this feels a bit circular, try to clean up. Also
-                    # this introduces another dependency on astropy which may
-                    # not be desireable.
-                    from . import fits_embed
-                    return fits_embed.AsdfInFits.open(fd, uri=uri,
-                                validate_checksums=validate_checksums,
-                                extensions=self._extensions)
-                except ValueError:
-                    msg += " or FITS with an ASDF extension"
-            raise ValueError(msg)
+            try:
+                # TODO: this feels a bit circular, try to clean up. Also
+                # this introduces another dependency on astropy which may
+                # not be desireable.
+                from . import fits_embed
+                return fits_embed.AsdfInFits.open(fd, uri=uri,
+                            validate_checksums=validate_checksums,
+                            extensions=self._extensions)
+            except ValueError:
+                pass
+            raise ValueError(
+                "Input object does not appear to be ASDF file or FITS with " +
+                "ASDF extension")
         return cls._open_asdf(self, fd, uri=uri, mode=mode,
                 validate_checksums=validate_checksums,
                 do_not_fill_defaults=do_not_fill_defaults,
@@ -512,8 +511,7 @@ class AsdfFile(versioning.VersionedMixin):
     def open(cls, fd, uri=None, mode='r',
              validate_checksums=False,
              extensions=None,
-             do_not_fill_defaults=False,
-             accept_asdf_in_fits=True):
+             do_not_fill_defaults=False):
         """
         Open an existing ASDF file.
 
@@ -543,11 +541,6 @@ class AsdfFile(versioning.VersionedMixin):
         do_not_fill_defaults : bool, optional
             When `True`, do not fill in missing default values.
 
-        accept_asdf_in_fits : bool, optional
-            When `True`, try to automatically process FITS files with ASDF
-            extensions. If backwards compatibility with old behavior is
-            required, set this flag to `False`.
-
         Returns
         -------
         asdffile : AsdfFile
@@ -558,8 +551,7 @@ class AsdfFile(versioning.VersionedMixin):
         return cls._open_impl(
             self, fd, uri=uri, mode=mode,
             validate_checksums=validate_checksums,
-            do_not_fill_defaults=do_not_fill_defaults,
-            accept_asdf_in_fits=accept_asdf_in_fits)
+            do_not_fill_defaults=do_not_fill_defaults)
 
     def _write_tree(self, tree, fd, pad_blocks):
         fd.write(constants.ASDF_MAGIC)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -224,26 +224,9 @@ def test_asdf_open(tmpdir):
 def test_bad_input(tmpdir):
     """Make sure these functions behave properly with bad input"""
     text_file = os.path.join(str(tmpdir), 'test.txt')
-    fits_file = os.path.join(str(tmpdir), 'test.fits')
-    asdf_in_fits = create_asdf_in_fits()
-    asdf_in_fits.write_to(fits_file)
 
     with open(text_file, 'w') as fh:
         fh.write('I <3 ASDF!!!!!')
 
     with pytest.raises(ValueError):
         asdf_open(text_file)
-
-    with pytest.raises(ValueError):
-        asdf_open(text_file, accept_asdf_in_fits=False)
-
-    with pytest.raises(ValueError):
-        asdf_open(fits_file, accept_asdf_in_fits=False)
-
-    with pytest.raises(ValueError):
-        with open(fits_file, 'rb') as handle:
-            asdf_open(handle, accept_asdf_in_fits=False)
-
-    with pytest.raises(ValueError):
-        with fits.open(fits_file) as hdulist:
-            asdf_open(hdulist, accept_asdf_in_fits=False)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -5,22 +5,16 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import copy
 import os
-
-try:
-    import astropy
-except ImportError:
-    HAS_ASTROPY = False
-else:
-    HAS_ASTROPY = True
-    from astropy.io import fits
-    from .. import fits_embed
+import pytest
 
 import numpy as np
 from numpy.testing import assert_array_equal
 
-import pytest
+astropy = pytest.importorskip('astropy')
+from astropy.io import fits
 
 from .. import asdf
+from .. import fits_embed
 from .. import open as asdf_open
 from .helpers import assert_tree_match
 
@@ -51,7 +45,6 @@ def create_asdf_in_fits():
 
     return fits_embed.AsdfInFits(hdulist, tree)
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_embed_asdf_in_fits_file(tmpdir):
     hdulist = fits.HDUList()
     hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='SCI'))
@@ -92,7 +85,6 @@ def test_embed_asdf_in_fits_file(tmpdir):
         assert_tree_match(tree, ff.tree)
 
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
     # Write the AsdfInFits object out as a FITS file with ASDF extension
     asdf_in_fits = create_asdf_in_fits()
@@ -116,7 +108,6 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
         assert_tree_match(asdf_in_fits.tree, ff.tree)
 
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_create_in_tree_first(tmpdir):
     tree = {
         'model': {
@@ -166,7 +157,6 @@ def compare_asdfs(asdf0, asdf1):
             asdf0.tree['model'][key]['data'],
             asdf1.tree['model'][key]['data'])
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_asdf_in_fits_open(tmpdir):
     """Test the open method of AsdfInFits"""
     tmpfile = os.path.join(str(tmpdir), 'test.fits')
@@ -193,7 +183,6 @@ def test_asdf_in_fits_open(tmpdir):
         with fits_embed.AsdfInFits.open(hdulist) as ff:
             compare_asdfs(asdf_in_fits, ff)
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_asdf_open(tmpdir):
     """Test the top-level open method of the asdf module"""
     tmpfile = os.path.join(str(tmpdir), 'test.fits')
@@ -220,7 +209,6 @@ def test_asdf_open(tmpdir):
         with asdf_open(hdulist) as ff:
             compare_asdfs(asdf_in_fits, ff)
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_bad_input(tmpdir):
     """Make sure these functions behave properly with bad input"""
     text_file = os.path.join(str(tmpdir), 'test.txt')

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -1084,3 +1084,18 @@ foo : bar
     with pytest.raises(ValueError):
         with asdf.AsdfFile.open(buff) as ff:
             pass
+
+def test_valid_version(tmpdir):
+    content = b"""#ASDF 1.0.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-0.1.0
+foo : bar
+..."""
+    buff = io.BytesIO(content)
+    with asdf.AsdfFile.open(buff) as ff:
+        version = ff.file_format_version
+
+    assert version['major'] == 1
+    assert version['minor'] == 0
+    assert version['patch'] == 0


### PR DESCRIPTION
Addresses issue #264. The `accept_asdf_in_fits` parameter was provided for backwards compatibility with older behavior. However it is no longer needed by the only client that ever used it, which was the jwst pipeline.