### PR TITLE
WIP: Schema backwards compatibility

### DIFF
--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -35,7 +35,7 @@ if _ASDF_SETUP_ is False:
         raise ImportError("asdf requires numpy")
 
     from .asdf import AsdfFile
-    from .asdftypes import AsdfType
+    from .asdftypes import UserType
     from .extension import AsdfExtension
     from .stream import Stream
     from . import commands

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -15,7 +15,7 @@ from ._internal_init import *
 # ----------------------------------------------------------------------------
 
 if _ASDF_SETUP_ is False:
-    __all__ = ['AsdfFile', 'UserType', 'AsdfExtension',
+    __all__ = ['AsdfFile', 'CustomType', 'AsdfExtension',
                'Stream', 'open', 'test', 'commands',
                'ValidationError']
 
@@ -35,7 +35,7 @@ if _ASDF_SETUP_ is False:
         raise ImportError("asdf requires numpy")
 
     from .asdf import AsdfFile
-    from .asdftypes import UserType
+    from .asdftypes import CustomType
     from .extension import AsdfExtension
     from .stream import Stream
     from . import commands

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -15,7 +15,7 @@ from ._internal_init import *
 # ----------------------------------------------------------------------------
 
 if _ASDF_SETUP_ is False:
-    __all__ = ['AsdfFile', 'AsdfType', 'AsdfExtension',
+    __all__ = ['AsdfFile', 'UserType', 'AsdfExtension',
                'Stream', 'open', 'test', 'commands',
                'ValidationError']
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -448,7 +448,6 @@ class AsdfFile(versioning.VersionedMixin):
             self.version = version
 
         yaml_token = fd.read(4)
-        yaml_content = b''
         tree = {}
         has_blocks = False
         if yaml_token == b'%YAM':
@@ -456,8 +455,11 @@ class AsdfFile(versioning.VersionedMixin):
                 constants.YAML_END_MARKER_REGEX, 7, 'End of YAML marker',
                 include=True, initial_content=yaml_token)
 
+            # For testing: just return the raw YAML content
             if _get_yaml_content:
                 yaml_content = reader.read()
+                fd.close()
+                return yaml_content
             else:
                 # We parse the YAML content into basic data structures
                 # now, but we don't do anything special with it until
@@ -468,11 +470,6 @@ class AsdfFile(versioning.VersionedMixin):
             has_blocks = True
         elif yaml_token != b'':
             raise IOError("ASDF file appears to contain garbage after header.")
-
-        # For testing: just return the raw YAML content
-        if _get_yaml_content:
-            fd.close()
-            return yaml_content
 
         if has_blocks:
             self._blocks.read_internal_blocks(

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -391,16 +391,13 @@ class ExtensionTypeMeta(type):
                 raise TypeError("name must be string or list")
 
         if hasattr(cls, 'supported_versions'):
-            if isinstance(cls.supported_versions, six.string_types):
-                cls.supported_versions = set(cls.supported_versions)
-            elif isinstance(cls.supported_versions, tuple):
-                cls.supported_versions = \
-                    set(version_to_string(cls.supported_versions))
-            elif isinstance(cls.supported_versions, (list, set)):
-                supported_versions = set()
-                for ver in cls.supported_versions:
-                    supported_versions.add(version_to_string(ver))
-                cls.supported_versions = supported_versions
+            if not isinstance(cls.supported_versions, (list, set)):
+                raise TypeError(
+                    "supported_versions attribute must be list or set")
+            supported_versions = set()
+            for ver in cls.supported_versions:
+                supported_versions.add(version_to_string(ver))
+            cls.supported_versions = supported_versions
 
         return cls
 

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -390,6 +390,18 @@ class ExtensionTypeMeta(type):
             elif cls.name is not None:
                 raise TypeError("name must be string or list")
 
+        if hasattr(cls, 'supported_versions'):
+            if isinstance(cls.supported_versions, six.string_types):
+                cls.supported_versions = set(cls.supported_versions)
+            elif isinstance(cls.supported_versions, tuple):
+                cls.supported_versions = \
+                    set(version_to_string(cls.supported_versions))
+            elif isinstance(cls.supported_versions, (list, set)):
+                supported_versions = set()
+                for ver in cls.supported_versions:
+                    supported_versions.add(version_to_string(ver))
+                cls.supported_versions = supported_versions
+
         return cls
 
 
@@ -452,6 +464,7 @@ class ExtensionType(object):
     organization = 'stsci.edu'
     standard = 'asdf'
     version = (1, 0, 0)
+    supported_versions = set()
     types = []
     handle_dynamic_subclasses = False
     validators = {}
@@ -508,7 +521,9 @@ class ExtensionType(object):
         Indicates whether this tag class knows how to convert the given version
         of the associated schema.
         """
-        # WIP: this will be updated in the near future
+        if cls.supported_versions:
+            if version_to_string(version) not in cls.supported_versions:
+                return False
         return True
 
 

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -257,10 +257,7 @@ class AsdfTypeIndex(object):
                     name,
                     semver.format_version(*version),
                     semver.format_version(*best_version))
-            if version[:2] < best_version[:2]:
-                raise ValueError(warning_string)
-            else:
-                warnings.warn(warning_string)
+            warnings.warn(warning_string)
 
         best_tag = join_tag_version(name, best_version)
         self._best_matches[tag] = best_tag, warning_string

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -448,6 +448,11 @@ class ExtensionType(object):
     version : 3-tuple of int
         The version of the standard the type is defined in.
 
+    supported_versions : set
+        If provided, indicates explicit compatibility with the given set of
+        versions. Other versions of the same schema that are not included in
+        this set will not be converted to custom types with this class.
+
     yaml_tag : str
         The YAML tag to use for the type.  If not provided, it will be
         automatically generated from name, organization, standard and

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -527,15 +527,19 @@ class ExtensionType(object):
         return cls.from_tree(tree.data, ctx)
 
     @classmethod
-    def version_is_supported(cls, version):
+    def incompatible_version(cls, version):
         """
-        Indicates whether this tag class knows how to convert the given version
-        of the associated schema.
+        If this tag class explicitly identifies compatible versions then this
+        checks whether a given version is compatible or not. Otherwise, all
+        versions are assumed to be compatible.
+
+        Child classes can override this method to affect how version
+        compatiblity for this type is determined.
         """
         if cls.supported_versions:
             if version_to_string(version) not in cls.supported_versions:
-                return False
-        return True
+                return True
+        return False
 
 
 @six.add_metaclass(AsdfTypeMeta)

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -160,6 +160,7 @@ class AsdfTypeIndex(object):
         self._type_by_tag = {}
         self._versions_by_type_name = {}
         self._best_matches = {}
+        self._real_tag = {}
         self._unnamed_types = set()
         self._hooks_by_type = {}
         self._all_types = set()
@@ -245,7 +246,6 @@ class AsdfTypeIndex(object):
 
         # The versions list is kept sorted, so bisect can be used to
         # quickly find the best option.
-
         i = bisect.bisect_left(versions, version)
         i = max(0, i - 1)
 
@@ -261,7 +261,16 @@ class AsdfTypeIndex(object):
 
         best_tag = join_tag_version(name, best_version)
         self._best_matches[tag] = best_tag, warning_string
+        if tag != best_tag:
+            self._real_tag[best_tag] = tag
         return best_tag
+
+    def get_real_tag(self, tag):
+        if tag in self._real_tag:
+            return self._real_tag[tag]
+        elif tag in self._type_by_tag:
+            return tag
+        return None
 
     def from_yaml_tag(self, tag):
         """

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -16,7 +16,7 @@ from .extern import semver
 
 from . import tagged
 from . import util
-from . import versioning
+from .versioning import get_version_map, version_to_string
 
 
 __all__ = ['format_tag', 'AsdfTypeIndex', 'AsdfType']
@@ -51,7 +51,7 @@ def join_tag_version(name, version):
     """
     Join the root and version of a tag back together.
     """
-    return '{0}-{1}'.format(name, versioning.version_to_string(version))
+    return '{0}-{1}'.format(name, version_to_string(version))
 
 
 class _AsdfWriteTypeIndex(object):
@@ -106,7 +106,7 @@ class _AsdfWriteTypeIndex(object):
                 add_by_tag(name, version)
         else:
             try:
-                version_map = versioning.get_version_map(version)
+                version_map = get_version_map(version)
             except ValueError:
                 raise ValueError(
                     "Don't know how to write out ASDF version {0}".format(
@@ -455,7 +455,7 @@ class AsdfType(object):
         return format_tag(
             cls.organization,
             cls.standard,
-            versioning.version_to_string(cls.version),
+            version_to_string(cls.version),
             name)
 
     @classmethod
@@ -493,3 +493,12 @@ class AsdfType(object):
         with the tag directly.
         """
         return cls.from_tree(tree.data, ctx)
+
+    @classmethod
+    def version_is_supported(cls, version):
+        """
+        Indicates whether this tag class knows how to convert the given version
+        of the associated schema.
+        """
+        # WIP: this will be updated in the near future
+        return True

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -559,7 +559,7 @@ class AsdfType(ExtensionType):
 
 @six.add_metaclass(ExtensionTypeMeta)
 @six.add_metaclass(util.InheritDocstrings)
-class UserType(ExtensionType):
+class CustomType(ExtensionType):
     """
     Base class for all user-defined types. Unlike classes that inherit
     AsdfType, classes that inherit this class will *not* automatically be added

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -225,6 +225,8 @@ class AsdfTypeIndex(object):
         Raises a warning if it could not find a match where the major
         and minor numbers are the same.
         """
+        warning_string = None
+
         if tag in self._type_by_tag:
             return tag
 
@@ -248,20 +250,17 @@ class AsdfTypeIndex(object):
         i = max(0, i - 1)
 
         best_version = versions[i]
-        if best_version[:2] == version[:2]:
-            # Major and minor match, so only patch and devel differs
-            # -- no need for alarm
-            warning_string = None
-        else:
-            warning_string = (
-                "'{0}' with version {1} found in file, but asdf only "
-                "understands version {2}.".format(
+        if best_version[:2] != version[:2]:
+            warning_string = \
+                "'{}' with version {} found in file, but asdf only supports " \
+                "version {}".format(
                     name,
                     semver.format_version(*version),
-                    semver.format_version(*best_version)))
-
-        if warning_string:
-            warnings.warn(warning_string)
+                    semver.format_version(*best_version))
+            if version[:2] < best_version[:2]:
+                raise ValueError(warning_string)
+            else:
+                warnings.warn(warning_string)
 
         best_tag = join_tag_version(name, best_version)
         self._best_matches[tag] = best_tag, warning_string

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -415,6 +415,15 @@ class AsdfTypeMeta(ExtensionTypeMeta):
         # Classes using this metaclass get added to the list of built-in
         # extensions
         _all_asdftypes.add(cls)
+        if hasattr(cls, 'supported_versions'):
+            # Each supported version has a corresponding class tagged at that
+            # version added to the list of built-in ASDF types.
+            for version in cls.supported_versions:
+                if version != version_to_string(cls.version):
+                    attrs['version'] = version
+                    new_cls = super(AsdfTypeMeta, mcls).__new__(
+                        mcls, name, bases, attrs)
+                    _all_asdftypes.add(new_cls)
         return cls
 
 

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -120,6 +120,9 @@ class AsdfExtensionList(object):
             for typ in extension.types:
                 self._type_index.add_type(typ)
                 validators.update(typ.validators)
+                for sibling in typ.versioned_siblings:
+                    self._type_index.add_type(sibling)
+                    validators.update(sibling.validators)
         self._tag_mapping = resolver.Resolver(tag_mapping, 'tag')
         self._url_mapping = resolver.Resolver(url_mapping, 'url')
         self._validators = validators

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -127,3 +127,29 @@ def test_frames(tmpdir):
     }
 
     helpers.assert_roundtrip_tree(tree, tmpdir)
+
+@pytest.mark.xfail()
+def test_backwards_compatibility(tmpdir):
+    yaml = """
+wcs/celestial_frame-1.1.0
+  axes_names: [x, y, z]
+  axes_order: [0, 1, 2]
+  name: CelestialFrame
+  reference_frame:
+    galcen_dec: !unit/quantity-1.1.0
+      unit: rad
+      value: 1.0
+    galcen_distance: !unit/quantity-1.1.0
+      unit: m
+      value: 5.0
+    galcen_ra: !unit/quantity-1.1.0
+      unit: deg
+      value: 45.0
+    roll: !unit/quantity-1.1.0
+      unit: deg
+      value: 3.0
+    type: galactocentric
+    z_sun: !unit/quantity-1.1.0
+      unit: pc
+      value: 3.0
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]"""

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -131,7 +131,6 @@ def test_frames(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
-@pytest.mark.xfail(reason="Requires updates to schema version compatibility")
 def test_backwards_compat_galcen():
     # Hold these fields constant so that we can compare them
     declination = 1.0208        # in degrees
@@ -211,7 +210,6 @@ frames:
     assert old_refframe.galcen_coord.ra == new_refframe.galcen_coord.ra
 
 
-@pytest.mark.xfail(reason="Requires updates to schema version compatibility")
 def test_backwards_compat_gcrs():
     obsgeoloc = (
         3.0856775814671916e+16,

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -131,6 +131,7 @@ def test_frames(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.xfail(reason="Requires updates to schema version compatibility")
 def test_backwards_compat_galcen():
     # Hold these fields constant so that we can compare them
     declination = 1.0208        # in degrees
@@ -209,6 +210,8 @@ frames:
     assert old_refframe.galcen_coord.dec == new_refframe.galcen_coord.dec
     assert old_refframe.galcen_coord.ra == new_refframe.galcen_coord.ra
 
+
+@pytest.mark.xfail(reason="Requires updates to schema version compatibility")
 def test_backwards_compat_gcrs():
     obsgeoloc = (
         3.0856775814671916e+16,

--- a/asdf/tags/wcs/wcs.py
+++ b/asdf/tags/wcs/wcs.py
@@ -263,24 +263,10 @@ class FrameType(AsdfType):
     def to_tree(cls, frame, ctx):
         return cls._to_tree(frame, ctx)
 
-class OldCelestialFrameType(FrameType):
-    version = (1, 0, 0)
-    name = "wcs/celestial_frame"
-    types = ['gwcs.CelestialFrame']
-
-    @classmethod
-    def from_tree(cls, node, ctx):
-        import gwcs
-        node = cls._from_tree(node, ctx)
-        return gwcs.CelestialFrame(**node)
-
-    @classmethod
-    def to_tree(cls, frame, ctx):
-        return cls._to_tree(frame, ctx)
-
 class CelestialFrameType(FrameType):
     name = "wcs/celestial_frame"
     types = ['gwcs.CelestialFrame']
+    supported_versions = [(1,0,0), (1,1,0)]
 
     @classmethod
     def from_tree(cls, node, ctx):

--- a/asdf/tags/wcs/wcs.py
+++ b/asdf/tags/wcs/wcs.py
@@ -139,15 +139,17 @@ class FrameType(AsdfType):
                 # These fields are known to be CartesianRepresentations
                 if name in ['obsgeoloc', 'obsgeovel']:
                     if version == '1.0.0':
-                        x = Quantity(val[0][0], unit=val[0][1])
-                        y = Quantity(val[1][0], unit=val[1][1])
-                        z = Quantity(val[2][0], unit=val[2][1])
+                        unit = val[1]
+                        x = Quantity(val[0][0], unit=unit)
+                        y = Quantity(val[0][1], unit=unit)
+                        z = Quantity(val[0][2], unit=unit)
                     else:
                         x = QuantityType.from_tree(val[0], ctx)
                         y = QuantityType.from_tree(val[1], ctx)
                         z = QuantityType.from_tree(val[2], ctx)
                     val = CartesianRepresentation(x, y, z)
                 elif name == 'galcen_v_sun':
+                    # This field only exists since v1.1.0
                     d_x = QuantityType.from_tree(val[0], ctx)
                     d_y = QuantityType.from_tree(val[1], ctx)
                     d_z = QuantityType.from_tree(val[2], ctx)

--- a/asdf/tests/data/custom_flow-1.1.0.yaml
+++ b/asdf/tests/data/custom_flow-1.1.0.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://nowhere.org/schemas/custom/custom_flow-1.1.0"
+type: object
+properties:
+  c:
+    type: number
+  d:
+    type: number
+flowStyle: block

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -265,15 +265,12 @@ def test_newer_tag():
             self.c = c
             self.d = d
 
-    class CustomFlowType(object):
+    class CustomFlowType(asdftypes.UserType):
         version = '1.1.0'
         name = 'custom_flow'
         organization = 'nowhere.org'
         standard = 'custom'
         types = [CustomFlow]
-        yaml_tag = "tag:nowhere.org:custom/custom_flow-1.1.0"
-        handle_dynamic_subclasses = False
-        validators = {}
 
         @classmethod
         def from_tree(cls, tree, ctx):
@@ -285,15 +282,6 @@ def test_newer_tag():
         @classmethod
         def to_tree(cls, data, ctx):
             tree = {'c': data.c, 'd': data.d}
-
-        @classmethod
-        def from_tree_tagged(cls, tree, ctx):
-            """
-            Converts from basic types to a custom type.  Overriding this,
-            rather than the more common `from_tree`, allows types to deal
-            with the tag directly.
-            """
-            return cls.from_tree(tree.data, ctx)
 
         @classmethod
         def version_is_supported(cls, version):

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -324,7 +324,6 @@ flow_thing:
         "in file, but asdf only supports version 1.1.0")
 
 
-@pytest.mark.xfail(reason="Needs impl. of supported_versions for UserType")
 def test_supported_versions():
     from astropy.tests.helper import catch_warnings
     class CustomFlow(object):
@@ -391,11 +390,4 @@ flow_thing:
     old_buff = helpers.yaml_to_asdf(old_yaml)
     with catch_warnings() as w:
         old_data = asdf.AsdfFile.open(old_buff, extensions=CustomFlowExtension())
-    # TODO: this will fail until UserType is handled properly
     assert type(old_data.tree['flow_thing']) == CustomFlow
-
-    # TODO: should we actually expect this warning here?
-    assert len(w) == 1
-    assert str(w[0].message) == (
-        "'tag:nowhere.org:custom/custom_flow' with version 1.0.0 found "
-        "in file, but asdf only supports version 1.1.0")

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -293,15 +293,12 @@ def test_newer_tag():
             rather than the more common `from_tree`, allows types to deal
             with the tag directly.
             """
-            real_tag = ctx.type_index.get_real_tag(tree._tag)
-            _, version = asdftypes.split_tag_version(real_tag)
-
-            cls_version = versioning.version_to_string(cls.version)
-            tag_version = versioning.version_to_string(version)
-            if tag_version != cls_version:
-                raise TypeError(
-                    "Version {} of class not supported".format(tag_version))
             return cls.from_tree(tree.data, ctx)
+
+        @classmethod
+        def version_is_supported(cls, version):
+            version_to_string = versioning.version_to_string
+            return version_to_string(cls.version) == version_to_string(version)
 
     class CustomFlowExtension(object):
         @property

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -264,12 +264,15 @@ def test_newer_tag():
             self.c = c
             self.d = d
 
-    class CustomFlowType(asdftypes.AsdfType):
+    class CustomFlowType(object):
         version = '1.1.0'
         name = 'custom_flow'
         organization = 'nowhere.org'
         standard = 'custom'
         types = [CustomFlow]
+        yaml_tag = "tag:nowhere.org:custom/custom_flow-1.1.0"
+        handle_dynamic_subclasses = False
+        validators = {}
 
         @classmethod
         def from_tree(cls, tree, ctx):
@@ -281,6 +284,15 @@ def test_newer_tag():
         @classmethod
         def to_tree(cls, data, ctx):
             tree = {'c': data.c, 'd': data.d}
+
+        @classmethod
+        def from_tree_tagged(cls, tree, ctx):
+            """
+            Converts from basic types to a custom type.  Overriding this,
+            rather than the more common `from_tree`, allows types to deal
+            with the tag directly.
+            """
+            return cls.from_tree(tree.data, ctx)
 
     class CustomFlowExtension(object):
         @property

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -250,7 +250,6 @@ undefined_data:
     assert missing[3][1] == 3.14j
 
 
-@pytest.mark.xfail(reason="Requires implementation of schema version handling")
 def test_newer_tag():
     from astropy.tests.helper import catch_warnings
     # This test simulates a scenario where newer versions of CustomFlow

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -220,3 +220,28 @@ def test_module_versioning():
     assert nmt.has_required_modules == False
     assert hcp.has_required_modules == True
     assert dhcp.has_required_modules == False
+
+
+def test_undefined_tag():
+    from numpy import array
+
+    yaml = """
+undefined_data:
+  !<tag:nowhere.org:custom/undefined_tag-1.0.0>
+    - 5
+    - {'message': 'there is no tag'}
+    - !core/ndarray-1.0.0
+      [[1, 2, 3], [4, 5, 6]]
+    - !<tag:nowhere.org:custom/also_undefined-1.3.0>
+        - !core/ndarray-1.0.0 [[7],[8],[9],[10]]
+        - !core/complex-1.0.0 3.14j
+"""
+    buff = helpers.yaml_to_asdf(yaml)
+    afile = asdf.AsdfFile.open(buff)
+    missing = afile.tree['undefined_data']
+
+    assert missing[0] == 5
+    assert missing[1] == {'message': 'there is no tag'}
+    assert (missing[2] == array([[1, 2, 3], [4, 5, 6]])).all()
+    assert (missing[3][0] == array([[7],[8],[9],[10]])).all()
+    assert missing[3][1] == 3.14j

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -266,7 +266,6 @@ def test_newer_tag():
 
     class CustomFlowType(asdftypes.UserType):
         version = '1.1.0'
-        supported_versions = [version]
         name = 'custom_flow'
         organization = 'nowhere.org'
         standard = 'custom'

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -293,6 +293,14 @@ def test_newer_tag():
             rather than the more common `from_tree`, allows types to deal
             with the tag directly.
             """
+            real_tag = ctx.type_index.get_real_tag(tree._tag)
+            _, version = asdftypes.split_tag_version(real_tag)
+
+            cls_version = versioning.version_to_string(cls.version)
+            tag_version = versioning.version_to_string(version)
+            if tag_version != cls_version:
+                raise TypeError(
+                    "Version {} of class not supported".format(tag_version))
             return cls.from_tree(tree.data, ctx)
 
     class CustomFlowExtension(object):

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -267,6 +267,7 @@ def test_newer_tag():
 
     class CustomFlowType(asdftypes.UserType):
         version = '1.1.0'
+        supported_versions = [version]
         name = 'custom_flow'
         organization = 'nowhere.org'
         standard = 'custom'
@@ -282,11 +283,6 @@ def test_newer_tag():
         @classmethod
         def to_tree(cls, data, ctx):
             tree = {'c': data.c, 'd': data.d}
-
-        @classmethod
-        def version_is_supported(cls, version):
-            version_to_string = versioning.version_to_string
-            return version_to_string(cls.version) == version_to_string(version)
 
     class CustomFlowExtension(object):
         @property

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -264,7 +264,7 @@ def test_newer_tag():
             self.c = c
             self.d = d
 
-    class CustomFlowType(asdftypes.UserType):
+    class CustomFlowType(asdftypes.CustomType):
         version = '1.1.0'
         name = 'custom_flow'
         organization = 'nowhere.org'
@@ -331,7 +331,7 @@ def test_supported_versions():
             self.c = c
             self.d = d
 
-    class CustomFlowType(asdftypes.UserType):
+    class CustomFlowType(asdftypes.CustomType):
         version = '1.1.0'
         supported_versions = [(1,0,0), (1,1,0)]
         name = 'custom_flow'

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -103,7 +103,7 @@ a: !core/complex-42.0.0
     assert len(w) == 1
     assert str(w[0].message) == (
         "'tag:stsci.edu:asdf/core/complex' with version 42.0.0 found in file, "
-        "but asdf only understands version 1.0.0.")
+        "but asdf only supports version 1.0.0")
 
     # Make sure warning is repeatable
     buff.seek(0)
@@ -114,7 +114,7 @@ a: !core/complex-42.0.0
     assert len(w) == 1
     assert str(w[0].message) == (
         "'tag:stsci.edu:asdf/core/complex' with version 42.0.0 found in file, "
-        "but asdf only understands version 1.0.0.")
+        "but asdf only supports version 1.0.0")
 
     # If the major and minor match, there should be no warning.
     yaml = """

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -248,7 +248,10 @@ def tagged_tree_to_custom_tree(tree, ctx):
         if tag_name is not None:
             tag_type = ctx.type_index.from_yaml_tag(tag_name)
             if tag_type is not None:
-                return tag_type.from_tree_tagged(node, ctx)
+                try:
+                    return tag_type.from_tree_tagged(node, ctx)
+                except TypeError:
+                    pass
         return node
 
     return treeutil.walk_and_modify(tree, walker)

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -253,8 +253,17 @@ def tagged_tree_to_custom_tree(tree, ctx):
             if tag_type is not None:
                 real_tag = ctx.type_index.get_real_tag(tag_name)
                 _, real_tag_version = asdftypes.split_tag_version(real_tag)
-                if tag_type.version_is_supported(real_tag_version):
-                    return tag_type.from_tree_tagged(node, ctx)
+                if not tag_type.incompatible_version(real_tag_version):
+                    # If a tag class does not explicitly list compatible
+                    # versions, then all versions of the corresponding schema
+                    # are assumed to be compatible. Therefore we need to check
+                    # to make sure whether the conversion is actually
+                    # successful, and just return a raw Python data type if it
+                    # is not.
+                    try:
+                        return tag_type.from_tree_tagged(node, ctx)
+                    except TypeError:
+                        pass
         return node
 
     return treeutil.walk_and_modify(tree, walker)

--- a/docs/asdf/extensions.rst
+++ b/docs/asdf/extensions.rst
@@ -5,7 +5,7 @@ Supporting new types in asdf is easy.  There are three pieces needed:
 
 1. A YAML Schema file for each new type.
 
-2. A Python class (inheriting from `asdf.UserType`) for each new
+2. A Python class (inheriting from `asdf.CustomType`) for each new
    user-defined type.
 
 3. A Python class to define an "extension" to ASDF, which is a set of
@@ -33,7 +33,7 @@ First, the YAML Schema, defining the type as a pair of integers:
    maxItems: 2
    ...
 
-Then, the Python implementation.  See the `asdf.UserType` and
+Then, the Python implementation.  See the `asdf.CustomType` and
 `asdf.AsdfExtension` documentation for more information::
 
     import os
@@ -43,7 +43,7 @@ Then, the Python implementation.  See the `asdf.UserType` and
 
     import fractions
 
-    class FractionType(asdf.UserType):
+    class FractionType(asdf.CustomType):
         name = 'fraction'
         organization = 'nowhere.org'
         version = (1, 0, 0)
@@ -83,7 +83,7 @@ values in an ASDF file.  This feature is used internally so a schema
 can specify the required datatype of an array.
 
 To support custom validation keywords, set the ``validators`` member
-of a ``UserType`` subclass to a dictionary where the keys are the
+of a ``CustomType`` subclass to a dictionary where the keys are the
 validation keyword name and the values are validation functions.  The
 validation functions are of the same form as the validation functions
 in the underlying ``jsonschema`` library, and are passed the following

--- a/docs/asdf/extensions.rst
+++ b/docs/asdf/extensions.rst
@@ -5,8 +5,8 @@ Supporting new types in asdf is easy.  There are three pieces needed:
 
 1. A YAML Schema file for each new type.
 
-2. A Python class (inheriting from `asdf.AsdfType`) for each new
-   type.
+2. A Python class (inheriting from `asdf.UserType`) for each new
+   user-defined type.
 
 3. A Python class to define an "extension" to ASDF, which is a set of
    related types.  This class must implement the
@@ -33,7 +33,7 @@ First, the YAML Schema, defining the type as a pair of integers:
    maxItems: 2
    ...
 
-Then, the Python implementation.  See the `asdf.AsdfType` and
+Then, the Python implementation.  See the `asdf.UserType` and
 `asdf.AsdfExtension` documentation for more information::
 
     import os
@@ -43,7 +43,7 @@ Then, the Python implementation.  See the `asdf.AsdfType` and
 
     import fractions
 
-    class FractionType(asdf.AsdfType):
+    class FractionType(asdf.UserType):
         name = 'fraction'
         organization = 'nowhere.org'
         version = (1, 0, 0)
@@ -83,7 +83,7 @@ values in an ASDF file.  This feature is used internally so a schema
 can specify the required datatype of an array.
 
 To support custom validation keywords, set the ``validators`` member
-of an ``AsdfType`` subclass to a dictionary where the keys are the
+of a ``UserType`` subclass to a dictionary where the keys are the
 validation keyword name and the values are validation functions.  The
 validation functions are of the same form as the validation functions
 in the underlying ``jsonschema`` library, and are passed the following


### PR DESCRIPTION
As it stands, this is a fairly naive implementation of backwards compatibility for `CelestialFrame`s. More than anything it's meant to demonstrate how backwards compatibility might be implemented for future tag classes where it is actually required. It's also meant to expose functionality that needs to be added/modified in order to support backwards compatibility. I will continue to update this PR with improvements until it seems mature enough to merge.

This is an attempt to address issue #249, and also may be related to #252.