### PR TITLE
Issue warnings for unrecognized tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@
 - When possible, display name of ASDF file that caused version mismatch
   warning. [#306]
 
+- Issue a warning when an unrecognized tag is encountered. [#295]
 
 1.2.1(2016-11-07)
 -----------------

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -18,6 +18,7 @@ class HistoryEntry(dict, AsdfType):
     name = 'core/history_entry'
 
 
+from .constant import ConstantType
 from .ndarray import NDArrayType
 from .complex import ComplexType
 from .table import TableType, ColumnType

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -33,9 +33,8 @@ import jsonschema
 
 import yaml
 
-from ....tests import helpers
+from ....tests import helpers, CustomTestType
 from .... import asdf
-from ....asdftypes import CustomType
 from .... import util
 
 from .. import ndarray
@@ -47,13 +46,13 @@ TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 # These custom types and the custom extension are here purely for the purpose
 # of testing NDArray objects and making sure that they can be validated as part
 # of a nested hierarchy, and not just top-level objects.
-class CustomNdim(CustomType):
+class CustomNdim(CustomTestType):
     name = 'ndim'
     organization = 'nowhere.org'
     standard = 'custom'
     version = '1.0.0'
 
-class CustomDatatype(CustomType):
+class CustomDatatype(CustomTestType):
     name = 'datatype'
     organization = 'nowhere.org'
     standard = 'custom'

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -35,6 +35,7 @@ import yaml
 
 from ....tests import helpers
 from .... import asdf
+from ....asdftypes import CustomType
 from .... import util
 
 from .. import ndarray
@@ -43,10 +44,25 @@ from .. import ndarray
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 
 
-class CustomExtension:
+# These custom types and the custom extension are here purely for the purpose
+# of testing NDArray objects and making sure that they can be validated as part
+# of a nested hierarchy, and not just top-level objects.
+class CustomNdim(CustomType):
+    name = 'ndim'
+    organization = 'nowhere.org'
+    standard = 'custom'
+    version = '1.0.0'
+
+class CustomDatatype(CustomType):
+    name = 'datatype'
+    organization = 'nowhere.org'
+    standard = 'custom'
+    version = '1.0.0'
+
+class CustomExtension(object):
     @property
     def types(self):
-        return []
+        return [CustomNdim, CustomDatatype]
 
     @property
     def tag_mapping(self):

--- a/asdf/tags/transform/compound.py
+++ b/asdf/tags/transform/compound.py
@@ -132,7 +132,7 @@ class RemapAxesType(TransformType):
             else:
                 new_mapping.append(i)
                 transform = transform & ConstantType.from_tree(
-                    {'value': int(entry)}, ctx)
+                    {'value': int(entry.value)}, ctx)
                 i += 1
         return transform | Mapping(new_mapping)
 

--- a/asdf/tests/__init__.py
+++ b/asdf/tests/__init__.py
@@ -2,3 +2,21 @@
 """
 This packages contains affiliated package tests.
 """
+
+from .. import CustomType
+
+
+class CustomTestType(CustomType):
+    """This class is intended to be inherited by custom types that are used
+    purely for the purposes of testing. The methods ``from_tree_tagged`` and
+    ``from_tree`` are implemented solely in order to avoid custom type
+    conversion warnings.
+    """
+
+    @classmethod
+    def from_tree_tagged(cls, tree, ctx):
+        return cls.from_tree(tree.data, ctx)
+
+    @classmethod
+    def from_tree(cls, tree, ctx):
+        return tree

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -251,3 +251,27 @@ def get_file_sizes(dirname):
         if os.path.isfile(path):
             files[filename] = os.stat(path).st_size
     return files
+
+
+def display_warnings(_warnings):
+    """
+    Return a string that displays a list of unexpected warnings
+
+    Parameters
+    ----------
+    _warnings : iterable
+        List of warnings to be displayed
+
+    Returns
+    -------
+    msg : str
+        String containing the warning messages to be displayed
+    """
+    msg = "Unexpected warning(s) occurred:\n"
+    for warning in _warnings:
+        msg += "{}:{}: {}: {}\n".format(
+            warning.filename,
+            warning.lineno,
+            warning.category.__name__,
+            warning.message)
+    return msg

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -8,8 +8,6 @@ import os
 import sys
 import pytest
 
-from astropy.tests.helper import catch_warnings
-
 from .. import asdf
 from .. import asdftypes
 from .. import extension
@@ -367,10 +365,15 @@ flow_thing:
     with catch_warnings() as warning:
         asdf.AsdfFile.open(old_buff, extensions=CustomFlowExtension())
 
-    assert len(warning) == 1
+    assert len(warning) == 2, helpers.display_warnings(warning)
     assert str(warning[0].message) == (
         "'tag:nowhere.org:custom/custom_flow' with version 1.0.0 found "
         "in file, but latest supported version is 1.1.0")
+    # We expect this warning since it will not be possible to convert version
+    # 1.0.0 of CustomFlow to a CustomType (by design, for testing purposes).
+    assert str(warning[1].message).startswith(
+        "Failed to convert "
+        "tag:nowhere.org:custom/custom_flow-1.0.0 to custom type")
 
 def test_incompatible_version_check():
     class TestType0(asdftypes.CustomType):

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -169,10 +169,26 @@ def test_versioned_writing():
         }
     }
 
-    versioning.supported_versions.append('42.0.0')
+    versioning.supported_versions.append(versioning.AsdfVersion('42.0.0'))
 
-    class FancyComplexType(ComplexType):
+    # Currently this class cannot inherit directly from ComplexType because if
+    # it does it pollutes ASDF's built-in extension and causes later tests that
+    # rely on ComplexType to fail. However, if CustomType is ever implemented
+    # as an abstract base class, then it will be possible to use it as a mix-in
+    # and also inherit from ComplexType. This means the only method/attribute
+    # that will need to be explicitly defined will be 'version'.
+    class FancyComplexType(asdftypes.CustomType):
+        name = ComplexType.name
         version = (42, 0, 0)
+        types = ComplexType.types
+
+        @classmethod
+        def to_tree(cls, node, ctx):
+            return ComplexType.to_tree(node, ctx)
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            return ComplexType.from_tree(tree, ctx)
 
     class FancyComplexExtension(object):
         @property

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -154,6 +154,20 @@ def _display_warnings(_warnings):
             warning.message)
     return msg
 
+def _assert_warnings(_warnings):
+    if astropy.__version__ < '1.3.3':
+        # Make sure at least one warning occurred
+        assert len(_warnings) != 0, \
+            "Expected astropy version warning did not occur"
+        # Make sure only one warning occurred
+        assert len(_warnings) == 1, _display_warnings(_warnings)
+        # Make sure the warning was the one we expected
+        assert _warnings[0].message.startswith(
+                "gwcs and astropy-1.3.3 is required"), \
+            _display_warnings(_warnings)
+    else:
+        assert len(_warnings) == 0, _display_warnings(_warnings)
+
 def test_schema_example(filename, example):
     """Pytest to check validity of a specific example within schema file
 
@@ -193,8 +207,9 @@ def test_schema_example(filename, example):
     try:
         with catch_warnings() as w:
             ff._open_impl(ff, buff, ignore_version_mismatch=True)
-        # Do not tolerate any warnings that occur during schema validation
-        assert len(w) == 0, _display_warnings(w)
+        # Do not tolerate any warnings that occur during schema validation,
+        # other than a few that we expect to occur under certain circumstances
+        _assert_warnings(w)
     except:
         print("From file:", filename)
         raise

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -114,6 +114,16 @@ def generate_schema_list():
                 continue
             yield os.path.join(root, fname)
 
+def _display_warnings(_warnings):
+    msg = "Unexpected warnings occurred:\n"
+    for warning in _warnings:
+        msg += "{}:{}: {}: {}\n".format(
+            warning.filename,
+            warning.lineno,
+            warning.category.__name__,
+            warning.message)
+    return msg
+
 def test_schema_example(filename, example):
     """Pytest to check validity of a specific example within schema file
 
@@ -149,9 +159,10 @@ def test_schema_example(filename, example):
     b._array_storage = "streamed"
 
     try:
-        # Ignore warnings that result from examples from schemas that have
-        # versions higher than the current standard version.
-        ff._open_impl(ff, buff, ignore_version_mismatch=True)
+        with catch_warnings() as w:
+            ff._open_impl(ff, buff, ignore_version_mismatch=True)
+        # Do not tolerate any warnings that occur during schema validation
+        assert len(w) == 0, _display_warnings(w)
     except:
         print("From file:", filename)
         raise

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -160,7 +160,7 @@ def _assert_warnings(_warnings):
         assert len(_warnings) <= 1, _display_warnings(_warnings)
         # Make sure the warning was the one we expected
         if len(_warnings) == 1:
-            assert _warnings[0].message.startswith(
+            assert str(_warnings[0].message).startswith(
                     "gwcs and astropy-1.3.3 is required"), \
                 _display_warnings(_warnings)
     else:

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -161,7 +161,7 @@ def _assert_warnings(_warnings):
         # Make sure the warning was the one we expected
         if len(_warnings) == 1:
             assert str(_warnings[0].message).startswith(
-                    "gwcs and astropy-1.3.3 is required"), \
+                    "gwcs and astropy-1.3.3 packages is required"), \
                 _display_warnings(_warnings)
     else:
         assert len(_warnings) == 0, _display_warnings(_warnings)

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -144,27 +144,17 @@ def generate_schema_list():
                 continue
             yield os.path.join(root, fname)
 
-def _display_warnings(_warnings):
-    msg = "Unexpected warning(s) occurred:\n"
-    for warning in _warnings:
-        msg += "{}:{}: {}: {}\n".format(
-            warning.filename,
-            warning.lineno,
-            warning.category.__name__,
-            warning.message)
-    return msg
-
 def _assert_warnings(_warnings):
     if astropy.__version__ < '1.3.3':
         # Make sure at most only one warning occurred
-        assert len(_warnings) <= 1, _display_warnings(_warnings)
+        assert len(_warnings) <= 1, helpers.display_warnings(_warnings)
         # Make sure the warning was the one we expected
         if len(_warnings) == 1:
             assert str(_warnings[0].message).startswith(
                     "gwcs and astropy-1.3.3 packages is required"), \
-                _display_warnings(_warnings)
+                helpers.display_warnings(_warnings)
     else:
-        assert len(_warnings) == 0, _display_warnings(_warnings)
+        assert len(_warnings) == 0, helpers.display_warnings(_warnings)
 
 def test_schema_example(filename, example):
     """Pytest to check validity of a specific example within schema file

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -145,7 +145,7 @@ def generate_schema_list():
             yield os.path.join(root, fname)
 
 def _display_warnings(_warnings):
-    msg = "Unexpected warnings occurred:\n"
+    msg = "Unexpected warning(s) occurred:\n"
     for warning in _warnings:
         msg += "{}:{}: {}: {}\n".format(
             warning.filename,
@@ -156,15 +156,13 @@ def _display_warnings(_warnings):
 
 def _assert_warnings(_warnings):
     if astropy.__version__ < '1.3.3':
-        # Make sure at least one warning occurred
-        assert len(_warnings) != 0, \
-            "Expected astropy version warning did not occur"
-        # Make sure only one warning occurred
-        assert len(_warnings) == 1, _display_warnings(_warnings)
+        # Make sure at most only one warning occurred
+        assert len(_warnings) <= 1, _display_warnings(_warnings)
         # Make sure the warning was the one we expected
-        assert _warnings[0].message.startswith(
-                "gwcs and astropy-1.3.3 is required"), \
-            _display_warnings(_warnings)
+        if len(_warnings) == 1:
+            assert _warnings[0].message.startswith(
+                    "gwcs and astropy-1.3.3 is required"), \
+                _display_warnings(_warnings)
     else:
         assert len(_warnings) == 0, _display_warnings(_warnings)
 

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -31,7 +31,7 @@ from .. import treeutil
 from .. import util
 
 
-from . import helpers
+from . import helpers, CustomTestType
 from astropy.tests.helper import catch_warnings
 
 
@@ -57,11 +57,11 @@ class CustomExtension:
                  util.filepath_to_url(TEST_DATA_PATH) +
                  '/{url_suffix}.yaml')]
 
-class LabelMapperTestType(asdftypes.CustomType):
+class LabelMapperTestType(CustomTestType):
     version = '1.0.0'
     name = 'transform/label_mapper'
 
-class RegionsSelectorTestType(asdftypes.CustomType):
+class RegionsSelectorTestType(CustomTestType):
     version = '1.0.0'
     name = 'transform/regions_selector'
 

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -267,9 +267,11 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False):
                     # is not.
                     try:
                         return tag_type.from_tree_tagged(node, ctx)
-                    except TypeError:
-                        # TODO: there should definitely be a warning here
-                        pass
+                    except TypeError as err:
+                        warnings.warn(
+                            "Failed to convert {} to custom type (detail: {}). "
+                            "Using raw Python data structure instead"
+                            .format(real_tag, err))
                 # TODO: there should be a warning here too
             # This means the tag did not correspond to any type in our type
             # index. TODO: maybe this warning should be possible to suppress?

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -257,7 +257,8 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False):
             tag_type = ctx.type_index.from_yaml_tag(ctx, tag_name)
             if tag_type is not None:
                 real_tag = ctx.type_index.get_real_tag(tag_name)
-                _, real_tag_version = asdftypes.split_tag_version(real_tag)
+                real_tag_name, real_tag_version = \
+                    asdftypes.split_tag_version(real_tag)
                 if not tag_type.incompatible_version(real_tag_version):
                     # If a tag class does not explicitly list compatible
                     # versions, then all versions of the corresponding schema
@@ -272,7 +273,14 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False):
                             "Failed to convert {} to custom type (detail: {}). "
                             "Using raw Python data structure instead"
                             .format(real_tag, err))
-                # TODO: there should be a warning here too
+                # This means that there is an explicit description of versions
+                # that are compatible with the associated tag class
+                # implementation, but the version we found does not fit that
+                # description.
+                else:
+                    warnings.warn("Version {} of {} is not compatible with "
+                        "any existing tag implementations".format(
+                            real_tag_version, real_tag_name))
             # This means the tag did not correspond to any type in our type
             # index. TODO: maybe this warning should be possible to suppress?
             else:


### PR DESCRIPTION
This fixes #13. It also fixes unit tests that were producing warnings once this feature was added.

It's possible that later we will want to add an option to suppress this warning.