### PR TITLE
asdf validation error

### DIFF
--- a/asdf/tags/transform/__init__.py
+++ b/asdf/tags/transform/__init__.py
@@ -8,5 +8,6 @@ from .compound import *
 from .projections import *
 from .polynomial import *
 from .tabular import *
+from .test_fail import *
 
     

--- a/asdf/tags/transform/test_fail-1.1.0.yaml
+++ b/asdf/tags/transform/test_fail-1.1.0.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/test_fail-1.1.0"
+tag: "tag:stsci.edu:jwst_pipeline/test_fail-1.1.0"
+title: >
+ Test NRSZCoords
+
+type: object
+properties:
+  model: 
+    $ref: ../asdf/transform/shift-1.1.0
+required: [model]

--- a/asdf/tags/transform/test_fail-1.1.0.yaml
+++ b/asdf/tags/transform/test_fail-1.1.0.yaml
@@ -1,8 +1,8 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "http://stsci.edu/schemas/jwst_pipeline/test_fail-1.1.0"
-tag: "tag:stsci.edu:jwst_pipeline/test_fail-1.1.0"
+id: "http://stsci.edu/schemas/asdf/test_fail-1.1.0"
+tag: "tag:stsci.edu:asdf/test_fail-1.1.0"
 title: >
  Test NRSZCoords
 

--- a/asdf/tags/transform/test_fail.py
+++ b/asdf/tags/transform/test_fail.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+from ... import yamlutil
+from .basic import TransformType
+from astropy.modeling.core import Model
+
+__all__ = ['TestFailType', 'TestFail']
+
+
+class TestFail(Model):
+    """
+    Class to compute the z coordinate through the NIRSPEC grating wheel.
+
+    """
+    separable = False
+
+    inputs = ("x",)
+    outputs = ("z",)
+
+    def __init__(self, tab, **kwargs):
+        self.tab = tab
+        super(TestFail, self).__init__(**kwargs)
+        
+    def evaluate(self, x):
+        return self.tab(x)
+
+    
+class TestFailType(TransformType):
+    name = "transform/test_fail"
+    types = [TestFail]
+    version = "1.1.0"
+
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        tab = node['model']
+        return TestFail(tab)
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        node = {'model': model.tab}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)


### PR DESCRIPTION
The purpose of this PR is to illustrate a failing example. The schema is included here although for the example to work it should be placed under `asdf-standard/schema/.../transform`. The error I get is
```
ValidationError: mismatched tags, wanted 'tag:stsci.edu:jwst_pipeline/test_fail-1.1.0', got 'tag:stsci.edu:asdf/transform/test_fail-1.1.0'
```
The example to trigger the error:
```
from astropy.modeling import models as astmodels
from asdf import AsdfFile
from asdf.tags.transform import test_fail
fa=AsdfFile()
m=test_fail.TestFail(astmodels.Shift(1))
fa.tree['model']=m
 fa.write_to('test_fail.asdf')
```

If I don't specify `version='1.1.0'` in TestFailType, it defaults to version `1.0.0` and the error is
```
ValidationError: mismatched tags, wanted 'tag:stsci.edu:jwst_pipeline/test_fail-1.1.0', got 'tag:stsci.edu:asdf/transform/test_fail-1.0.0'
``` 
This only happens when a specific transform is defined in the schema, like `shift-1.1.0` here. If instead the schema requires `transform-1.1.0`, it works. Since all schemas we have in JWST sofar need a general `transform` and not a specific one this error just surfaced now. 

This is a simplified version of the real use case. @drdavella Do you see anything wrong with the example? If not, is this sufficient information to debug it?