### PR TITLE
Validate ASDF trees as early as possible

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -242,7 +242,7 @@ class AsdfFile(versioning.VersionedMixin):
 
     @tree.setter
     def tree(self, tree):
-        asdf_object = AsdfObject(tree)
+        asdf_object = AsdfObject(tree, validator=self._validate)
         self._validate(asdf_object)
         self._tree = asdf_object
 
@@ -254,8 +254,7 @@ class AsdfFile(versioning.VersionedMixin):
         return self._comments
 
     def _validate(self, tree):
-        tagged_tree = yamlutil.custom_tree_to_tagged_tree(
-            tree, self)
+        tagged_tree = yamlutil.custom_tree_to_tagged_tree(tree, self)
         schema.validate(tagged_tree, self)
 
     def validate(self):
@@ -852,8 +851,8 @@ class AsdfFile(versioning.VersionedMixin):
         try:
             with generic_io.get_file(fd, mode='w') as fd:
                 self._fd = fd
-                self._pre_write(fd, all_array_storage, all_array_compression,
-                                auto_inline)
+                self._pre_write(
+                    fd, all_array_storage, all_array_compression, auto_inline)
 
                 try:
                     self._serial_write(fd, pad_blocks, include_block_index)

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -6,15 +6,30 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 from ...asdftypes import AsdfType
 
 
-class AsdfObject(dict, AsdfType):
+class ValidateDictMixin(dict):
+    def __init__(self, *args, **kwargs):
+        self._validator = kwargs.get('validator')
+        if self._validator:
+            kwargs.pop('validator')
+        super(ValidateDictMixin, self).__init__(*args, **kwargs)
+
+    def __setitem__(self, key, value):
+        if self._validator:
+            asdf_object = AsdfObject(self)
+            asdf_object[key] = value
+            self._validator(asdf_object)
+        super(ValidateDictMixin, self).__setitem__(key, value)
+
+
+class AsdfObject(ValidateDictMixin, AsdfType):
     name = 'core/asdf'
 
 
-class Software(dict, AsdfType):
+class Software(ValidateDictMixin, AsdfType):
     name = 'core/software'
 
 
-class HistoryEntry(dict, AsdfType):
+class HistoryEntry(ValidateDictMixin, AsdfType):
     name = 'core/history_entry'
 
 

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import io
 import os
 
+from jsonschema import ValidationError
+
 import numpy as np
 from numpy.testing import assert_array_equal
 from astropy.modeling import models
@@ -1134,3 +1136,16 @@ def test_fd_not_seekable():
     # We lost the information about the underlying array type,
     # but still can compare the bytes.
     assert b.data.tobytes() == data.tobytes()
+
+
+def test_tree_validation(tmpdir):
+    af = asdf.AsdfFile()
+
+    with pytest.raises(ValidationError):
+        af.tree = {'data': 42}
+
+    with pytest.raises(ValidationError):
+        af.tree['data'] = 42
+
+    # This should not cause an error
+    af.tree['data'] = np.array([x for x in range(10)])

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -60,10 +60,11 @@ def test_violate_toplevel_schema():
         asdf.AsdfFile(tree)
 
     ff = asdf.AsdfFile()
-    ff.tree['fits'] = 'This does not look like a FITS file'
     with pytest.raises(ValidationError):
-        buff = io.BytesIO()
-        ff.write_to(buff)
+        ff.tree['fits'] = 'This does not look like a FITS file'
+
+    with pytest.raises(ValidationError):
+        asdf.AsdfFile({'fits': 'This does not look like a FITS file'})
 
 
 @pytest.mark.skipif('not HAS_ASTROPY')

--- a/docs/asdf/examples.rst
+++ b/docs/asdf/examples.rst
@@ -77,16 +77,9 @@ will complain::
     'tag:yaml.org,2002:str'
     ...
 
-This validation happens only when a `AsdfFile` is instantiated, read
-or saved, so it's still possible to get the tree into an invalid
-intermediate state::
-
     >>> from asdf import AsdfFile
-    >>> ff = AsdfFile()
-    >>> ff.tree['data'] = 'Not an array'
-    >>> # The ASDF file is now invalid, but asdf will tell us when
-    >>> # we write it out.
-    >>> ff.write_to('test.asdf')  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> af = AsdfFile()
+    >>> af.tree['data'] = 'Not an array' # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     ValidationError: mismatched tags, wanted


### PR DESCRIPTION
This change allows ASDF trees to be validated as early as possible. In many cases it will be possible to notice a schema validation issue at the time that an ASDF tree is assigned, rather than having to wait until the file is written.

However, it will not always be possible to catch validation errors that occur when updating existing trees. Enabling this kind of "deep" validation will require a lot of additional machinery that may not be worth the effort.

This fixes #287.