### PR TITLE
Fix reading json schema in Python 3.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,8 @@
 
 - Issue a warning when an unrecognized tag is encountered. [#295]
 
+- Fix bug with loading JSON schemas in Python 3.5. [#317]
+
 1.2.1(2016-11-07)
 -----------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -284,7 +284,8 @@ if six.PY2:
 def _load_schema(url):
     with generic_io.get_file(url) as fd:
         if isinstance(url, six.text_type) and url.endswith('json'):
-            result = json.load(fd, object_pairs_hook=OrderedDict)
+            json_data = fd.read().decode('utf-8')
+            result = json.loads(json_data, object_pairs_hook=OrderedDict)
         else:
             result = yaml.load(fd, Loader=OrderedLoader)
     return result, fd.uri

--- a/asdf/tests/data/example_schema.json
+++ b/asdf/tests/data/example_schema.json
@@ -1,0 +1,43 @@
+{
+      "date" : {
+          "title" : "[yyyy-mm-ddThh:mm:ss.ssssss] UTC date file created",
+          "type" : "string",
+          "sql_dtype" : "datetime2",
+          "fits_keyword" : "DATE",
+          "description" : "The UTC date and time when the HDU was created, in the form YYYY-MM-DDThh:mm:ss.ssssss, where YYYY shall be the four-digit calendar year number, MM the two-digit month number with January given by 01 and December by 12, and DD the two-digit day of the month. The literal T shall separate the date and time, hh shall be the two-digit hour in the day, mm the two-digit number of minutes after the hour, and ss.ssssss the number of seconds (two digits followed by a fraction accurate to microseconds) after the minute. Default values must not be given to any portion of the date/time string, and leading zeros must not be omitted.",
+          "calculation" : "Operating system time in the format of YYYY-MM-DDThh:mm:ss.ssssss",
+          "default_value" : "",
+          "example" : "2015-01-01T00:00:00.000001",
+          "units" : "",
+          "sw_source" : "calculation",
+          "source" : "Science Data Processing (SDP)",
+          "destination" : ["ScienceCommon.date","GuideStar.date"],
+          "level" : "1a",
+          "si" : "Multiple",
+          "section" : "Basic",
+          "mode" : "All",
+          "fits_hdu" : "PRIMARY",
+          "misc" : ""
+          },
+
+      "origin" : {
+          "title" : "institution responsible for creating FITS file",
+          "type" : "string",
+          "sql_dtype" : "nvarchar(20)",
+          "fits_keyword" : "ORIGIN",
+          "description" : "Identifies the organization or institution responsible for creating the FITS file.",
+          "calculation" : "",
+          "default_value" : "STSCI",
+          "example" : "STSCI",
+          "units" : "",
+          "sw_source" : "",
+          "source" : "Science Data Processing (SDP)",
+          "destination" : ["ScienceCommon.origin","GuideStar.origin"],
+          "level" : "1a",
+          "si" : "Multiple",
+          "section" : "Basic",
+          "mode" : "All",
+          "fits_hdu" : "PRIMARY",
+          "misc" : ""
+          }
+}

--- a/asdf/tests/setup_package.py
+++ b/asdf/tests/setup_package.py
@@ -7,4 +7,4 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 def get_package_data():  # pragma: no cover
     return {
         str(_PACKAGE_NAME_ + '.tests'):
-            ['coveragerc', 'data/*.yaml', 'data/*.fits']}
+            ['coveragerc', 'data/*.yaml', 'data/*.json', 'data/*.fits']}

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -132,6 +132,16 @@ def test_validate_schema(schema_path):
     schema_tree = schema.load_schema(schema_path, resolve_references=True)
     schema.check_schema(schema_tree)
 
+def test_read_json_schema():
+    """Pytest to make sure reading JSON schemas succeeds.
+
+    This was known to fail on Python 3.5 See issue #314 at
+    https://github.com/spacetelescope/asdf/issues/314 for more details.
+    """
+    json_schema = os.path.join(TEST_DATA_PATH, 'example_schema.json')
+    schema_tree = schema.load_schema(json_schema, resolve_references=True)
+    schema.check_schema(schema_tree)
+
 def generate_schema_list():
     """Returns a generator for all schema files"""
     src = os.path.join(os.path.dirname(__file__), '../schemas')


### PR DESCRIPTION
This fixes #314 (and fixes #242 which is a duplicate). The JSON module in Python 3.5 doesn't accept `bytearray` as input, but 3.6 does. This PR adds a test and a workaround.