### PR TITLE
Update travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.11
+        - NUMPY_VERSION=stable
         - ASTROPY_VERSION=development
         - CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4'
         - PIP_DEPENDENCIES_FLAGS='--no-deps --force'
@@ -52,10 +52,12 @@ matrix:
           env: NUMPY_VERSION=1.11 ASTROPY_VERSION=1.2.1 SETUP_CMD='test'
         - python: 3.5
           env: NUMPY_VERSION=1.11 ASTROPY_VERSION=1.1.2 SETUP_CMD='test'
-
-        # latest versions
         - python: 3.6
           env: NUMPY_VERSION=1.12 ASTROPY_VERSION=1.3.2 SETUP_CMD='test'
+
+        # latest stable versions
+        - python: 3.6
+          env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ environment:
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "1.3.2"
-        NUMPY_VERSION: "1.11.1"
+        NUMPY_VERSION: "1.13.0"
         platform: x64
 
       - PYTHON_VERSION: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ environment:
 
       - PYTHON_VERSION: "3.5"
         ASTROPY_VERSION: "1.3.2"
+        NUMPY_VERSION: "1.11.1"
         platform: x64
 
       - PYTHON_VERSION: "3.5"
@@ -37,6 +38,7 @@ environment:
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "1.3.2"
+        NUMPY_VERSION: "1.11.1"
         platform: x64
 
       - PYTHON_VERSION: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,23 +7,34 @@ environment:
       PYTHON: "C:\\conda"
       MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-      ASTROPY_VERSION: "development"
+      NUMPY_VERSION: "stable"
       CONDA_DEPENDENCIES: "semantic_version jsonschema pyyaml six lz4"
       PIP_DEPENDENCIES: "git+http://github.com/spacetelescope/gwcs.git#egg=gwcs"
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        NUMPY_VERSION: "1.9.1"
+        ASTROPY_VERSION: "stable"
         platform: x86
         PYTHON_ARCH: "32"
 
       - PYTHON_VERSION: "2.7"
-        NUMPY_VERSION: "1.9.1"
+        ASTROPY_VERSION: "stable"
         platform: x64
         PYTHON_ARCH: "64"
 
       - PYTHON_VERSION: "3.4"
-        NUMPY_VERSION: "1.9.1"
+        ASTROPY_VERSION: "stable"
+        platform: x64
+        PYTHON_ARCH: "64"
+
+      - PYTHON_VERSION: "3.5"
+        ASTROPY_VERSION: "1.3.2" "stable" "development"
+        platform: x64
+        PYTHON_ARCH: "64"
+
+      - PYTHON_VERSION: "3.6"
+        NUMPY_VERSION: "stable" "latest"
+        ASTROPY_VERSION: "1.3.2" "stable" "development"
         platform: x64
         PYTHON_ARCH: "64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ environment:
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "1.3.2"
-        NUMPY_VERSION: "1.13.0"
+        NUMPY_VERSION: "1.12.0"
         platform: x64
 
       - PYTHON_VERSION: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,35 +8,48 @@ environment:
       MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       NUMPY_VERSION: "stable"
+      ASTROPY_VERSION: "stable"
       CONDA_DEPENDENCIES: "semantic_version jsonschema pyyaml six lz4"
       PIP_DEPENDENCIES: "git+http://github.com/spacetelescope/gwcs.git#egg=gwcs"
+      PYTHON_ARCH: "64"
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "stable"
         platform: x86
         PYTHON_ARCH: "32"
 
       - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "stable"
         platform: x64
-        PYTHON_ARCH: "64"
 
       - PYTHON_VERSION: "3.4"
-        ASTROPY_VERSION: "stable"
         platform: x64
-        PYTHON_ARCH: "64"
 
       - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "1.3.2" "stable" "development"
+        ASTROPY_VERSION: "1.3.2"
         platform: x64
-        PYTHON_ARCH: "64"
+
+      - PYTHON_VERSION: "3.5"
+        platform: x64
+
+      - PYTHON_VERSION: "3.5"
+        ASTROPY_VERSION: "development"
+        platform: x64
 
       - PYTHON_VERSION: "3.6"
-        NUMPY_VERSION: "stable" "latest"
-        ASTROPY_VERSION: "1.3.2" "stable" "development"
+        ASTROPY_VERSION: "1.3.2"
         platform: x64
-        PYTHON_ARCH: "64"
+
+      - PYTHON_VERSION: "3.6"
+        platform: x64
+
+      - PYTHON_VERSION: "3.6"
+        ASTROPY_VERSION: "development"
+        platform: x64
+
+      - PYTHON_VERSION: "3.6"
+        ASTROPY_VERSION: "development"
+        NUMPY_VERSION: "development"
+        platform: x64
 
 install:
     - "git clone git://github.com/astropy/ci-helpers.git"


### PR DESCRIPTION
This resolves #316. Instead of hard-coding the latest stable versions of `numpy` and `astropy`, use the `stable` flag provided by [astropy/ci-helpers](https://github.com/astropy/ci-helpers).

Also add a new test to the matrix covering `astropy-1.3.2` since that is now the previous stable version, not the latest.