### PR TITLE
Configure warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,10 @@
 - When possible, display name of ASDF file that caused version mismatch
   warning. [#306]
 
-- Issue a warning when an unrecognized tag is encountered. [#295]
+- Issue a warning when an unrecognized tag is encountered. [#295] This warning
+  is silenced by default, but can be enabled with a parameter to the
+  ``AsdfFile`` constructor, or to ``AsdfFile.open``. Also added an option for
+  ignoring warnings from unrecognized schema tags. [#319]
 
 - Fix bug with loading JSON schemas in Python 3.5. [#317]
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -428,7 +428,7 @@ class AsdfFile(versioning.VersionedMixin):
     def _open_asdf(cls, self, fd, uri=None, mode='r',
                    validate_checksums=False,
                    do_not_fill_defaults=False,
-                   ignore_version_mismatch=False,
+                   ignore_version_mismatch=True,
                    _get_yaml_content=False,
                    _force_raw_types=False):
         """Attempt to populate AsdfFile data from file-like object"""
@@ -493,7 +493,7 @@ class AsdfFile(versioning.VersionedMixin):
     def _open_impl(cls, self, fd, uri=None, mode='r',
                    validate_checksums=False,
                    do_not_fill_defaults=False,
-                   ignore_version_mismatch=False,
+                   ignore_version_mismatch=True,
                    _get_yaml_content=False,
                    _force_raw_types=False):
         """Attempt to open file-like object as either AsdfFile or AsdfInFits"""
@@ -505,6 +505,7 @@ class AsdfFile(versioning.VersionedMixin):
                 from . import fits_embed
                 return fits_embed.AsdfInFits.open(fd, uri=uri,
                             validate_checksums=validate_checksums,
+                            ignore_version_mismatch=ignore_version_mismatch,
                             extensions=self._extensions)
             except ValueError:
                 pass
@@ -523,7 +524,7 @@ class AsdfFile(versioning.VersionedMixin):
              validate_checksums=False,
              extensions=None,
              do_not_fill_defaults=False,
-             ignore_version_mismatch=False,
+             ignore_version_mismatch=True,
              _force_raw_types=False):
         """
         Open an existing ASDF file.

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -215,7 +215,7 @@ class AsdfTypeIndex(object):
 
         return write_type_index.from_custom_type(custom_type)
 
-    def fix_yaml_tag(self, ctx, tag, ignore_version_mismatch=False):
+    def fix_yaml_tag(self, ctx, tag, ignore_version_mismatch=True):
         """
         Given a YAML tag, adjust it to the best supported version.
 
@@ -224,8 +224,9 @@ class AsdfTypeIndex(object):
         the earliest understood version if none are less than the
         version in the file.
 
-        Raises a warning if it could not find a match where the major
-        and minor numbers are the same.
+        If ``ignore_version_mismatch==False``, this function raises a warning
+        if it could not find a match where the major and minor numbers are the
+        same.
         """
         warning_string = None
 
@@ -236,7 +237,7 @@ class AsdfTypeIndex(object):
         if tag in self._best_matches:
             best_tag, warning_string = self._best_matches[tag]
 
-            if warning_string:
+            if warning_string and not ignore_version_mismatch:
                 warnings.warn(warning_string.format(fname))
 
             return best_tag

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -140,11 +140,10 @@ class AsdfInFits(asdf.AsdfFile):
         ff.write_to('test.fits')  # doctest: +SKIP
     """
 
-    def __init__(self, hdulist=None, tree=None, uri=None, extensions=None):
+    def __init__(self, hdulist=None, tree=None, **kwargs):
         if hdulist is None:
             hdulist = fits.HDUList()
-        super(AsdfInFits, self).__init__(
-            tree=tree, uri=uri, extensions=extensions)
+        super(AsdfInFits, self).__init__(tree=tree, **kwargs)
         self._blocks = _EmbeddedBlockManager(hdulist, self)
         self._hdulist = hdulist
         self._close_hdulist = False
@@ -163,7 +162,7 @@ class AsdfInFits(asdf.AsdfFile):
 
     @classmethod
     def open(cls, fd, uri=None, validate_checksums=False, extensions=None,
-             ignore_version_mismatch=True):
+             ignore_version_mismatch=True, ignore_unrecognized_tag=False):
         """Creates a new AsdfInFits object based on given input data
 
         Parameters
@@ -206,7 +205,9 @@ class AsdfInFits(asdf.AsdfFile):
                 msg = "Failed to parse given file '{}'. Is it FITS?"
                 raise ValueError(msg.format(file_obj.uri))
 
-        self = cls(hdulist, uri=uri, extensions=extensions)
+        self = cls(hdulist, uri=uri, extensions=extensions,
+                   ignore_version_mismatch=ignore_version_mismatch,
+                   ignore_unrecognized_tag=ignore_unrecognized_tag)
         self._close_hdulist = close_hdulist
 
         try:
@@ -217,8 +218,7 @@ class AsdfInFits(asdf.AsdfFile):
 
         buff = io.BytesIO(asdf_extension.data)
         return cls._open_asdf(self, buff, uri=uri, mode='r',
-                              validate_checksums=validate_checksums,
-                              ignore_version_mismatch=ignore_version_mismatch)
+                              validate_checksums=validate_checksums)
 
     def _update_asdf_extension(self, all_array_storage=None,
                                all_array_compression=None,

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -162,7 +162,8 @@ class AsdfInFits(asdf.AsdfFile):
         self._tree = {}
 
     @classmethod
-    def open(cls, fd, uri=None, validate_checksums=False, extensions=None):
+    def open(cls, fd, uri=None, validate_checksums=False, extensions=None,
+             ignore_version_mismatch=True):
         """Creates a new AsdfInFits object based on given input data
 
         Parameters
@@ -185,6 +186,9 @@ class AsdfInFits(asdf.AsdfFile):
             A list of extensions to the ASDF to support when reading
             and writing ASDF files.  See `asdftypes.AsdfExtension` for
             more information.
+
+        ignore_version_mismatch : bool, optional
+            When `True`, do not raise warnings for mismatched schema versions.
         """
         close_hdulist = False
         if isinstance(fd, fits.hdu.hdulist.HDUList):
@@ -213,7 +217,8 @@ class AsdfInFits(asdf.AsdfFile):
 
         buff = io.BytesIO(asdf_extension.data)
         return cls._open_asdf(self, buff, uri=uri, mode='r',
-                              validate_checksums=validate_checksums)
+                              validate_checksums=validate_checksums,
+                              ignore_version_mismatch=ignore_version_mismatch)
 
     def _update_asdf_extension(self, all_array_storage=None,
                                all_array_compression=None,

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -267,6 +267,9 @@ def display_warnings(_warnings):
     msg : str
         String containing the warning messages to be displayed
     """
+    if len(_warnings) == 0:
+        return "No warnings occurred (was one expected?)"
+
     msg = "Unexpected warning(s) occurred:\n"
     for warning in _warnings:
         msg += "{}:{}: {}: {}\n".format(

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -306,6 +306,12 @@ undefined_data:
             "tag:nowhere.org:custom/{} is not recognized, converting to raw "
             "Python data structure".format(tag))
 
+    # Make sure no warning occurs if explicitly ignored
+    buff.seek(0)
+    with catch_warnings() as warning:
+        afile = asdf.AsdfFile.open(buff, ignore_unrecognized_tag=True)
+    assert len(warning) == 0
+
 
 def test_newer_tag():
     # This test simulates a scenario where newer versions of CustomFlow

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -18,7 +18,7 @@ from astropy.tests.helper import catch_warnings
 from .. import asdf
 from .. import fits_embed
 from .. import open as asdf_open
-from .helpers import assert_tree_match, yaml_to_asdf
+from .helpers import assert_tree_match, yaml_to_asdf, display_warnings
 
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
@@ -230,7 +230,8 @@ def test_version_mismatch_file():
     testfile = os.path.join(TEST_DATA_PATH, 'version_mismatch.fits')
 
     with catch_warnings() as w:
-        with asdf.AsdfFile.open(testfile) as fits_handle:
+        with asdf.AsdfFile.open(testfile,
+                ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
     # This is the warning that we expect from opening the FITS file
     assert len(w) == 1
@@ -238,10 +239,23 @@ def test_version_mismatch_file():
         "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
         "'file://{}', but latest supported version is 1.0.0".format(testfile))
 
+    # Make sure warning does not occur when warning is ignored (default)
     with catch_warnings() as w:
-        with fits_embed.AsdfInFits.open(testfile) as fits_handle:
+        with asdf.AsdfFile.open(testfile) as fits_handle:
+            assert fits_handle.tree['a'] == complex(0j)
+    assert len(w) == 0, display_warnings(w)
+
+    with catch_warnings() as w:
+        with fits_embed.AsdfInFits.open(testfile,
+                ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
     assert len(w) == 1
     assert str(w[0].message) == (
         "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
         "'file://{}', but latest supported version is 1.0.0".format(testfile))
+
+    # Make sure warning does not occur when warning is ignored (default)
+    with catch_warnings() as w:
+        with fits_embed.AsdfInFits.open(testfile) as fits_handle:
+            assert fits_handle.tree['a'] == complex(0j)
+    assert len(w) == 0, display_warnings(w)

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -204,7 +204,7 @@ def test_schema_example(filename, example):
 
     try:
         with catch_warnings() as w:
-            ff._open_impl(ff, buff, ignore_version_mismatch=True)
+            ff._open_impl(ff, buff)
         # Do not tolerate any warnings that occur during schema validation,
         # other than a few that we expect to occur under certain circumstances
         _assert_warnings(w)

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -260,8 +260,9 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False):
         # This means the tag did not correspond to any type in our type index.
         # TODO: maybe this warning should be possible to suppress?
         if tag_type is None:
-            warnings.warn("{} is not recognized, converting to raw Python data "
-                "structure".format(tag_name))
+            if not ctx._ignore_unrecognized_tag:
+                warnings.warn("{} is not recognized, converting to raw Python "
+                    "data structure".format(tag_name))
             return node
 
         real_tag = ctx.type_index.get_real_tag(tag_name)

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -258,7 +258,6 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False):
 
         tag_type = ctx.type_index.from_yaml_tag(ctx, tag_name)
         # This means the tag did not correspond to any type in our type index.
-        # TODO: maybe this warning should be possible to suppress?
         if tag_type is None:
             if not ctx._ignore_unrecognized_tag:
                 warnings.warn("{} is not recognized, converting to raw Python "


### PR DESCRIPTION
This PR does two things:

1. It makes version mismatch warnings silent by default
2. It enables warnings for unrecognized tags to be silenced

@nden, this seems like the right way to handle the large number of version mismatch warnings in jwst in the long term. However, I think that unrecognized tag warnings should be enabled by default, and there are a few other more serious warnings which are still not possible to silence at all.

Also, while this resolves #313 for the most part, it does not add a module-level configuration mechanism. There are too many questions about precedence that make it a little too complicated to implement without sufficient motivation. Please let me know if you disagree.