### PR TITLE
Fix sphinx build errors, update sphinx builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
   - 2.7
   - 3.5
   - 3.6
- 
+
 env:
     global:
         # The following versions are the 'default' for tests, unless

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='build_docs -w'
 
+        - python: 3.6
+          env: SETUP_CMD='build_docs -w'
+
         # Try older numpy versions
         - python: 2.7
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,8 @@ matrix:
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        # Sphinx version is temporarily fix to be <1.3.5, until #192 is
-        # resolved
         - python: 2.7
-          env: SETUP_CMD='build_sphinx -w' SPHINX_VERSION='<1.3.5'
+          env: SETUP_CMD='build_docs -w'
 
         # Try older numpy versions
         - python: 2.7

--- a/docs/sphinxext/example.py
+++ b/docs/sphinxext/example.py
@@ -128,7 +128,7 @@ class AsdfDirective(Directive):
                     internal_blocks[-1].array_storage != 'streamed'):
                     buff = io.BytesIO()
                     ff.blocks.write_block_index(buff, ff)
-                    block_index = buff.getvalue()
+                    block_index = buff.getvalue().decode('utf-8')
                     literal = nodes.literal_block(block_index, block_index)
                     literal['language'] = 'yaml'
                     set_source_info(self, literal)


### PR DESCRIPTION
This fixes #321 by addressing the error that was preventing sphinx builds. It also updates the travis build to make sure that we build sphinx documentation in a Python 3.6 environment.

This also closes #192 since the reported warning no longer appears. It seems reasonable to assume that this has been fixed. It's also reasonable to close the issue since there have been [numerous sphinx releases](http://www.sphinx-doc.org/en/stable/changes.html) since version 1.3.5.