### PR TITLE
Reactivate reference file tests

### DIFF
--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -254,7 +254,6 @@ def pytest_generate_tests(metafunc):
     """
     def get_schema_name(schema_path):
         """Helper function to return the informative part of a schema path"""
-        print(schema_path)
         path = os.path.normpath(schema_path)
         return os.path.sep.join(path.split(os.path.sep)[-3:])
 

--- a/asdf/tests/test_suite.py
+++ b/asdf/tests/test_suite.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import os
 import sys
 
-from .. import open
+from asdf import open as asdf_open
+from asdf import versioning
 
 from .helpers import assert_tree_match
 
@@ -27,10 +28,10 @@ def test_reference_files():
             known_fail = known_fail | (basename in ('unicode_spp.asdf'))
 
         try:
-            with open(filename) as asdf:
+            with asdf_open(filename) as asdf:
                 asdf.resolve_and_inline()
 
-                with open(filename[:-4] + "yaml") as ref:
+                with asdf_open(filename[:-4] + "yaml") as ref:
                     assert_tree_match(asdf.tree, ref.tree,
                                       funcname='assert_allclose')
         except:
@@ -39,10 +40,13 @@ def test_reference_files():
             else:
                 raise
 
-    root = os.path.join(
-        os.path.dirname(__file__), '..', "reference_files")
-    for filename in os.listdir(root):
-        if filename.endswith(".asdf"):
-            filepath = os.path.join(root, filename)
-            if os.path.exists(filepath[:-4] + "yaml"):
-                yield test_reference_file, filepath
+    root = os.path.join(os.path.dirname(__file__), '..', "reference_files")
+    for version in versioning.supported_versions:
+        version_dir = os.path.join(root, str(version))
+        if os.path.exists(version_dir):
+            for filename in os.listdir(version_dir):
+                if filename.endswith(".asdf"):
+                    filepath = os.path.join(version_dir, filename)
+                    basename, _ = os.path.splitext(filepath)
+                    if os.path.exists(basename + ".yaml"):
+                        yield test_reference_file, filepath

--- a/asdf/tests/test_suite.py
+++ b/asdf/tests/test_suite.py
@@ -13,7 +13,13 @@ from asdf import versioning
 from .helpers import assert_tree_match
 
 
+def get_test_id(reference_file_path):
+    """Helper function to return the informative part of a schema path"""
+    path = os.path.normpath(reference_file_path)
+    return os.path.sep.join(path.split(os.path.sep)[-3:])
+
 def collect_reference_files():
+    """Function used by pytest to collect ASDF reference files for testing."""
     root = os.path.join(os.path.dirname(__file__), '..', "reference_files")
     for version in versioning.supported_versions:
         version_dir = os.path.join(root, str(version))
@@ -25,7 +31,8 @@ def collect_reference_files():
                     if os.path.exists(basename + ".yaml"):
                         yield filepath
 
-@pytest.mark.parametrize('reference_file', collect_reference_files())
+@pytest.mark.parametrize(
+    'reference_file', collect_reference_files(), ids=get_test_id)
 def test_reference_file(reference_file):
     basename = os.path.basename(reference_file)
 

--- a/asdf/tests/test_suite.py
+++ b/asdf/tests/test_suite.py
@@ -46,12 +46,13 @@ def test_reference_file(reference_file):
         known_fail = known_fail | (basename in ('unicode_spp.asdf'))
 
     try:
-        with asdf_open(reference_file) as asdf:
-            asdf.resolve_and_inline()
+        with asdf_open(reference_file) as af_handle:
+            af_handle.resolve_and_inline()
 
-            with asdf_open(reference_file[:-4] + "yaml") as ref:
-                assert_tree_match(asdf.tree, ref.tree,
-                                  funcname='assert_allclose')
+            barename, _ = os.path.splitext(reference_file)
+            with asdf_open(barename + ".yaml") as ref:
+                assert_tree_match(
+                    af_handle.tree, ref.tree, funcname='assert_allclose')
     except:
         if known_fail:
             pytest.xfail()

--- a/asdf/tests/test_suite.py
+++ b/asdf/tests/test_suite.py
@@ -5,41 +5,15 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import os
 import sys
+import pytest
 
 from asdf import open as asdf_open
 from asdf import versioning
 
 from .helpers import assert_tree_match
 
-import pytest
 
-
-def test_reference_files():
-    def test_reference_file(filename):
-        basename = os.path.basename(filename)
-
-        known_fail = False
-        if sys.version_info[:2] == (2, 6):
-            known_fail = (basename in ('complex.asdf', 'unicode_spp.asdf'))
-        elif sys.version_info[:2] == (2, 7):
-            known_fail = (basename in ('complex.asdf'))
-
-        if sys.maxunicode <= 65535:
-            known_fail = known_fail | (basename in ('unicode_spp.asdf'))
-
-        try:
-            with asdf_open(filename) as asdf:
-                asdf.resolve_and_inline()
-
-                with asdf_open(filename[:-4] + "yaml") as ref:
-                    assert_tree_match(asdf.tree, ref.tree,
-                                      funcname='assert_allclose')
-        except:
-            if known_fail:
-                pytest.xfail()
-            else:
-                raise
-
+def collect_reference_files():
     root = os.path.join(os.path.dirname(__file__), '..', "reference_files")
     for version in versioning.supported_versions:
         version_dir = os.path.join(root, str(version))
@@ -49,4 +23,30 @@ def test_reference_files():
                     filepath = os.path.join(version_dir, filename)
                     basename, _ = os.path.splitext(filepath)
                     if os.path.exists(basename + ".yaml"):
-                        yield test_reference_file, filepath
+                        yield filepath
+
+@pytest.mark.parametrize('reference_file', collect_reference_files())
+def test_reference_file(reference_file):
+    basename = os.path.basename(reference_file)
+
+    known_fail = False
+    if sys.version_info[:2] == (2, 6):
+        known_fail = (basename in ('complex.asdf', 'unicode_spp.asdf'))
+    elif sys.version_info[:2] == (2, 7):
+        known_fail = (basename in ('complex.asdf'))
+
+    if sys.maxunicode <= 65535:
+        known_fail = known_fail | (basename in ('unicode_spp.asdf'))
+
+    try:
+        with asdf_open(reference_file) as asdf:
+            asdf.resolve_and_inline()
+
+            with asdf_open(reference_file[:-4] + "yaml") as ref:
+                assert_tree_match(asdf.tree, ref.tree,
+                                  funcname='assert_allclose')
+    except:
+        if known_fail:
+            pytest.xfail()
+        else:
+            raise


### PR DESCRIPTION
After a little bit of random poking around I realized that there was a set of tests that haven't been running at all. These tests run against the ASDF and YAML reference files in `asdf-standard`. They have now been cleaned up and reactivated.