### PR TITLE
Override repr and str methods in Stream

### DIFF
--- a/asdf/stream.py
+++ b/asdf/stream.py
@@ -58,3 +58,10 @@ class Stream(ndarray.NDArrayType):
         if data._strides is not None:
             result['strides'] = data._strides
         return result
+
+    def __repr__(self):
+        return "Stream({}, {}, strides={})".format(
+            self._shape, self._datatype, self._strides)
+
+    def __str__(self):
+        return str(self.__repr__())

--- a/asdf/tests/test_stream.py
+++ b/asdf/tests/test_stream.py
@@ -192,3 +192,11 @@ def test_too_many_streams():
     ff.set_array_storage(tree['stream1'], 'streamed')
     with pytest.raises(ValueError):
         ff.set_array_storage(tree['stream2'], 'streamed')
+
+def test_stream_repr():
+    tree = {
+        'stream': stream.Stream([16], np.int64)
+    }
+
+    ff = asdf.AsdfFile(tree)
+    repr(ff.tree)

--- a/asdf/tests/test_stream.py
+++ b/asdf/tests/test_stream.py
@@ -193,10 +193,11 @@ def test_too_many_streams():
     with pytest.raises(ValueError):
         ff.set_array_storage(tree['stream2'], 'streamed')
 
-def test_stream_repr():
+def test_stream_repr_and_str():
     tree = {
         'stream': stream.Stream([16], np.int64)
     }
 
     ff = asdf.AsdfFile(tree)
-    repr(ff.tree)
+    repr(ff.tree['stream'])
+    str(ff.tree['stream'])


### PR DESCRIPTION
These were missing, which caused problems since `Stream` inherits from `tags.core.ndarray.NDArrayType`, but does not implement all of the attributes that are used by the `__repr__` and `__str__` methods of the parent class.