### PR TITLE
Fix hanging tests on darwin related to remote data access

### DIFF
--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -15,6 +15,11 @@ except ImportError:
     ICRS = None
 
 try:
+    from astropy.tests.disable_internet import INTERNET_OFF
+except ImportError:
+    INTERNET_OFF = False
+
+try:
     from astropy.coordinates.representation import CartesianRepresentation
 except ImportError:
     CartesianRepresentation = None
@@ -181,7 +186,7 @@ def assert_roundtrip_tree(
             asdf_check_func(ff)
 
     # Now try everything on an HTTP range server
-    if not sys.platform.startswith('win'):
+    if not INTERNET_OFF and not sys.platform.startswith('win'):
         server = RangeHTTPServer()
         try:
             ff = AsdfFile(tree, extensions=extensions)

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -22,9 +22,11 @@ from . import helpers
 
 try:
     from astropy.io import fits
+    from astropy.tests.disable_internet import INTERNET_OFF
     HAS_ASTROPY = True
 except ImportError:
     HAS_ASTROPY = False
+    INTERNET_OFF = False
 
 
 def _get_small_tree():
@@ -253,6 +255,7 @@ def test_streams2():
     assert len(x) == 60
 
 
+@pytest.mark.skipif(INTERNET_OFF, reason="Astropy has disabled internet access")
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     reason="Windows firewall prevents test")
 def test_urlopen(tree, httpserver):
@@ -272,6 +275,7 @@ def test_urlopen(tree, httpserver):
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.ndarray)
 
 
+@pytest.mark.skipif(INTERNET_OFF, reason="Astropy has disabled internet access")
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     reason="Windows firewall prevents test")
 def test_http_connection(tree, httpserver):
@@ -296,6 +300,7 @@ def test_http_connection(tree, httpserver):
         ff.tree['science_data'][0] == 42
 
 
+@pytest.mark.skipif(INTERNET_OFF, reason="Astropy has disabled internet access")
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     reason="Windows firewall prevents test")
 def test_http_connection_range(tree, rhttpserver):

--- a/asdf/tests/test_remote_data.py
+++ b/asdf/tests/test_remote_data.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import pytest
+
+astropy = pytest.importorskip('astropy')
+from astropy.tests.helper import remote_data
+from astropy.tests.disable_internet import INTERNET_OFF
+
+_REMOTE_DATA = False
+
+@remote_data('any')
+def test_internet_on():
+    global _REMOTE_DATA
+    _REMOTE_DATA = True
+    assert INTERNET_OFF == False
+
+def test_internet_off():
+    if not _REMOTE_DATA:
+        assert INTERNET_OFF == True


### PR DESCRIPTION
This fixes #328. There are many tests in the suite that create HTTP servers of various types behind the scenes and attempt to access ASDF files from them. Prior to this PR these tests had no awareness of astropy's attempt to disable internet access when `--remote-data` is not explicitly given.

This PR allows the tests to pass without hanging. However, I'm not entirely sure why this only happened on darwin and not on linux. It makes me wonder whether there's a deeper issue, maybe even upstream in astropy.