### PR TITLE
Add osx test to the travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ addons:
     - texlive-latex-extra
     - dvipng
 
-python:
-  - 2.7
-  - 3.5
-  - 3.6
-
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -34,6 +29,11 @@ env:
         - PIP_DEPENDENCIES='git+http://github.com/spacetelescope/gwcs.git#egg=gwcs'
         - SETUP_CMD='test --remote-data'
 
+    matrix:
+        - PYTHON_VERSION=2.7 SETUP_CMD='test'
+        - PYTHON_VERSION=3.5 SETUP_CMD='test'
+        - PYTHON_VERSION=3.6 SETUP_CMD='test'
+
 matrix:
     include:
 
@@ -45,7 +45,7 @@ matrix:
         # may run for a long time
         - env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
 
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
+        - env: SETUP_CMD='build_docs -w'
 
         # Try older numpy versions
         - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
-language: python
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
+language: c
+
+os:
+    - linux
 
 # Use Travis' container-based architecture
 sudo: false
@@ -59,6 +65,12 @@ matrix:
         # latest stable versions
         - python: 3.6
           env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
+
+        # Try a run on OSX
+        - os: osx
+          python: 3.6
+          env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
+
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
+        - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=development
         - CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4'
@@ -37,38 +38,32 @@ matrix:
     include:
 
         # Do a coverage test in Python 2.
-        - python: 2.7
-          env: SETUP_CMD='test --coverage --open-files --remote-data'
+        - env: PYTHON_VERSION=2.7
+               SETUP_CMD='test --coverage --open-files --remote-data'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - python: 2.7
-          env: SETUP_CMD='build_docs -w'
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
 
-        - python: 3.6
-          env: SETUP_CMD='build_docs -w'
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
 
         # Try older numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.10 SETUP_CMD='test'
+        - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test'
+
+        - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10 SETUP_CMD='test'
 
         # try older astropy versions
-        - python: 3.5
-          env: NUMPY_VERSION=1.11 ASTROPY_VERSION=1.2.1 SETUP_CMD='test'
-        - python: 3.5
-          env: NUMPY_VERSION=1.11 ASTROPY_VERSION=1.1.2 SETUP_CMD='test'
-        - python: 3.6
-          env: NUMPY_VERSION=1.12 ASTROPY_VERSION=1.3.2 SETUP_CMD='test'
+        - env: PYTHON_VERSION=3.5
+               NUMPY_VERSION=1.11 ASTROPY_VERSION=1.2.1 SETUP_CMD='test'
+        - env: PYTHON_VERSION=3.5
+               NUMPY_VERSION=1.11 ASTROPY_VERSION=1.1.2 SETUP_CMD='test'
+        - env: NUMPY_VERSION=1.12 ASTROPY_VERSION=1.3.2 SETUP_CMD='test'
 
         # latest stable versions
-        - python: 3.6
-          env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
+        - env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
 
         # Try a run on OSX
         - os: osx
-          python: 3.6
           env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
 
 install:


### PR DESCRIPTION
This closes #331 by adding an OSX test to the travis test matrix. Unfortunately, since travis doesn't technically support Python builds on OSX, this required some fairly substantial changes to the config file. Thankfully, [astropy/ci-helpers](https://github.com/astropy/ci-helpers) makes it fairly easy to work around this restriction.