### PR TITLE
Update coverage test to run in Py3.6 instead of Py2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,8 @@ env:
 matrix:
     include:
 
-        # Do a coverage test in Python 2.
-        - env: PYTHON_VERSION=2.7
-               SETUP_CMD='test --coverage --open-files --remote-data'
+        # Do a coverage test
+        - env: SETUP_CMD='test --coverage --open-files --remote-data'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -380,8 +380,8 @@ class BlockManager(object):
                 allow_unicode=True, encoding='utf-8')
 
     _re_index_content = re.compile(
-        b'^' + constants.INDEX_HEADER + b'\r?\n%YAML.*\.\.\.\r?\n?$')
-    _re_index_misc = re.compile(b'^[\n\r\x20-\x7f]+$')
+        br'^' + constants.INDEX_HEADER + br'\r?\n%YAML.*\.\.\.\r?\n?$')
+    _re_index_misc = re.compile(br'^[\n\r\x20-\x7f]+$')
 
     def read_block_index(self, fd, ctx):
         """

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -894,7 +894,7 @@ class Block(object):
         updating the file in-place, otherwise the work is redundant.
         """
         if self._data is not None:
-            if six.PY2:
+            if six.PY2: # pragma: no cover
                 self._data_size = len(self._data.data)
             else:
                 self._data_size = self._data.data.nbytes

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -60,7 +60,7 @@ def _check_bytes(fd, mode):
         if not isinstance(x, bytes):
             return False
     elif 'w' in mode:
-        if six.PY2:
+        if six.PY2: # pragma: no cover
             if isinstance(fd, file):
                 if 'b' not in fd.mode:
                     return False
@@ -1196,7 +1196,7 @@ def get_file(init, mode='r', uri=None):
         raise TypeError(
             "io.StringIO objects are not supported.  Use io.BytesIO instead.")
 
-    elif six.PY2 and isinstance(init, file):
+    elif six.PY2 and isinstance(init, file): # pragma: no cover
         if init.mode[0] not in mode:
             raise ValueError(
                 "File is opened as '{0}', but '{1}' was requested".format(

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -55,7 +55,7 @@ PYTHON_TYPE_TO_YAML_TAG = {
 }
 
 
-if six.PY2:
+if six.PY2: # pragma: no cover
     PYTHON_TYPE_TO_YAML_TAG[long] = 'int'
 
 
@@ -274,7 +274,7 @@ OrderedLoader.add_constructor(
     construct_mapping)
 
 
-if six.PY2:
+if six.PY2: # pragma: no cover
     # Load strings in as Unicode on Python 2
     OrderedLoader.add_constructor('tag:yaml.org,2002:str',
                                   OrderedLoader.construct_scalar)
@@ -430,7 +430,7 @@ def get_validator(schema={}, ctx=None, validators=None, url_mapping=None,
     return validator
 
 
-if six.PY2:
+if six.PY2: # pragma: no cover
     def validate_large_literals(instance):
         """
         Validate that the tree has no large numeric literals.

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -216,7 +216,7 @@ for scalar_type in util.iter_subclasses(np.integer):
 # ----------------------------------------------------------------------
 # Unicode fix on Python 2
 
-if six.PY2:
+if six.PY2: # pragma: no cover
     # This dumps Python unicode strings as regular YAML strings rather
     # than !!python/unicode. See http://pyyaml.org/ticket/11
     def _unicode_representer(dumper, value):


### PR DESCRIPTION
This is necessary especially given the upcoming deprecation of Py2.