### PR TITLE
Fix bug with astropy.time location, update time schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,9 @@
   versions of the same type. It also makes sure that schema example tests run
   against the correct version of the ASDF standard. [#350]
 
+- Update time schema to reflect changes in astropy. This fixes an outstanding
+  bug. [#343]
+
 1.2.1(2016-11-07)
 -----------------
 

--- a/asdf/commands/tests/data/frames0.asdf
+++ b/asdf/commands/tests/data/frames0.asdf
@@ -14,18 +14,18 @@ frames:
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
-  reference_frame: {equinox: !time/time-1.0.0 '2010-01-01 00:00:00.000', type: FK5}
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: FK5}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
-  reference_frame: {equinox: !time/time-1.0.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.0.0 '2015-01-01
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
       00:00:00.000', type: FK4}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
-  reference_frame: {equinox: !time/time-1.0.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.0.0 '2015-01-01
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
       00:00:00.000', type: FK4_noeterms}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
@@ -64,25 +64,25 @@ frames:
     - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 2.0}
     - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 1.0}
     - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 8.0}
-    obstime: !time/time-1.0.0 2010-01-01 00:00:00.000
+    obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
     type: GCRS
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
-  reference_frame: {obstime: !time/time-1.0.0 '2010-01-01 00:00:00.000', type: CIRS}
+  reference_frame: {obstime: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: CIRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [x, y, z]
   axes_order: [0, 1, 2]
   name: CelestialFrame
-  reference_frame: {obstime: !time/time-1.0.0 '2022-01-03 00:00:00.000', type: ITRS}
+  reference_frame: {obstime: !time/time-1.1.0 '2022-01-03 00:00:00.000', type: ITRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame:
-    equinox: !time/time-1.0.0 J2000.000
+    equinox: !time/time-1.1.0 J2000.000
     obsgeoloc:
     - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 3.0856775814671916e+16}
     - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 9.257032744401574e+16}
@@ -91,7 +91,7 @@ frames:
     - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 2.0}
     - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 1.0}
     - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 8.0}
-    obstime: !time/time-1.0.0 2010-01-01 00:00:00.000
+    obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
     type: precessed_geocentric
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 ...

--- a/asdf/commands/tests/data/frames1.asdf
+++ b/asdf/commands/tests/data/frames1.asdf
@@ -14,18 +14,18 @@ frames:
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
-  reference_frame: {equinox: !time/time-1.0.0 '2010-01-01 00:00:00.000', type: FK5}
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: FK5}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
-  reference_frame: {equinox: !time/time-1.0.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.0.0 '2015-01-01
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
       00:00:00.000', type: FK4}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
-  reference_frame: {equinox: !time/time-1.0.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.0.0 '2015-01-01
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
       00:00:00.000', type: FK4_noeterms}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
@@ -79,25 +79,25 @@ frames:
     - !unit/quantity-1.1.0
       unit: m s-1
       value: 8.0
-    obstime: !time/time-1.0.0 2010-01-01 00:00:00.000
+    obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
     type: GCRS
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
-  reference_frame: {obstime: !time/time-1.0.0 '2010-01-01 00:00:00.000', type: CIRS}
+  reference_frame: {obstime: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: CIRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [x, y, z]
   axes_order: [0, 1, 2]
   name: CelestialFrame
-  reference_frame: {obstime: !time/time-1.0.0 '2022-01-03 00:00:00.000', type: ITRS}
+  reference_frame: {obstime: !time/time-1.1.0 '2022-01-03 00:00:00.000', type: ITRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 - !wcs/celestial_frame-1.1.0
   axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame:
-    equinox: !time/time-1.0.0 J2000.000
+    equinox: !time/time-1.1.0 J2000.000
     obsgeoloc:
     - !unit/quantity-1.1.0
       unit: m
@@ -118,7 +118,7 @@ frames:
     - !unit/quantity-1.1.0
       unit: m s-1
       value: 8.0
-    obstime: !time/time-1.0.0 2010-01-01 00:00:00.000
+    obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
     type: precessed_geocentric
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 ...

--- a/asdf/tags/time/tests/test_time.py
+++ b/asdf/tags/time/tests/test_time.py
@@ -104,7 +104,12 @@ def test_time(tmpdir):
 
 def test_time_with_location(tmpdir):
     # See https://github.com/spacetelescope/asdf/issues/341
-    t = time.Time([1,2], location=[[1,2], [3,4], [5,6]], format='cxcsec')
+    from astropy import units as u
+    from astropy.coordinates.earth import EarthLocation
+
+    location = EarthLocation(x=[1,2]*u.m, y=[3,4]*u.m, z=[5,6]*u.m)
+
+    t = time.Time([1,2], location=location, format='cxcsec')
 
     tree = {'time': t}
 

--- a/asdf/tags/time/tests/test_time.py
+++ b/asdf/tags/time/tests/test_time.py
@@ -7,7 +7,6 @@ import six
 import pytest
 import datetime
 from collections import OrderedDict
-from jsonschema import ValidationError
 
 astropy = pytest.importorskip('astropy')
 from astropy import time

--- a/asdf/tags/time/tests/test_time.py
+++ b/asdf/tags/time/tests/test_time.py
@@ -125,7 +125,7 @@ def test_isot(tmpdir):
 
 def test_time_tag():
     schema = asdf_schema.load_schema(
-        'http://stsci.edu/schemas/asdf/time/time-1.0.0',
+        'http://stsci.edu/schemas/asdf/time/time-1.1.0',
         resolve_references=True)
     schema = _flatten_combiners(schema)
 
@@ -136,7 +136,7 @@ def test_time_tag():
 
     asdf_schema.validate(instance, schema=schema)
 
-    tag = 'tag:stsci.edu:asdf/time/time-1.0.0'
+    tag = 'tag:stsci.edu:asdf/time/time-1.1.0'
     date = tagged.tag_object(tag, date)
     tree = {'date': date}
     asdf = AsdfFile(tree=tree)

--- a/asdf/tags/time/tests/test_time.py
+++ b/asdf/tags/time/tests/test_time.py
@@ -103,6 +103,15 @@ def test_time(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+def test_time_with_location(tmpdir):
+    # See https://github.com/spacetelescope/asdf/issues/341
+    t = time.Time([1,2], location=[[1,2], [3,4], [5,6]], format='cxcsec')
+
+    tree = {'time': t}
+
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
 def test_isot(tmpdir):
     tree = {
         'time': time.Time('2000-01-01T00:00:00.000')

--- a/asdf/tags/time/time.py
+++ b/asdf/tags/time/time.py
@@ -87,6 +87,7 @@ class TimeType(AsdfType):
     def from_tree(cls, node, ctx):
         from astropy import time
         from astropy import units as u
+        from astropy.units import Quantity
         from astropy.coordinates import EarthLocation
 
         if isinstance(node, (six.string_types, list, np.ndarray)):
@@ -101,6 +102,12 @@ class TimeType(AsdfType):
         scale = node.get('scale')
         location = node.get('location')
         if location is not None:
+            unit = location.get('unit', u.m)
+            # This ensures that we can read the v.1.0.0 schema and convert it
+            # to the new EarthLocation object, which expects Quantity components
+            for comp in ['x', 'y', 'z']:
+                if not isinstance(location[comp], Quantity):
+                    location[comp] = Quantity(location[comp], unit=unit)
             location = EarthLocation.from_geocentric(
                 location['x'], location['y'], location['z'])
 

--- a/asdf/tags/time/time.py
+++ b/asdf/tags/time/time.py
@@ -29,7 +29,8 @@ def _assert_earthlocation_equal(a, b):
     assert_array_equal(a.y, b.y)
     assert_array_equal(a.z, b.z)
     # This allows us to test against earlier versions of astropy
-    if version < '2.0.0':
+    # This code path does get tested in CI, but we don't run a coverage test
+    if version < '2.0.0': # pragma: no cover
         assert_array_equal(a.latitude, b.latitude)
         assert_array_equal(a.longitude, b.longitude)
     else:
@@ -84,7 +85,8 @@ class TimeType(AsdfType):
             x, y, z = node.location.x, node.location.y, node.location.z
             # Preserve backwards compatibility for writing the old schema
             # This allows WCS to test backwards compatibility with old frames
-            if cls.version == '1.0.0':
+            # This code does get tested in CI, but we don't run a coverage test
+            if cls.version == '1.0.0': # pragma: no cover
                 unit = node.location.unit
                 d['location'] = { 'x': x, 'y': y, 'z': z, 'unit': unit }
             else:

--- a/asdf/tags/time/time.py
+++ b/asdf/tags/time/time.py
@@ -24,11 +24,17 @@ _astropy_format_to_asdf_format = {
 
 
 def _assert_earthlocation_equal(a, b):
+    from astropy import __version__ as version
     assert_array_equal(a.x, b.x)
     assert_array_equal(a.y, b.y)
     assert_array_equal(a.z, b.z)
-    assert_array_equal(a.lat, b.lat)
-    assert_array_equal(a.lon, b.lon)
+    # This allows us to test against earlier versions of astropy
+    if version < '2.0.0':
+        assert_array_equal(a.latitude, b.latitude)
+        assert_array_equal(a.longitude, b.longitude)
+    else:
+        assert_array_equal(a.lat, b.lat)
+        assert_array_equal(a.lon, b.lon)
 
 
 class TimeType(AsdfType):

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -253,7 +253,7 @@ frames:
       - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: %f}
       - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: %f}
       - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: %f}
-      obstime: !time/time-1.0.0 2010-01-01 00:00:00.000
+      obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
     unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
 """ % (obsgeovel + obsgeoloc)
 


### PR DESCRIPTION
This fixes #341. Time objects from astropy are now serialized correctly when they have an `EarthLocation` attribute. The proper way to implement this fix was to update the time schema to `v1.1.0`, so this PR requires https://github.com/spacetelescope/asdf-standard/pull/147 to be merged first.

This change also supports backwards compatible writing with `time-1.0.0` in order to support tests for WCS to ensure backwards compatibility with the old frame format.