### PR TITLE
Remove unnecessary warning capture for supported_versions test

### DIFF
--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -552,8 +552,7 @@ flow_thing:
     assert type(new_data.tree['flow_thing']) == CustomFlow
 
     old_buff = helpers.yaml_to_asdf(old_yaml)
-    with catch_warnings() as warning:
-        old_data = asdf.AsdfFile.open(old_buff, extensions=CustomFlowExtension())
+    old_data = asdf.AsdfFile.open(old_buff, extensions=CustomFlowExtension())
     assert type(old_data.tree['flow_thing']) == CustomFlow
 
 def test_unsupported_version_warning():


### PR DESCRIPTION
Title says it all. This is a minor change, although it's possible that other commits could be added here before merge.