### PR TITLE
Remove astropy-1.1.2 from test matrix, add 1.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,8 @@ matrix:
         # try older astropy versions
         - env: PYTHON_VERSION=3.5
                NUMPY_VERSION=1.11 ASTROPY_VERSION=1.2.1 SETUP_CMD='test'
-        - env: PYTHON_VERSION=3.5
-               NUMPY_VERSION=1.11 ASTROPY_VERSION=1.1.2 SETUP_CMD='test'
         - env: NUMPY_VERSION=1.12 ASTROPY_VERSION=1.3.2 SETUP_CMD='test'
+        - env: NUMPY_VERSION=1.12 ASTROPY_VERSION=1.3.3 SETUP_CMD='test'
 
         # latest stable versions
         - env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,11 +22,6 @@ environment:
         platform: x64
 
       - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "1.3.2"
-        NUMPY_VERSION: "1.11.1"
-        platform: x64
-
-      - PYTHON_VERSION: "3.5"
         platform: x64
 
       - PYTHON_VERSION: "3.5"
@@ -35,6 +30,11 @@ environment:
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "1.3.2"
+        NUMPY_VERSION: "1.12.0"
+        platform: x64
+
+      - PYTHON_VERSION: "3.6"
+        ASTROPY_VERSION: "1.3.3"
         NUMPY_VERSION: "1.12.0"
         platform: x64
 


### PR DESCRIPTION
This also removes a test against astropy-1.3.2 using Python 3.5 from the appveyor matrix since it seems redundant.

This resolves #345.