### PR TITLE
Fix mechanism used to handle missing requirements for tag classes

### DIFF
--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -350,12 +350,14 @@ _all_asdftypes = set()
 
 def _from_tree_tagged_missing_requirements(cls, tree, ctx):
     # A special version of AsdfType.from_tree_tagged for when the
-    # required dependencies for an AsdfType are missing.  Shows a
-    # warning, and then returns the raw dictionary.
+    # required dependencies for an AsdfType are missing.
     plural = 's' if len(cls.requires) else ''
-    warnings.warn("{0} package{1} is required to instantiate '{2}'".format(
-        util.human_list(cls.requires), plural, tree._tag))
-    return tree
+    message = "{0} package{1} is required to instantiate '{2}'".format(
+        util.human_list(cls.requires), plural, tree._tag)
+    # This error will be handled by yamlutil.tagged_tree_to_custom_tree, which
+    # will cause a warning to be issued indicating that the tree failed to be
+    # converted.
+    raise TypeError(message)
 
 
 class ExtensionTypeMeta(type):

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -351,9 +351,9 @@ _all_asdftypes = set()
 def _from_tree_tagged_missing_requirements(cls, tree, ctx):
     # A special version of AsdfType.from_tree_tagged for when the
     # required dependencies for an AsdfType are missing.
-    plural = 's' if len(cls.requires) else ''
-    message = "{0} package{1} is required to instantiate '{2}'".format(
-        util.human_list(cls.requires), plural, tree._tag)
+    plural, verb = ('s', 'are') if len(cls.requires) else ('', 'is')
+    message = "{0} package{1} {2} required to instantiate '{3}'".format(
+        util.human_list(cls.requires), plural, verb, tree._tag)
     # This error will be handled by yamlutil.tagged_tree_to_custom_tree, which
     # will cause a warning to be issued indicating that the tree failed to be
     # converted.

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -160,8 +160,11 @@ def _assert_warnings(_warnings):
         assert len(_warnings) <= 1, helpers.display_warnings(_warnings)
         # Make sure the warning was the one we expected
         if len(_warnings) == 1:
-            assert str(_warnings[0].message).startswith(
-                    "gwcs and astropy-1.3.3 packages is required"), \
+            message = str(_warnings[0].message)
+            target_string = "gwcs and astropy-1.3.3 packages are required"
+            assert message.startswith('Failed to convert'), \
+                helpers.display_warnings(_warnings)
+            assert target_string in str(_warnings[0].message), \
                 helpers.display_warnings(_warnings)
     else:
         assert len(_warnings) == 0, helpers.display_warnings(_warnings)


### PR DESCRIPTION
Instead of directly issuing a warning and passing the raw node back in this case, raise an exception that will be handled by `tagged_tree_to_custom_tree`, which will then use the existing warning mechanism to indicate a failure to convert the tree. This is much cleaner since it reuses mechanisms that were recently improved; and it avoids some issues that occurred when running tests against older versions of astropy.

This also helps address an issue that was uncovered by PR #343 when running against older versions of astropy.