### PR TITLE
Fix issues with the type index for writing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,11 @@
 
 - Remove all remnants of support for Python 2.6. [#333]
 
+- Fix issues with the type index used for writing out ASDF files. This ensures
+  that items in the type index are not inadvertently overwritten by later
+  versions of the same type. It also makes sure that schema example tests run
+  against the correct version of the ASDF standard. [#350]
+
 1.2.1(2016-11-07)
 -----------------
 

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -81,6 +81,7 @@ class _AsdfWriteTypeIndex(object):
         self._version = version
 
         self._type_by_cls = {}
+        self._type_by_name = {}
         self._type_by_subclasses = {}
         self._types_with_dynamic_subclasses = {}
 
@@ -97,8 +98,9 @@ class _AsdfWriteTypeIndex(object):
 
         def add_by_tag(name, version):
             tag = join_tag_version(name, version)
-            if tag in index._type_by_tag:
+            if tag in index._type_by_tag and name not in self._type_by_name:
                 asdftype = index._type_by_tag[tag]
+                self._type_by_name[name] = asdftype
                 add_type(asdftype)
 
         if version == 'latest':

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -103,26 +103,24 @@ class _AsdfWriteTypeIndex(object):
                 self._type_by_name[name] = asdftype
                 add_type(asdftype)
 
-        if version == 'latest':
+        if self._version == 'latest':
             for name, versions in six.iteritems(index._versions_by_type_name):
-                version = versions[-1]
-                add_by_tag(name, version)
+                add_by_tag(name, versions[-1])
         else:
             try:
-                version_map = get_version_map(version)
+                version_map = get_version_map(self._version)
             except ValueError:
                 raise ValueError(
                     "Don't know how to write out ASDF version {0}".format(
-                        version))
+                        self._version))
 
-            for name, version in six.iteritems(version_map['tags']):
-                add_by_tag(name, AsdfVersion(version))
+            for name, _version in six.iteritems(version_map['tags']):
+                add_by_tag(name, AsdfVersion(_version))
 
             # Now add any extension types that aren't known to the ASDF standard
             for name, versions in six.iteritems(index._versions_by_type_name):
                 if name not in version_map:
-                    version = versions[-1]
-                    add_by_tag(name, version)
+                    add_by_tag(name, versions[-1])
 
         for asdftype in index._unnamed_types:
             add_type(asdftype)

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -98,7 +98,7 @@ class _AsdfWriteTypeIndex(object):
 
         def add_by_tag(name, version):
             tag = join_tag_version(name, version)
-            if tag in index._type_by_tag and name not in self._type_by_name:
+            if tag in index._type_by_tag:
                 asdftype = index._type_by_tag[tag]
                 self._type_by_name[name] = asdftype
                 add_type(asdftype)
@@ -119,7 +119,7 @@ class _AsdfWriteTypeIndex(object):
 
             # Now add any extension types that aren't known to the ASDF standard
             for name, versions in six.iteritems(index._versions_by_type_name):
-                if name not in version_map:
+                if name not in self._type_by_name:
                     add_by_tag(name, versions[-1])
 
         for asdftype in index._unnamed_types:

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -200,7 +200,7 @@ def assert_roundtrip_tree(
             server.finalize()
 
 
-def yaml_to_asdf(yaml_content, yaml_headers=True):
+def yaml_to_asdf(yaml_content, yaml_headers=True, standard_version=None):
     """
     Given a string of YAML content, adds the extra pre-
     and post-amble to make it an ASDF file.
@@ -222,12 +222,16 @@ def yaml_to_asdf(yaml_content, yaml_headers=True):
 
     buff = io.BytesIO()
 
+    if standard_version is None:
+        standard_version = versioning.default_version
+
     if yaml_headers:
         buff.write("""#ASDF {0}
+#ASDF_STANDARD {1}
 %YAML 1.1
 %TAG ! tag:stsci.edu:asdf/
 --- !core/asdf-{0}
-""".format('1.0.0').encode('ascii'))
+""".format('1.0.0', standard_version).encode('ascii'))
     buff.write(yaml_content)
     if yaml_headers:
         buff.write(b"\n...\n")

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -168,8 +168,8 @@ def _assert_warnings(_warnings):
         assert len(_warnings) == 0, helpers.display_warnings(_warnings)
 
 def _find_standard_version(filename):
-    components = filename[filename.find('schemas/'):].split(os.path.sep)
-    tag = 'tag:{}:{}'.format(components[1], os.path.sep.join(components[2:]))
+    components = filename[filename.find('schemas') + 1:].split(os.path.sep)
+    tag = 'tag:{}:{}'.format(components[1], '/'.join(components[2:]))
     name, version = asdftypes.split_tag_version(tag.replace('.yaml', ''))
 
     for sv in versioning.supported_versions:


### PR DESCRIPTION
There were several issues with the type index used for writing ASDF file. These bugs were causing issues that were exposed in PR #343. This PR fixes those issues. 

One of the main problems was that items in the type index for earlier versions of the standard (i.e. `1.0.0`) were being overwritten by more recent version of the same type. This meant that files that used the earlier version of the standard were not being validated properly.

Also, this PR make sure that all of the tests of examples in schema files run against the appropriate version of the ASDF standard. It is not enough to assume in all cases that the examples can be tested against the latest version of the standard.