### PR TITLE
Allow ASDF tree to be accessed from top-level AsdfFile object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@
 - Add ``copy_arrays`` option to ``asdf.open`` to control whether or not
   underlying array data should be memory mapped, if possible. [#355]
 
+- Allow the tree to be accessed using top-level ``__getitem__`` and
+  ``__setitem__``. [#352]
+
 1.2.1(2016-11-07)
 -----------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -264,6 +264,12 @@ class AsdfFile(versioning.VersionedMixin):
         self._validate(asdf_object)
         self._tree = asdf_object
 
+    def __getitem__(self, key):
+        return self._tree[key]
+
+    def __setitem__(self, key, value):
+        self._tree[key] = value
+
     @property
     def comments(self):
         """

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -19,6 +19,7 @@ from .. import block
 from .. import constants
 from .. import generic_io
 from .. import treeutil
+from ..tests.helpers import assert_tree_match
 
 
 def _get_small_tree():
@@ -1162,3 +1163,13 @@ def test_fd_not_seekable():
     # We lost the information about the underlying array type,
     # but still can compare the bytes.
     assert b.data.tobytes() == data.tobytes()
+
+
+def test_top_level_tree():
+    tree = {'tree': _get_small_tree()}
+    ff = asdf.AsdfFile(tree)
+    assert_tree_match(ff.tree['tree'], ff['tree'])
+
+    ff2 = asdf.AsdfFile()
+    ff2['tree'] = _get_small_tree()
+    assert_tree_match(ff2.tree['tree'], ff2['tree'])


### PR DESCRIPTION
This provides a convenient shortcut for accessing the ASDF tree:
```python
import asdf

tree = {'a': 10, 'b': 'foo'}
af = asdf.AsdfFile(tree)
assert af['a'] == af.tree['a']
```

This resolves #339.