### PR TITLE
Use generic setup_conda script from ci-helpers for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - source ci-helpers/travis/setup_conda.sh
 
 script:
    - python setup.py $SETUP_CMD


### PR DESCRIPTION
This will allow us to take advantage of some magic like `skip travis`, or `docs only`, or cron, etc.