### PR TITLE
Add copy option to asdf.open

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,9 @@
 - Update time schema to reflect changes in astropy. This fixes an outstanding
   bug. [#343]
 
+- Add ``copy`` option to ``asdf.open`` to control whether or not underlying
+  block data should be memory mapped, if possible. [#355]
+
 1.2.1(2016-11-07)
 -----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,8 +63,8 @@
 - Update time schema to reflect changes in astropy. This fixes an outstanding
   bug. [#343]
 
-- Add ``copy`` option to ``asdf.open`` to control whether or not underlying
-  block data should be memory mapped, if possible. [#355]
+- Add ``copy_arrays`` option to ``asdf.open`` to control whether or not
+  underlying array data should be memory mapped, if possible. [#355]
 
 1.2.1(2016-11-07)
 -----------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -43,7 +43,8 @@ class AsdfFile(versioning.VersionedMixin):
     The main class that represents a ASDF file.
     """
     def __init__(self, tree=None, uri=None, extensions=None, version=None,
-        ignore_version_mismatch=True, ignore_unrecognized_tag=False):
+        ignore_version_mismatch=True, ignore_unrecognized_tag=False,
+        copy=False):
         """
         Parameters
         ----------
@@ -74,6 +75,10 @@ class AsdfFile(versioning.VersionedMixin):
         ignore_unrecognized_tag : bool, optional
             When `True`, do not raise warnings for unrecognized tags. Set to
             `False` by default.
+
+        copy : bool, optional
+            When `False`, when reading files, attempt to memmap underlying data
+            arrays when possible.
         """
 
         if extensions is None or extensions == []:
@@ -92,7 +97,7 @@ class AsdfFile(versioning.VersionedMixin):
 
         self._fd = None
         self._external_asdf_by_uri = {}
-        self._blocks = block.BlockManager(self)
+        self._blocks = block.BlockManager(self, copy=copy)
         self._uri = None
         if tree is None:
             self.tree = {}
@@ -536,7 +541,8 @@ class AsdfFile(versioning.VersionedMixin):
              do_not_fill_defaults=False,
              ignore_version_mismatch=True,
              ignore_unrecognized_tag=False,
-             _force_raw_types=False):
+             _force_raw_types=False,
+             copy=False):
         """
         Open an existing ASDF file.
 
@@ -581,7 +587,8 @@ class AsdfFile(versioning.VersionedMixin):
         """
         self = cls(extensions=extensions,
                    ignore_version_mismatch=ignore_version_mismatch,
-                   ignore_unrecognized_tag=ignore_unrecognized_tag)
+                   ignore_unrecognized_tag=ignore_unrecognized_tag,
+                   copy=copy)
 
         return cls._open_impl(
             self, fd, uri=uri, mode=mode,

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -44,7 +44,7 @@ class AsdfFile(versioning.VersionedMixin):
     """
     def __init__(self, tree=None, uri=None, extensions=None, version=None,
         ignore_version_mismatch=True, ignore_unrecognized_tag=False,
-        copy=False):
+        copy_arrays=False):
         """
         Parameters
         ----------
@@ -76,7 +76,7 @@ class AsdfFile(versioning.VersionedMixin):
             When `True`, do not raise warnings for unrecognized tags. Set to
             `False` by default.
 
-        copy : bool, optional
+        copy_arrays : bool, optional
             When `False`, when reading files, attempt to memmap underlying data
             arrays when possible.
         """
@@ -97,7 +97,7 @@ class AsdfFile(versioning.VersionedMixin):
 
         self._fd = None
         self._external_asdf_by_uri = {}
-        self._blocks = block.BlockManager(self, copy=copy)
+        self._blocks = block.BlockManager(self, copy_arrays=copy_arrays)
         self._uri = None
         if tree is None:
             self.tree = {}
@@ -542,7 +542,7 @@ class AsdfFile(versioning.VersionedMixin):
              ignore_version_mismatch=True,
              ignore_unrecognized_tag=False,
              _force_raw_types=False,
-             copy=False):
+             copy_arrays=False):
         """
         Open an existing ASDF file.
 
@@ -580,6 +580,10 @@ class AsdfFile(versioning.VersionedMixin):
             When `True`, do not raise warnings for unrecognized tags. Set to
             `False` by default.
 
+        copy_arrays : bool, optional
+            When `False`, when reading files, attempt to memmap underlying data
+            arrays when possible.
+
         Returns
         -------
         asdffile : AsdfFile
@@ -588,7 +592,7 @@ class AsdfFile(versioning.VersionedMixin):
         self = cls(extensions=extensions,
                    ignore_version_mismatch=ignore_version_mismatch,
                    ignore_unrecognized_tag=ignore_unrecognized_tag,
-                   copy=copy)
+                   copy_arrays=copy_arrays)
 
         return cls._open_impl(
             self, fd, uri=uri, mode=mode,

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -33,7 +33,7 @@ class BlockManager(object):
     """
     Manages the `Block`s associated with a ASDF file.
     """
-    def __init__(self, asdffile, copy=False):
+    def __init__(self, asdffile, copy_arrays=False):
         self._asdffile = weakref.ref(asdffile)
 
         self._internal_blocks = []
@@ -50,7 +50,7 @@ class BlockManager(object):
 
         self._data_to_block_mapping = {}
         self._validate_checksums = False
-        self._memmap = not copy
+        self._memmap = not copy_arrays
 
     def __len__(self):
         """

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -1108,7 +1108,7 @@ def test_open_no_memmap(tmpdir):
         assert isinstance(array.block._data, np.memmap)
 
     # Test that if we ask for copy, we do not get memmapped arrays
-    with asdf.AsdfFile.open(tmpfile, copy=True) as af:
+    with asdf.AsdfFile.open(tmpfile, copy_arrays=True) as af:
         array = af.tree['array']
         x = array[0]
         assert array.block._memmapped == False

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -1089,6 +1089,34 @@ def test_dots_but_no_block_index():
         assert len(ff.blocks) == 1
 
 
+def test_open_no_memmap(tmpdir):
+    tmpfile = os.path.join(str(tmpdir), 'random.asdf')
+
+    tree = {
+        'array': np.random.random((20, 20))
+    }
+
+    ff = asdf.AsdfFile(tree)
+    ff.write_to(tmpfile)
+
+    # Test that by default we use memmapped arrays when possible
+    with asdf.AsdfFile.open(tmpfile) as af:
+        array = af.tree['array']
+        # Make sure to access the block so that it gets loaded
+        x = array[0]
+        assert array.block._memmapped == True
+        assert isinstance(array.block._data, np.memmap)
+
+    # Test that if we ask for copy, we do not get memmapped arrays
+    with asdf.AsdfFile.open(tmpfile, copy=True) as af:
+        array = af.tree['array']
+        x = array[0]
+        assert array.block._memmapped == False
+        # We can't just check for isinstance(..., np.array) since this will
+        # be true for np.memmap as well
+        assert not isinstance(array.block._data, np.memmap)
+
+
 def test_invalid_version(tmpdir):
     content = b"""#ASDF 0.1.0
 %YAML 1.1


### PR DESCRIPTION
This resolves #226 and allows callers to optionally specify that underlying data blocks should not be memory mapped. Memory mapping is not possible under all circumstances (e.g. when an array is compressed), but is enabled by default if it is possible. Using `copy=True` will ensure that the array is **not** memory mapped, even if it is possible.

This does not affect ASDF-in-FITS since apparently memory mapping of FITS files depends on the HDUs and keywords that are present, so it is out of our control.