### PR TITLE
CI script update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,7 @@ matrix:
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
-
         - env: SETUP_CMD='build_docs -w'
-
-        # Try older numpy versions
-        - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test'
-
-        - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10 SETUP_CMD='test'
 
         # try older astropy versions
         - env: PYTHON_VERSION=3.5
@@ -60,6 +53,9 @@ matrix:
 
         # latest stable versions
         - env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
+
+        # Test against development version of numpy (failure allowed)
+        - env: NUMPY_VERSION=development SETUP_CMD='test'
 
         # Try a run on OSX
         - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,15 @@ matrix:
         # latest stable versions
         - env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
 
-        # Test against development version of numpy (failure allowed)
+        # Test against development version of numpy (this job can fail)
         - env: NUMPY_VERSION=development SETUP_CMD='test'
 
         # Try a run on OSX
         - os: osx
           env: NUMPY_VERSION=stable ASTROPY_VERSION=stable SETUP_CMD='test'
+
+    allow_failures:
+        - env: NUMPY_VERSION=development SETUP_CMD='test'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,6 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        platform: x86
-        PYTHON_ARCH: "32"
-
-      - PYTHON_VERSION: "2.7"
         platform: x64
 
       - PYTHON_VERSION: "3.5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,10 +41,15 @@ environment:
         ASTROPY_VERSION: "development"
         platform: x64
 
+      # Tests against development version of numpy may fail
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "development"
         NUMPY_VERSION: "development"
         platform: x64
+
+matrix:
+  allow_failures:
+    - NUMPY_VERSION: "development"
 
 install:
     - "git clone git://github.com/astropy/ci-helpers.git"


### PR DESCRIPTION
Start to scale back tests against Py2. Also run tests against development version of `numpy`. These tests are allowed to fail.