### PR TITLE
Fix bug when duplicating inline arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Fix bug when retrieving file format version from new ASDF file. [#365]
 
+- Fix bug when duplicating inline arrays. [#370]
+
 1.3.0 (2017-10-24)
 ------------------
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -645,6 +645,10 @@ class BlockManager(object):
             block = asdffile.blocks._internal_blocks[0]
             self.set_array_storage(block, 'external')
 
+        # Handle the case of inline data
+        elif isinstance(source, list):
+            block = Block(data=np.array(source), array_storage='inline')
+
         else:
             raise TypeError("Unknown source '{0}'".format(source))
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -211,6 +211,21 @@ def test_auto_inline_recursive(tmpdir):
         tree, tmpdir, check_asdf, None, {'auto_inline': 64})
 
 
+def test_copy_inline():
+    yaml = """
+x0: !core/ndarray-1.0.0
+  data: [-1.0, 1.0]
+    """
+
+    buff = helpers.yaml_to_asdf(yaml)
+
+    with asdf.AsdfFile.open(buff) as infile:
+        with asdf.AsdfFile() as f:
+            f.tree['a'] = infile.tree['x0']
+            f.tree['b'] = f.tree['a']
+            f.write_to(io.BytesIO())
+
+
 def test_table(tmpdir):
     table = np.array(
         [(0, 1, (2, 3)), (4, 5, (6, 7))],


### PR DESCRIPTION
This makes sure that inline arrays are handled properly by `get_block`, so that they can be duplicated within a file and written out properly. This fixes #368. Thanks @bobpepin for the bug report.