### PR TITLE
Resolve tag references that use tag URI scheme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Fix bug when duplicating inline arrays. [#370]
 
+- Allow tag references using the tag URI scheme to be resolved in schema files.
+  [#371]
+
 1.3.0 (2017-10-24)
 ------------------
 

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -104,7 +104,11 @@ DEFAULT_URL_MAPPING = [
     (constants.STSCI_SCHEMA_URI_BASE,
      util.filepath_to_url(
          os.path.join(SCHEMA_PATH, 'stsci.edu')) +
-         '/{url_suffix}.yaml')]
+         '/{url_suffix}.yaml'),
+    ('tag:stsci.edu:asdf/',
+     util.filepath_to_url(
+         os.path.join(SCHEMA_PATH, 'stsci.edu')) +
+         '/asdf/{url_suffix}.yaml')]
 
 
 default_url_mapping = Resolver(DEFAULT_URL_MAPPING, 'url')

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -361,7 +361,7 @@ def load_schema(url, resolver=None, resolve_references=False):
             if json_id is None:
                 json_id = url
             if isinstance(node, dict) and '$ref' in node:
-                suburl = generic_io.resolve_uri(json_id, node['$ref'])
+                suburl = generic_io.resolve_uri(json_id, resolver(node['$ref']))
                 parts = urlparse.urlparse(suburl)
                 fragment = parts.fragment
                 if len(fragment):

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -96,6 +96,76 @@ def test_read_json_schema():
     schema.check_schema(schema_tree)
 
 
+def test_load_schema(tmpdir):
+    schema_def = """
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/asdf/nugatory/nugatory-1.0.0"
+tag: "tag:stsci.edu:asdf/nugatory/nugatory-1.0.0"
+
+type: object
+properties:
+  foobar:
+      $ref: "../core/ndarray-1.0.0"
+
+required: [foobar]
+...
+    """
+    schema_path = tmpdir.join('nugatory.yaml')
+    schema_path.write(schema_def.encode())
+
+    schema_tree = schema.load_schema(str(schema_path), resolve_references=True)
+    schema.check_schema(schema_tree)
+
+
+def test_load_schema_with_full_tag(tmpdir):
+    schema_def = """
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/asdf/nugatory/nugatory-1.0.0"
+tag: "tag:stsci.edu:asdf/nugatory/nugatory-1.0.0"
+
+type: object
+properties:
+  foobar:
+      $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+
+required: [foobar]
+...
+    """
+    schema_path = tmpdir.join('nugatory.yaml')
+    schema_path.write(schema_def.encode())
+
+    schema_tree = schema.load_schema(str(schema_path), resolve_references=True)
+    schema.check_schema(schema_tree)
+
+
+def test_load_schema_with_tag_address(tmpdir):
+    schema_def = """
+%YAML 1.1
+%TAG !asdf! tag:stsci.edu:asdf/
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://stsci.edu/schemas/asdf/nugatory/nugatory-1.0.0"
+tag: "tag:stsci.edu:asdf/nugatory/nugatory-1.0.0"
+
+type: object
+properties:
+  foobar:
+      $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+
+required: [foobar]
+...
+    """
+    schema_path = tmpdir.join('nugatory.yaml')
+    schema_path.write(schema_def.encode())
+
+    schema_tree = schema.load_schema(str(schema_path), resolve_references=True)
+    schema.check_schema(schema_tree)
+
+
 def test_schema_caching():
     # Make sure that if we request the same URL, we get the *exact
     # same* object, to ensure the cache is working.

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -4,13 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import io
-
-try:
-    import astropy
-except ImportError:
-    HAS_ASTROPY = False
-else:
-    HAS_ASTROPY = True
+from collections import OrderedDict
 
 import numpy as np
 
@@ -19,8 +13,6 @@ import pytest
 import six
 
 import yaml
-
-from collections import OrderedDict
 
 from .. import asdf
 from .. import tagged
@@ -129,23 +121,19 @@ def test_tags_removed_after_load(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check_asdf)
 
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_explicit_tags():
-
-    yaml = """#ASDF 1.0.0
+    yaml = """#ASDF {}
 %YAML 1.1
 --- !<tag:stsci.edu:asdf/core/asdf-1.0.0>
-unit: !<tag:stsci.edu:asdf/unit/unit-1.0.0> m
+foo: !<tag:stsci.edu:asdf/core/ndarray-1.0.0> [1, 2, 3]
 ...
-    """
-    from astropy import units as u
+    """.format(asdf.versioning.default_version)
 
-    # Check that fully-qualified explicit tags work
-
+    # Check that fully qualified explicit tags work
     buff = helpers.yaml_to_asdf(yaml, yaml_headers=False)
-    ff = asdf.AsdfFile.open(buff)
 
-    assert isinstance(ff.tree['unit'], u.UnitBase)
+    with asdf.AsdfFile.open(buff) as ff:
+        assert all(ff.tree['foo'] == [1, 2, 3])
 
 
 def test_yaml_internal_reference(tmpdir):


### PR DESCRIPTION
This fixes #367 and allows tag references that use the tag URI scheme to be properly resolved in schema files.