### PR TITLE
Update usage of astropy test infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,16 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4'
         - PIP_DEPENDENCIES_FLAGS='--no-deps --force'
-        - PIP_DEPENDENCIES='git+http://github.com/spacetelescope/gwcs.git#egg=gwcs'
+        - GWCS_GIT='git+http://github.com/spacetelescope/gwcs.git#egg=gwcs'
+        - PIP_DEPENDENCIES="$GWCS_GIT"
         - SETUP_CMD='test --remote-data'
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='test'
         - PYTHON_VERSION=3.5 SETUP_CMD='test' ASTROPY_VERSION=development
+          PIP_DEPENDENCIES="$GWCS_GIT pytest-astropy"
         - PYTHON_VERSION=3.6 SETUP_CMD='test' ASTROPY_VERSION=development
+          PIP_DEPENDENCIES="$GWCS_GIT pytest-astropy"
 
 matrix:
     include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ environment:
       NUMPY_VERSION: "stable"
       ASTROPY_VERSION: "stable"
       CONDA_DEPENDENCIES: "semantic_version jsonschema pyyaml six lz4"
-      PIP_DEPENDENCIES: "git+http://github.com/spacetelescope/gwcs.git#egg=gwcs"
+      GWCS_GIT: "git+http://github.com/spacetelescope/gwcs.git#egg=gwcs"
+      PIP_DEPENDENCIES: "%GWCS_GIT%"
       PYTHON_ARCH: "64"
 
   matrix:
@@ -22,6 +23,7 @@ environment:
 
       - PYTHON_VERSION: "3.5"
         ASTROPY_VERSION: "development"
+        PIP_DEPENDENCIES: "%GWCS_GIT% pytest-astropy"
         platform: x64
 
       - PYTHON_VERSION: "3.6"
@@ -39,12 +41,14 @@ environment:
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "development"
+        PIP_DEPENDENCIES: "%GWCS_GIT% pytest-astropy"
         platform: x64
 
       # Tests against development version of numpy may fail
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "development"
         NUMPY_VERSION: "development"
+        PIP_DEPENDENCIES: "%GWCS_GIT% pytest-astropy"
         platform: x64
 
 matrix:

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -1,5 +1,4 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
@@ -14,10 +13,16 @@ try:
 except ImportError:
     ICRS = None
 
-try:
+# Attempt to maintain backwards compatibility withearlier versions of astropy
+from astropy import __version__ as astropy_version
+if astropy_version < '3.0':
+    import astropy
     from astropy.tests.disable_internet import INTERNET_OFF
-except ImportError:
-    INTERNET_OFF = False
+    remote_data = astropy.tests.helper.remote_data
+else:
+    import pytest
+    from pytest_remotedata.disable_internet import INTERNET_OFF
+    remote_data = pytest.mark.remote_data
 
 try:
     from astropy.coordinates.representation import CartesianRepresentation

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -20,14 +20,6 @@ from .. import util
 
 from . import helpers
 
-try:
-    from astropy.io import fits
-    from astropy.tests.disable_internet import INTERNET_OFF
-    HAS_ASTROPY = True
-except ImportError:
-    HAS_ASTROPY = False
-    INTERNET_OFF = False
-
 
 def _get_small_tree():
     x = np.arange(0, 10, dtype=np.float)
@@ -253,7 +245,7 @@ def test_streams2():
     assert len(x) == 60
 
 
-@pytest.mark.skipif(INTERNET_OFF, reason="Astropy has disabled internet access")
+@helpers.remote_data
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     reason="Windows firewall prevents test")
 def test_urlopen(tree, httpserver):
@@ -273,7 +265,7 @@ def test_urlopen(tree, httpserver):
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.ndarray)
 
 
-@pytest.mark.skipif(INTERNET_OFF, reason="Astropy has disabled internet access")
+@helpers.remote_data
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     reason="Windows firewall prevents test")
 def test_http_connection(tree, httpserver):
@@ -298,7 +290,7 @@ def test_http_connection(tree, httpserver):
         ff.tree['science_data'][0] == 42
 
 
-@pytest.mark.skipif(INTERNET_OFF, reason="Astropy has disabled internet access")
+@helpers.remote_data
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     reason="Windows firewall prevents test")
 def test_http_connection_range(tree, rhttpserver):
@@ -363,6 +355,7 @@ def test_exploded_filesystem_fail(tree, tmpdir):
                 helpers.assert_tree_match(tree, ff.tree)
 
 
+@helpers.remote_data
 @pytest.mark.skipif(sys.platform.startswith('win'),
                     reason="Windows firewall prevents test")
 def test_exploded_http(tree, httpserver):
@@ -795,12 +788,14 @@ def test_truncated_reader():
     assert tr.read() == b''
 
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_is_asdf(tmpdir):
     # test fits
+    astropy = pytest.importorskip('astropy')
+    from astropy.io import fits
+
     hdul = fits.HDUList()
-    phdu=fits.PrimaryHDU()
-    imhdu=fits.ImageHDU(data=np.arange(24).reshape((4,6)))
+    phdu= fits.PrimaryHDU()
+    imhdu= fits.ImageHDU(data=np.arange(24).reshape((4,6)))
     hdul.append(phdu)
     hdul.append(imhdu)
     path = os.path.join(str(tmpdir), 'test.fits')

--- a/asdf/tests/test_remote_data.py
+++ b/asdf/tests/test_remote_data.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import pytest
 
 astropy = pytest.importorskip('astropy')
-from astropy.tests.helper import remote_data
-from astropy.tests.disable_internet import INTERNET_OFF
+from .helpers import remote_data, INTERNET_OFF
 
 _REMOTE_DATA = False
 


### PR DESCRIPTION
This update handles the changes that were introduced to astropy's test infrastructure in https://github.com/astropy/astropy/pull/6606. It makes sure that the appropriate test dependencies are installed on the CI servers.

In the long term, we may want to find an alternative to the use of `INTERNET_OFF` in the `assert_tree_match`.

This fixes #375.