### PR TITLE
Enable strict remote data checking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
+remote_data_strict = True
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
When using the latest version of astropy, and therefore the `pytest-remotedata` plugin, it is necessary to explicitly enable strict testing of remote data access. When strict testing is enabled, it means that any test will fail that attempts to access the internet but is not marked with `@remote_data`. This was the behavior previously expected by ASDF, and we want to preserve it now.

Setting this option in `setup.cfg` will have no affect on earlier versions of asdf and astropy.

This should fix the recent test failures that appeared on the nightly cron jobs.