### PR TITLE
Test numpy array with dtype=object

### DIFF
--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -786,3 +786,26 @@ def test_inline_shape_mismatch():
     with pytest.raises(ValueError):
         with asdf.AsdfFile.open(buff) as ff:
             pass
+
+
+@pytest.mark.xfail(
+    reason="NDArrays with dtype=object are not currently supported")
+def test_simple_object_array(tmpdir):
+    dictdata = np.empty((3, 3), dtype=object)
+    for i, _ in enumerate(dictdata.flat):
+        dictdata.flat[i] = {'foo': i*42, 'bar': i**2}
+
+    helpers.assert_roundtrip_tree({'bizbaz': dictdata}, tmpdir)
+
+
+@pytest.mark.xfail(
+    reason="NDArrays with dtype=object are not currently supported")
+def test_tagged_object_array(tmpdir):
+    astropy = pytest.importorskip('astropy')
+    from astropy.units.quantity import Quantity
+
+    objdata = np.empty((3, 3), dtype=object)
+    for i, _ in enumerate(objdata.flat):
+        objdata.flat[i] = Quantity(i, 'angstrom')
+
+    helpers.assert_roundtrip_tree({'bizbaz': objdata}, tmpdir)

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -779,6 +779,8 @@ def test_inline_shape_mismatch():
 @pytest.mark.xfail(
     reason="NDArrays with dtype=object are not currently supported")
 def test_simple_object_array(tmpdir):
+    # See https://github.com/spacetelescope/asdf/issues/383 for feature
+    # request
     dictdata = np.empty((3, 3), dtype=object)
     for i, _ in enumerate(dictdata.flat):
         dictdata.flat[i] = {'foo': i*42, 'bar': i**2}
@@ -789,6 +791,8 @@ def test_simple_object_array(tmpdir):
 @pytest.mark.xfail(
     reason="NDArrays with dtype=object are not currently supported")
 def test_tagged_object_array(tmpdir):
+    # See https://github.com/spacetelescope/asdf/issues/383 for feature
+    # request
     astropy = pytest.importorskip('astropy')
     from astropy.units.quantity import Quantity
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -8,22 +8,8 @@ import os
 import re
 import sys
 
-try:
-    import psutil
-except ImportError:
-    HAS_PSUTIL = False
-else:
-    HAS_PSUTIL = True
-
 import six
 import pytest
-
-try:
-    import astropy
-except ImportError:
-    HAS_ASTROPY = False
-else:
-    HAS_ASTROPY = True
 
 import numpy as np
 from numpy import ma
@@ -198,9 +184,10 @@ def test_table_inline(tmpdir):
         tree, tmpdir, None, check_raw_yaml, {'auto_inline': 64})
 
 
-@pytest.mark.skipif('not HAS_ASTROPY')
 def test_auto_inline_recursive(tmpdir):
+    astropy = pytest.importorskip('astropy')
     from astropy.modeling import models
+
     aff = models.AffineTransformation2D(matrix=[[1, 2], [3, 4]])
     tree = {'test': aff}
 
@@ -457,8 +444,9 @@ def test_inline_masked_array(tmpdir):
         assert b'null' in fd.read()
 
 
-@pytest.mark.skipif(not HAS_PSUTIL, reason="psutil not installed")
 def test_masked_array_stay_open_bug(tmpdir):
+    psutil = pytest.importorskip('psutil')
+
     tmppath = os.path.join(str(tmpdir), 'masked.asdf')
 
     tree = {


### PR DESCRIPTION
@Cadair has pointed out that it is not currently possible to serialize a `numpy` array with `dtype=object`. Consider the following  code example, which does not currently work:

```python
import asdf
import numpy as np

data = np.empty((10, 10), dtype=object)
for i, _ in enumerate(data.flat):
    data.flat[i] = SomeObject(i, foo, 42)

af = asdf.AsdfFile({'data': data})
af.write_to('data.asdf')
```

In principle, it seems possible to support inline `ndarray`s that contain arbitrary object data. We should discuss whether this should be supported. In the meantime, this PR introduces unit tests that demonstrate the kind of functionality that would be expected. They are currently marked with `pytest.mark.xfail` since they will not pass.

See [this PR](https://github.com/spacetelescope/asdf-standard/pull/148) in `asdf-standard` for the kind of change that might be required to the `ndarray` schema.