### PR TITLE
Install and load extensions using setuptools entry points

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
         - NUMPY_VERSION=stable
         - CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4'
         - GWCS_GIT='git+git://github.com/spacetelescope/gwcs.git#egg=gwcs'
-        - PIP_DEPENDENCIES="$GWCS_GIT pytest-astropy"
         - SETUP_CMD='test --remote-data'
 
     matrix:
@@ -63,6 +62,9 @@ matrix:
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
+    - python -m pip install --no-deps $GWCS_GIT
+    - python -m pip install pytest-astropy
+    - python setup.py install
 
 script:
    - python setup.py $SETUP_CMD

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - Astropy-specific tags have moved to Astropy core package. [#359]
 
+1.4.0 (unreleased)
+------------------
+
+- Install and load extensions using ``setuptools`` entry points. [#384]
+
 1.3.2 (unreleased)
 ------------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ environment:
       ASTROPY_VERSION: "development"
       GWCS_GIT: "git+git://github.com/spacetelescope/gwcs.git#egg=gwcs"
       CONDA_DEPENDENCIES: "semantic_version jsonschema pyyaml six lz4"
-      PIP_DEPENDENCIES: "%GWCS_GIT% pytest-astropy"
       PYTHON_ARCH: "64"
 
   matrix:
@@ -25,6 +24,7 @@ environment:
       - PYTHON_VERSION: "3.6"
         platform: x64
 
+      # Tests against development version of numpy may fail
       - PYTHON_VERSION: "3.6"
         NUMPY_VERSION: "development"
         platform: x64
@@ -36,9 +36,12 @@ matrix:
 install:
     - "git clone git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+    - "git submodule update --init asdf-standard"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
-    - "git submodule update --init asdf-standard"
+    - "%CMD_IN_ENV% python -m pip install --no-deps %GWCS_GIT%"
+    - "%CMD_IN_ENV% python -m pip install pytest-astropy"
+    - "%CMD_IN_ENV% python setup.py develop --no-deps"
 
 # Not a .NET project
 build: false

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,9 @@ entry_points = {}
 entry_points['console_scripts'] = [
     'asdftool = asdf.commands.main:main',
 ]
+entry_points['asdf_extensions'] = [
+    'builtin = asdf.extension:BuiltinExtension'
+]
 
 # Add the dependencies which are not strictly needed but enable otherwise skipped tests
 extra_requires = []


### PR DESCRIPTION
This closes #378. It allows ASDF extensions to be installed and loaded using `setuptools` entry points. ASDF's own `BuiltinExtension` is now installed this way. Other packages, such as `gwcs` or `astropy` that provide ASDF extensions should use entry points to install their own extensions.

cc @Cadair