### PR TITLE
Update astropy version in CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - PYTHON_VERSION=3.6
+        - ASTROPY_VERSION=development
         - NUMPY_VERSION=stable
         - CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4'
         - GWCS_GIT='git+git://github.com/spacetelescope/gwcs.git#egg=gwcs'
-        - ASTROPY_GIT='git+git://github.com/drdavella/astropy.git@integrate-asdf#egg=astropy'
-        - PIP_DEPENDENCIES="$GWCS_GIT $ASTROPY_GIT pytest-astropy"
+        - PIP_DEPENDENCIES="$GWCS_GIT pytest-astropy"
         - SETUP_CMD='test --remote-data'
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,10 @@ environment:
       MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       NUMPY_VERSION: "stable"
-      ASTROPY_VERSION: "stable"
+      ASTROPY_VERSION: "development"
       GWCS_GIT: "git+git://github.com/spacetelescope/gwcs.git#egg=gwcs"
-      ASTROPY_GIT: "git+git://github.com/drdavella/astropy.git@integrate-asdf"
       CONDA_DEPENDENCIES: "semantic_version jsonschema pyyaml six lz4"
-      PIP_DEPENDENCIES: "%GWCS_GIT% %ASTROPY_GIT% pytest-astropy"
+      PIP_DEPENDENCIES: "%GWCS_GIT% pytest-astropy"
       PYTHON_ARCH: "64"
 
   matrix:
@@ -28,7 +27,6 @@ environment:
 
       - PYTHON_VERSION: "3.6"
         NUMPY_VERSION: "development"
-        PIP_DEPENDENCIES: "%GWCS_GIT% pytest-astropy"
         platform: x64
 
 matrix:


### PR DESCRIPTION
It's not longer necessary to provide a link to the branch in Astropy where ASDF tags were added. However, we are required to use the development version of Astropy for all builds now.