### PR TITLE
Allow foreign tags to be resolved in schemas and files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
 
 - Automatically initialize ``asdf-standard`` submodule in ``setup.py``. [#398]
 
+- Allow foreign tags to be resolved in schemas and files. Deprecate
+  ``tag_to_schema_resolver`` property for ``AsdfFile`` and
+  ``AsdfExtensionList``. [#399]
+
 1.3.2 (unreleased)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -193,6 +193,9 @@ class AsdfFile(versioning.VersionedMixin):
     def url_mapping(self):
         return self._extensions.url_mapping
 
+    def resolver(self, uri):
+        return self.url_mapping(self.tag_to_schema_resolver(uri))
+
     @property
     def type_index(self):
         return self._extensions.type_index

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -3,10 +3,11 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-import datetime
-import copy
 import io
 import re
+import copy
+import datetime
+import warnings
 import importlib
 
 import numpy as np
@@ -21,6 +22,7 @@ from . import util
 from . import version
 from . import versioning
 from . import yamlutil
+from .exceptions import AsdfDeprecationWarning
 from .extension import AsdfExtensionList, default_extensions
 
 from .tags.core import AsdfObject, Software, HistoryEntry
@@ -187,14 +189,22 @@ class AsdfFile(versioning.VersionedMixin):
 
     @property
     def tag_to_schema_resolver(self):
-        return self._extensions.tag_to_schema_resolver
+        warnings.warn(
+            "The 'tag_to_schema_resolver' property is deprecated. Use "
+            "'tag_mapping' instead.",
+            AsdfDeprecationWarning)
+        return self._extensions.tag_mapping
+
+    @property
+    def tag_mapping(self):
+        return self._extensions.tag_mapping
 
     @property
     def url_mapping(self):
         return self._extensions.url_mapping
 
     def resolver(self, uri):
-        return self.url_mapping(self.tag_to_schema_resolver(uri))
+        return self.url_mapping(self.tag_mapping(uri))
 
     @property
     def type_index(self):

--- a/asdf/constants.py
+++ b/asdf/constants.py
@@ -23,6 +23,7 @@ YAML_END_MARKER_REGEX = br'\r?\n\.\.\.((\r?\n)|$)'
 
 
 STSCI_SCHEMA_URI_BASE = 'http://stsci.edu/schemas/'
+STSCI_SCHEMA_TAG_BASE = 'tag:stsci.edu:asdf'
 
 
 BLOCK_FLAG_STREAMED = 0x1

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -1,0 +1,13 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+
+class AsdfWarning(Warning):
+    """
+    The base warning class from which all ASDF warnings should inherit.
+    """
+
+class AsdfDeprecationWarning(AsdfWarning):
+    """
+    A warning class to indicate a deprecated feature.
+    """

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import abc
+import warnings
 from pkg_resources import iter_entry_points
 
 import six
@@ -11,6 +12,7 @@ import importlib
 
 from . import asdftypes
 from . import resolver
+from .exceptions import AsdfDeprecationWarning
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -131,6 +133,14 @@ class AsdfExtensionList(object):
 
     @property
     def tag_to_schema_resolver(self):
+        warnings.warn(
+            "The 'tag_to_schema_resolver' property is deprecated. Use "
+            "'tag_mapping' instead.",
+            AsdfDeprecationWarning)
+        return self._tag_mapping
+
+    @property
+    def tag_mapping(self):
         return self._tag_mapping
 
     @property

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -158,10 +158,7 @@ class BuiltinExtension(object):
 
     @property
     def tag_mapping(self):
-        return [
-            ('tag:stsci.edu:asdf',
-             'http://stsci.edu/schemas/asdf{tag_suffix}')
-        ]
+        return resolver.DEFAULT_TAG_TO_URL_MAPPING
 
     @property
     def url_mapping(self):

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -109,13 +109,14 @@ DEFAULT_URL_MAPPING = [
      util.filepath_to_url(
          os.path.join(SCHEMA_PATH, 'stsci.edu')) +
          '/{url_suffix}.yaml')]
-DEFAULT_TAG_MAPPING = [
-    ('tag:stsci.edu:asdf/',
-     util.filepath_to_url(
-         os.path.join(SCHEMA_PATH, 'stsci.edu')) +
-         '/asdf/{tag_suffix}.yaml')]
+DEFAULT_TAG_TO_URL_MAPPING = [
+    (constants.STSCI_SCHEMA_TAG_BASE,
+     'http://stsci.edu/schemas/asdf{tag_suffix}')
+]
 
 
-default_url_mapping = Resolver()
-default_url_mapping.add_mapping(DEFAULT_URL_MAPPING, 'url')
-default_url_mapping.add_mapping(DEFAULT_TAG_MAPPING, 'tag')
+default_url_mapping = Resolver(DEFAULT_URL_MAPPING, 'url')
+default_tag_to_url_mapping = Resolver(DEFAULT_TAG_TO_URL_MAPPING, 'tag')
+
+def default_resolver(uri):
+    return default_url_mapping(default_tag_to_url_mapping(uri))

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -48,10 +48,27 @@ class Resolver(object):
         prefix : str, optional
             The prefix to use for the Python formatting token names.
         """
-        self._mapping = self._validate_mapping(mapping)[::-1]
-        self._prefix = prefix
+        self._mapping = tuple()
+        if mapping:
+            self.add_mapping(mapping, prefix)
 
-    def _validate_mapping(self, mappings):
+    def add_mapping(self, mapping, prefix=''):
+        self._mapping = self._mapping + self._validate_mapping(mapping, prefix)
+
+    def _make_map_func(self, mapping, prefix):
+        def _map_func(uri):
+            if uri.startswith(mapping[0]):
+                format_tokens = {
+                    prefix: uri,
+                    prefix + "_prefix": mapping[0],
+                    prefix + "_suffix": uri[len(mapping[0]):]
+                }
+
+                return len(mapping[0]), mapping[1].format(**format_tokens)
+            return None
+        return _map_func
+
+    def _validate_mapping(self, mappings, prefix):
         normalized = []
         for mapping in mappings:
             if six.callable(mapping):
@@ -61,20 +78,7 @@ class Resolver(object):
                   isinstance(mapping[0], six.string_types) and
                   isinstance(mapping[1], six.string_types)):
 
-                def _make_map_func(mapping):
-                    def _map_func(uri):
-                        if uri.startswith(mapping[0]):
-                            format_tokens = {
-                                self._prefix: uri,
-                                self._prefix + "_prefix": mapping[0],
-                                self._prefix + "_suffix": uri[len(mapping[0]):]
-                            }
-
-                            return len(mapping[0]), mapping[1].format(**format_tokens)
-                        return None
-                    return _map_func
-
-                func = _make_map_func(mapping)
+                func = self._make_map_func(mapping, prefix)
             else:
                 raise ValueError("Invalid mapping '{0}'".format(mapping))
 
@@ -104,11 +108,14 @@ DEFAULT_URL_MAPPING = [
     (constants.STSCI_SCHEMA_URI_BASE,
      util.filepath_to_url(
          os.path.join(SCHEMA_PATH, 'stsci.edu')) +
-         '/{url_suffix}.yaml'),
+         '/{url_suffix}.yaml')]
+DEFAULT_TAG_MAPPING = [
     ('tag:stsci.edu:asdf/',
      util.filepath_to_url(
          os.path.join(SCHEMA_PATH, 'stsci.edu')) +
-         '/asdf/{url_suffix}.yaml')]
+         '/asdf/{tag_suffix}.yaml')]
 
 
-default_url_mapping = Resolver(DEFAULT_URL_MAPPING, 'url')
+default_url_mapping = Resolver()
+default_url_mapping.add_mapping(DEFAULT_URL_MAPPING, 'url')
+default_url_mapping.add_mapping(DEFAULT_TAG_MAPPING, 'tag')

--- a/asdf/tests/data/foreign_tag_reference-1.0.0.yaml
+++ b/asdf/tests/data/foreign_tag_reference-1.0.0.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://nowhere.org/schemas/custom/foreign_tag_reference-1.0.0"
+title: An example custom type for testing tag references
+
+tag: "tag:nowhere.org:custom/foreign_tag_reference-1.0.0"
+type: object
+properties:
+  a:
+    # Test foreign tag reference using tag URI
+    $ref: "tag:nowhere.org:custom/tag_reference-1.0.0"
+  b:
+    # Test foreign tag reference using tag ID
+    $ref: "http://nowhere.org/schemas/custom/tag_reference-1.0.0"
+required: [a, b]
+...

--- a/asdf/tests/data/tag_reference-1.0.0.yaml
+++ b/asdf/tests/data/tag_reference-1.0.0.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://nowhere.org/schemas/custom/tag_reference-1.0.0"
+title: An example custom type for testing tag references
+
+tag: "tag:nowhere.org:custom/tag_reference-1.0.0"
+type: object
+properties:
+  name:
+    type: string
+  things:
+    $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+required: [name, things]
+...

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -17,10 +17,12 @@ import six
 from .. import asdf
 from .. import block
 from .. import constants
+from .. import extension
 from .. import generic_io
 from .. import treeutil
 from .. import versioning
 from ..tests.helpers import assert_tree_match
+from ..exceptions import AsdfDeprecationWarning
 
 
 def _get_small_tree():
@@ -1183,3 +1185,13 @@ def test_top_level_tree():
     ff2 = asdf.AsdfFile()
     ff2['tree'] = _get_small_tree()
     assert_tree_match(ff2.tree['tree'], ff2['tree'])
+
+
+def test_tag_to_schema_resolver_deprecation():
+    ff = asdf.AsdfFile()
+    with pytest.warns(AsdfDeprecationWarning):
+        ff.tag_to_schema_resolver('foo')
+
+    with pytest.warns(AsdfDeprecationWarning):
+        extension_list = extension.default_extensions.extension_list
+        extension_list.tag_to_schema_resolver('foo')

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -33,7 +33,8 @@ TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 
 
 class CustomExtension:
-    """This is the base class that is used for extensions for custom tag
+    """
+    This is the base class that is used for extensions for custom tag
     classes that exist only for the purposes of testing.
     """
     @property
@@ -50,6 +51,24 @@ class CustomExtension:
         return [('http://nowhere.org/schemas/custom/',
                  util.filepath_to_url(TEST_DATA_PATH) +
                  '/{url_suffix}.yaml')]
+
+
+class TagReferenceType(asdftypes.CustomType):
+    """
+    This class is used by several tests below for validating foreign type
+    references in schemas and ASDF files.
+    """
+    name = 'tag_reference'
+    organization = 'nowhere.org'
+    version = (1, 0, 0)
+    standard = 'custom'
+
+    @classmethod
+    def from_tree(cls, tree, ctx):
+        node = {}
+        node['name'] = tree['name']
+        node['things'] = yamlutil.tagged_tree_to_custom_tree(tree['things'], ctx)
+        return node
 
 
 def test_violate_toplevel_schema():
@@ -375,23 +394,10 @@ custom: !<tag:nowhere.org:custom/default-1.0.0>
 
 
 def test_tag_reference_validation():
-    class ExampleType(asdftypes.CustomType):
-        name = 'tag_reference'
-        organization = 'nowhere.org'
-        version = (1, 0, 0)
-        standard = 'custom'
-
-        @classmethod
-        def from_tree(cls, tree, ctx):
-            node = {}
-            node['name'] = tree['name']
-            node['things'] = yamlutil.tagged_tree_to_custom_tree(tree['things'], ctx)
-            return node
-
     class DefaultTypeExtension(CustomExtension):
         @property
         def types(self):
-            return [ExampleType]
+            return [TagReferenceType]
 
     yaml = """
 custom: !<tag:nowhere.org:custom/tag_reference-1.0.0>
@@ -406,6 +412,49 @@ custom: !<tag:nowhere.org:custom/tag_reference-1.0.0>
         custom = ff.tree['custom']
         assert custom['name'] == "Something"
         assert_array_equal(custom['things'], [1, 2, 3])
+
+
+def test_foreign_tag_reference_validation():
+    class ForeignTagReferenceType(asdftypes.CustomType):
+        name = 'foreign_tag_reference'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            node = {}
+            node['a'] = yamlutil.tagged_tree_to_custom_tree(tree['a'], ctx)
+            node['b'] = yamlutil.tagged_tree_to_custom_tree(tree['b'], ctx)
+            return node
+
+    class ForeignTypeExtension(CustomExtension):
+        @property
+        def types(self):
+            return [TagReferenceType, ForeignTagReferenceType]
+
+    yaml = """
+custom: !<tag:nowhere.org:custom/foreign_tag_reference-1.0.0>
+  a: !<tag:nowhere.org:custom/tag_reference-1.0.0>
+    name:
+      "Something"
+    things: !core/ndarray-1.0.0
+      data: [1, 2, 3]
+  b: !<tag:nowhere.org:custom/tag_reference-1.0.0>
+    name:
+      "Anything"
+    things: !core/ndarray-1.0.0
+      data: [4, 5, 6]
+    """
+
+    buff = helpers.yaml_to_asdf(yaml)
+    with asdf.AsdfFile.open(buff, extensions=ForeignTypeExtension()) as ff:
+        a = ff.tree['custom']['a']
+        b = ff.tree['custom']['b']
+        assert a['name'] == 'Something'
+        assert_array_equal(a['things'], [1, 2, 3])
+        assert b['name'] == 'Anything'
+        assert_array_equal(b['things'], [4, 5, 6])
 
 
 def test_self_reference_resolution():


### PR DESCRIPTION
This fixes #392. Previously it was not possible to resolve foreign tag references that were included in ASDF schemas or files. For example, if a schema in an external package made reference to `tag:stsci.edu:asdf/core/ndarray-1.0.0`, it would not be resolved properly. 

This PR combines tag mappings and url mappings into a single resolver, so that both tags and urls used as IDs can be resolved to real urls. 

@nden this change will enable schemas to move to Astropy and GWCS as appropriate.

**[edit]**
To be clear, this change applies to *fully specified* tag references like `tag:stsci.edu:asdf/core/ndarray-1.0.0`. Relative tag references within the same organization (such as `stsci.edu` worked (e.g. `!core/ndarray-1.0.0`), but these are not sufficient for use by packages that define schemas in different organizations (e.g. `astropy.org`).