### PR TITLE
Add an external array reference type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 
 1.4.0 (unreleased)
 ------------------
+- Add and ``ExternalArrayReference`` type for referencing arrays in external files. [#400]
 
 - Improve the way URIs are detected for ASDF-in-FITS files in order to fix bug
   with reading gzipped ASDF-in-FITS files. [#416]

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -15,7 +15,7 @@ from ._internal_init import *
 
 __all__ = [
     'AsdfFile', 'CustomType', 'AsdfExtension', 'Stream', 'open', 'test',
-    'commands', 'ValidationError'
+    'commands', 'ValidationError', 'ExternalArrayReference'
 ]
 
 try:
@@ -38,6 +38,7 @@ from .asdftypes import CustomType
 from .extension import AsdfExtension
 from .stream import Stream
 from . import commands
+from .tags.core.external_reference import ExternalArrayReference
 
 from jsonschema import ValidationError
 

--- a/asdf/external_reference.py
+++ b/asdf/external_reference.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+from .asdftypes import AsdfType
+
+
+class ExternalArrayReference(AsdfType):
+    """
+    Store a reference to an array in an external File.
+
+    Parameters
+    ----------
+
+    filepath: `str`
+        The path to the path to be referenced. Can be relative to the file
+        containing the reference.
+
+    target: `object`
+        Some internal target to the data in the file. Examples may include a HDU
+        index, a HDF path or an asdf fragment.
+
+    dtype: `str`
+        The (numpy) dtype of the contained array.
+
+    shape: `tuple`
+        The shape of the array to be loaded.
+    """
+    name = "core/externalarray"
+
+    def __init__(self, filepath, target, dtype, shape):
+        self.filepath = str(filepath)
+        self.target = target
+        self.dtype = dtype
+        self.shape = tuple(shape)
+
+    def __repr__(self):
+        return "<External array reference in {0} at {1} shape: {2} dtype: {3}>".format(
+            self.filepath, self.target, self.shape, self.dtype)
+
+    def __str__(self):
+        return repr(self)
+
+    @classmethod
+    def to_tree(self, data, ctx):
+        node = {}
+        node['filepath'] = data.filepath
+        node['target'] = data.target
+        node['datatype'] = data.dtype
+        node['shape'] = data.shape
+
+        return node
+
+    @classmethod
+    def from_tree(cls, tree, ctx):
+        return cls(tree['filepath'], tree['target'], tree['datatype'], tree['shape'])

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -20,3 +20,4 @@ class HistoryEntry(dict, AsdfType):
 from .constant import ConstantType
 from .ndarray import NDArrayType
 from .complex import ComplexType
+from .external_reference import ExternalArrayReference

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals, print_function
-
 from .asdftypes import AsdfType
 
 
@@ -10,7 +8,7 @@ class ExternalArrayReference(AsdfType):
     Parameters
     ----------
 
-    filepath: `str`
+    fileuri: `str`
         The path to the path to be referenced. Can be relative to the file
         containing the reference.
 
@@ -25,16 +23,17 @@ class ExternalArrayReference(AsdfType):
         The shape of the array to be loaded.
     """
     name = "core/externalarray"
+    version = (1, 0, 0)
 
-    def __init__(self, filepath, target, dtype, shape):
-        self.filepath = str(filepath)
+    def __init__(self, fileuri, target, dtype, shape):
+        self.fileuri = str(fileuri)
         self.target = target
         self.dtype = dtype
         self.shape = tuple(shape)
 
     def __repr__(self):
         return "<External array reference in {0} at {1} shape: {2} dtype: {3}>".format(
-            self.filepath, self.target, self.shape, self.dtype)
+            self.fileuri, self.target, self.shape, self.dtype)
 
     def __str__(self):
         return repr(self)
@@ -42,7 +41,7 @@ class ExternalArrayReference(AsdfType):
     @classmethod
     def to_tree(self, data, ctx):
         node = {}
-        node['filepath'] = data.filepath
+        node['fileuri'] = data.fileuri
         node['target'] = data.target
         node['datatype'] = data.dtype
         node['shape'] = data.shape
@@ -51,4 +50,4 @@ class ExternalArrayReference(AsdfType):
 
     @classmethod
     def from_tree(cls, tree, ctx):
-        return cls(tree['filepath'], tree['target'], tree['datatype'], tree['shape'])
+        return cls(tree['fileuri'], tree['target'], tree['datatype'], tree['shape'])

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -6,7 +6,9 @@ class ExternalArrayReference(AsdfType):
     Store a reference to an array in an external File.
 
     This class is a simple way of referring to an array in another file. It
-    provides no way to resolve these references, that is left to the user.
+    provides no way to resolve these references, that is left to the user. It
+    also performs no checking to see if any of the arguments are correct. e.g.
+    if the file exits.
 
     Parameters
     ----------
@@ -24,6 +26,17 @@ class ExternalArrayReference(AsdfType):
 
     shape: `tuple`
         The shape of the array to be loaded.
+
+
+    Examples
+    --------
+
+    >>> import asdf
+    >>> ref = asdf.ExternalArrayReference("myfitsfile.fits, 1, "float64", (100, 100))
+    >>> tree = {'reference': ref}
+    >>> with asdf.AsdfFile(tree) as ff:
+    ...     ff.write_to("test.asdf")
+
     """
     name = "core/externalarray"
     version = (1, 0, 0)

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -5,6 +5,9 @@ class ExternalArrayReference(AsdfType):
     """
     Store a reference to an array in an external File.
 
+    This class is a simple way of referring to an array in another file. It
+    provides no way to resolve these references, that is left to the user.
+
     Parameters
     ----------
 
@@ -37,6 +40,14 @@ class ExternalArrayReference(AsdfType):
 
     def __str__(self):
         return repr(self)
+
+    def __eq__(self, other):
+        uri = self.fileuri == other.fileuri
+        target = self.target == other.target
+        dtype = self.dtype == other.dtype
+        shape = self.shape == other.shape
+
+        return all((uri, target, dtype, shape))
 
     @classmethod
     def to_tree(self, data, ctx):

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -32,7 +32,7 @@ class ExternalArrayReference(AsdfType):
     --------
 
     >>> import asdf
-    >>> ref = asdf.ExternalArrayReference("myfitsfile.fits, 1, "float64", (100, 100))
+    >>> ref = asdf.ExternalArrayReference("myfitsfile.fits", 1, "float64", (100, 100))
     >>> tree = {'reference': ref}
     >>> with asdf.AsdfFile(tree) as ff:
     ...     ff.write_to("test.asdf")

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -1,4 +1,4 @@
-from .asdftypes import AsdfType
+from ...asdftypes import AsdfType
 
 
 class ExternalArrayReference(AsdfType):

--- a/asdf/tags/core/tests/test_external_reference.py
+++ b/asdf/tags/core/tests/test_external_reference.py
@@ -1,0 +1,11 @@
+from ..external_reference import ExternalArrayReference
+from ....tests import helpers
+
+
+def test_roundtrip_external_array(tmpdir):
+    ref = ExternalArrayReference("./nonexistant.fits", 1,
+                                 "np.float64", (100, 100))
+
+    tree = {'nothere': ref}
+
+    helpers.assert_roundtrip_tree(tree, tmpdir)


### PR DESCRIPTION
This is a first attempt at adding a general tag for external array references. This needs testing with things other than FITS and much more work, but it's put here for feedback.

see also spacetelescope/asdf-standard#149, fixes #369