### PR TITLE
Fix bug that caused serialized FITS tables to be duplicated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@
   ``tag_to_schema_resolver`` property for ``AsdfFile`` and
   ``AsdfExtensionList``. [#399]
 
+- Fix bug that caused serialized FITS tables to be duplicated in embedded ASDF
+  HDU. [#411]
+
 1.3.2 (unreleased)
 ------------------
 

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -95,7 +95,9 @@ class _EmbeddedBlockManager(block.BlockManager):
         if not isinstance(arr, ndarray.NDArrayType):
             base = util.get_array_base(arr)
             for hdu in self._hdulist:
-                if base is hdu.data:
+                if hdu.data is None:
+                    continue
+                if base is util.get_array_base(hdu.data):
                     return _FitsBlock(hdu)
 
         return super(


### PR DESCRIPTION
This fixes #404. The bug occurred specifically in the case where the ASDF file was embedded inside an HDU in a FITS file.