### PR TITLE
Use new non-standard FITS extension for ASDF-in-FITS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@
 - Fix bug that caused serialized FITS tables to be duplicated in embedded ASDF
   HDU. [#411]
 
+- Create and use a new non-standard FITS extension instead of ImageHDU for
+  storing ASDF files embedded in FITS. Explicitly remove support for the
+  ``.update`` method of ``AsdfInFits``, even though it didn't appear to be
+  working previously. [#412]
+
 1.3.2 (unreleased)
 ------------------
 

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -45,4 +45,12 @@ from jsonschema import ValidationError
 class ValidationError(ValidationError):
     pass
 
+try:
+    from astropy.io import fits
+except ImportError:
+    pass
+else:
+    from .fits_embed import _AsdfHDU
+    fits.register_hdu(_AsdfHDU)
+
 open = AsdfFile.open

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -20,13 +20,80 @@ from . import generic_io
 
 try:
     from astropy.io import fits
+    from astropy.io.fits.file import _File
+    from astropy.io.fits.header import Header, _pad_length
+    from astropy.utils import lazyproperty
 except ImportError:
     raise ImportError("AsdfInFits requires astropy")
 
 
 ASDF_EXTENSION_NAME = 'ASDF'
-
 FITS_SOURCE_PREFIX = 'fits:'
+
+
+class AsdfHDU(fits.hdu.base.NonstandardExtHDU):
+    """
+    A non-standard extension HDU for encapsulating an entire ASDF file within a
+    single HDU of a container FITS file.  These HDUs have an extension (that is
+    an XTENSION keyword) of ASDF.
+    """
+
+    _extension = ASDF_EXTENSION_NAME
+
+    @classmethod
+    def from_buff(cls, buff, compress=False, **kwargs):
+        """
+        Creates a new AsdfHDU from a given AsdfFile object.
+
+        Parameters
+        ----------
+        buff : io.BytesIO
+            A buffer containing an ASDF metadata tree
+        compress : bool, optional
+            Gzip compress the contents of the ASDF HDU
+        """
+
+        if compress:
+            buff = gzip.GzipFile(fileobj=buff, mode='wb')
+
+        # A proper HDU should still be padded out to a multiple of 2880
+        # technically speaking
+        data_length = buff.tell()
+        padding = (_pad_length(data_length) * cls._padding_byte).encode('ascii')
+        buff.write(padding)
+
+        buff.seek(0)
+
+        cards = [
+            ('XTENSION', cls._extension, 'ASDF extension'),
+            ('BITPIX', 8, 'array data type'),
+            ('NAXIS', 1, 'number of array dimensions'),
+            ('NAXIS1', len(buff.getvalue()), 'Axis length'),
+            ('PCOUNT', 0, 'number of parameters'),
+            ('GCOUNT', 1, 'number of groups'),
+            ('COMPRESS', compress, 'Uses gzip compression'),
+            ('EXTNAME', cls._extension, 'Name of ASDF extension'),
+        ]
+
+        header = Header(cards)
+        return cls._readfrom_internal(_File(buff), header=header)
+
+
+    @classmethod
+    def match_header(cls, header):
+        card = header.cards[0]
+        if card.keyword != 'XTENSION':
+            return False
+        xtension = card.value
+        if isinstance(xtension, str):
+            xtension = xtension.rstrip()
+        return xtension == cls._extension
+
+    # TODO: Add header verification
+
+    def _summary(self):
+        # TODO: Perhaps make this more descriptive...
+        return (self.name, self.ver, self.__class__.__name__, len(self._header))
 
 
 class _FitsBlock(object):
@@ -222,9 +289,17 @@ class AsdfInFits(asdf.AsdfFile):
         return cls._open_asdf(self, buff, uri=uri, mode='r',
                               validate_checksums=validate_checksums)
 
+    def _create_hdu(self, buff, use_image_hdu):
+        # Allow writing to old-style ImageHDU for backwards compatibility
+        if use_image_hdu:
+            array = np.frombuffer(buff.getvalue(), np.uint8)
+            return fits.ImageHDU(array, name=ASDF_EXTENSION_NAME)
+        else:
+            return AsdfHDU.from_buff(buff)
+
     def _update_asdf_extension(self, all_array_storage=None,
-                               all_array_compression=None,
-                               auto_inline=None, pad_blocks=False):
+                               all_array_compression=None, auto_inline=None,
+                               pad_blocks=False, use_image_hdu=False):
         if self.blocks.streamed_block is not None:
             raise ValueError(
                 "Can not save streamed data to ASDF-in-FITS file.")
@@ -235,22 +310,19 @@ class AsdfInFits(asdf.AsdfFile):
             all_array_compression=all_array_compression,
             auto_inline=auto_inline, pad_blocks=pad_blocks,
             include_block_index=False)
-        array = np.frombuffer(buff.getvalue(), np.uint8)
 
-        try:
-            asdf_extension = self._hdulist[ASDF_EXTENSION_NAME]
-        except (KeyError, IndexError, AttributeError):
-            self._hdulist.append(fits.ImageHDU(array, name=ASDF_EXTENSION_NAME))
-        else:
-            asdf_extension.data = array
+        if ASDF_EXTENSION_NAME in self._hdulist:
+            del self._hdulist[ASDF_EXTENSION_NAME]
+        self._hdulist.append(self._create_hdu(buff, use_image_hdu))
 
     def write_to(self, filename, all_array_storage=None,
                  all_array_compression=None, auto_inline=None,
-                 pad_blocks=False, *args, **kwargs):
+                 pad_blocks=False, use_image_hdu=False, *args, **kwargs):
         self._update_asdf_extension(
             all_array_storage=all_array_storage,
             all_array_compression=all_array_compression,
-            auto_inline=auto_inline, pad_blocks=pad_blocks)
+            auto_inline=auto_inline, pad_blocks=pad_blocks,
+            use_image_hdu=use_image_hdu)
 
         self._hdulist.writeto(filename, *args, **kwargs)
 

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -22,7 +22,6 @@ try:
     from astropy.io import fits
     from astropy.io.fits.file import _File
     from astropy.io.fits.header import Header, _pad_length
-    from astropy.utils import lazyproperty
 except ImportError:
     raise ImportError("AsdfInFits requires astropy")
 
@@ -31,7 +30,10 @@ ASDF_EXTENSION_NAME = 'ASDF'
 FITS_SOURCE_PREFIX = 'fits:'
 
 
-class AsdfHDU(fits.hdu.base.NonstandardExtHDU):
+__all__ = ['AsdfInFits']
+
+
+class _AsdfHDU(fits.hdu.base.NonstandardExtHDU):
     """
     A non-standard extension HDU for encapsulating an entire ASDF file within a
     single HDU of a container FITS file.  These HDUs have an extension (that is
@@ -43,7 +45,7 @@ class AsdfHDU(fits.hdu.base.NonstandardExtHDU):
     @classmethod
     def from_buff(cls, buff, compress=False, **kwargs):
         """
-        Creates a new AsdfHDU from a given AsdfFile object.
+        Creates a new _AsdfHDU from a given AsdfFile object.
 
         Parameters
         ----------
@@ -295,7 +297,7 @@ class AsdfInFits(asdf.AsdfFile):
             array = np.frombuffer(buff.getvalue(), np.uint8)
             return fits.ImageHDU(array, name=ASDF_EXTENSION_NAME)
         else:
-            return AsdfHDU.from_buff(buff)
+            return _AsdfHDU.from_buff(buff)
 
     def _update_asdf_extension(self, all_array_storage=None,
                                all_array_compression=None, auto_inline=None,

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -98,9 +98,6 @@ class _AsdfHDU(fits.hdu.base.NonstandardExtHDU):
         return (self.name, self.ver, self.__class__.__name__, len(self._header))
 
 
-fits.register_hdu(_AsdfHDU)
-
-
 class _FitsBlock(object):
     def __init__(self, hdu):
         self._hdu = hdu

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -328,6 +328,9 @@ class AsdfInFits(asdf.AsdfFile):
 
     def update(self, all_array_storage=None, all_array_compression=None,
                auto_inline=None, pad_blocks=False):
+        raise NotImplementedError(
+            "In-place update is not currently implemented for ASDF-in-FITS")
+
         self._update_asdf_extension(
             all_array_storage=all_array_storage,
             all_array_compression=all_array_compression,

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -98,6 +98,9 @@ class _AsdfHDU(fits.hdu.base.NonstandardExtHDU):
         return (self.name, self.ver, self.__class__.__name__, len(self._header))
 
 
+fits.register_hdu(_AsdfHDU)
+
+
 class _FitsBlock(object):
     def __init__(self, hdu):
         self._hdu = hdu

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -79,7 +79,10 @@ def test_embed_asdf_in_fits_file(tmpdir):
         assert len(hdulist2) == 3
         assert [x.name for x in hdulist2] == ['SCI', 'DQ', 'ASDF']
         assert_array_equal(hdulist2[0].data, np.arange(512, dtype=np.float))
-        assert hdulist2['ASDF'].data.tostring().strip().endswith(b"...")
+        asdf_hdu = hdulist2['ASDF']
+        assert isinstance(asdf_hdu, fits.hdu.base.NonstandardExtHDU)
+        assert asdf_hdu.data.tostring().startswith(b'#ASDF')
+        assert len(asdf_hdu.data) % 2880 == 0
 
         with fits_embed.AsdfInFits.open(hdulist2) as ff2:
             assert_tree_match(tree, ff2.tree)
@@ -102,7 +105,10 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
     with fits.open(os.path.join(str(tmpdir), 'test.fits')) as hdulist:
         assert len(hdulist) == 4
         assert [x.name for x in hdulist] == ['PRIMARY', '', '', 'ASDF']
-        assert hdulist['ASDF'].data.tostring().strip().endswith(b"...")
+        asdf_hdu = hdulist['ASDF']
+        assert isinstance(asdf_hdu, fits.hdu.base.NonstandardExtHDU)
+        assert asdf_hdu.data.tostring().startswith(b'#ASDF')
+        assert len(asdf_hdu.data) % 2880 == 0
 
         with fits_embed.AsdfInFits.open(hdulist) as ff2:
             assert_tree_match(asdf_in_fits.tree, ff2.tree)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -168,6 +168,21 @@ def test_update_and_write_new(tmpdir):
         assert_tree_match(ff.tree['model'], asdf_in_fits.tree['model'])
 
 
+@pytest.mark.xfail(
+    reason="ASDF HDU implementation does not currently reseek after writing")
+def test_access_hdu_data_after_write(tmpdir):
+    # There is actually probably not a great reason to support this kind of
+    # functionality, but I am adding a test here to record the failure for
+    # posterity.
+    tempfile = str(tmpdir.join('test.fits'))
+
+    asdf_in_fits = create_asdf_in_fits()
+    asdf_in_fits.write_to(tempfile)
+    asdf_hdu = asdf_in_fits._hdulist['ASDF']
+
+    assert asdf_hdu.data.tostring().startswith('#ASDF')
+
+
 def test_create_in_tree_first(tmpdir):
     tree = {
         'model': {

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -129,6 +129,45 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
         assert_tree_match(asdf_in_fits.tree, ff.tree)
 
 
+@pytest.mark.xfail(
+    reason="In-place update for ASDF-in-FITS does not currently work")
+def test_update_in_place(tmpdir):
+    tempfile = str(tmpdir.join('test.fits'))
+
+    # Create a file and write it out
+    asdf_in_fits = create_asdf_in_fits()
+    asdf_in_fits.write_to(tempfile)
+
+    # Open the file and add data so it needs to be updated
+    with fits_embed.AsdfInFits.open(tempfile) as ff:
+        ff.tree['new_stuff'] = "A String"
+        ff.update()
+
+    # Open the updated file and make sure everything looks okay
+    with fits_embed.AsdfInFits.open(tempfile) as ff:
+        assert ff.tree['new_stuff'] == "A String"
+        assert_tree_match(ff.tree['model'], asdf_in_fits.tree['model'])
+
+
+def test_update_and_write_new(tmpdir):
+    tempfile = str(tmpdir.join('test.fits'))
+    newfile = str(tmpdir.join('new.fits'))
+
+    # Create a file and write it out
+    asdf_in_fits = create_asdf_in_fits()
+    asdf_in_fits.write_to(tempfile)
+
+    # Open the file and add data so it needs to be updated
+    with fits_embed.AsdfInFits.open(tempfile) as ff:
+        ff.tree['new_stuff'] = "A String"
+        ff.write_to(newfile)
+
+    # Open the updated file and make sure everything looks okay
+    with fits_embed.AsdfInFits.open(newfile) as ff:
+        assert ff.tree['new_stuff'] == "A String"
+        assert_tree_match(ff.tree['model'], asdf_in_fits.tree['model'])
+
+
 def test_create_in_tree_first(tmpdir):
     tree = {
         'model': {

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -90,7 +90,7 @@ def test_embed_asdf_in_fits_file(tmpdir, backwards_compat):
             assert isinstance(asdf_hdu, fits.ImageHDU)
             assert asdf_hdu.data.tostring().strip().endswith(b'...')
         else:
-            assert isinstance(asdf_hdu, fits.hdu.base.NonstandardExtHDU)
+            assert isinstance(asdf_hdu, fits_embed._AsdfHDU)
             assert len(asdf_hdu.data) % 2880 == 0
 
         with fits_embed.AsdfInFits.open(hdulist2) as ff2:
@@ -115,7 +115,7 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
         assert len(hdulist) == 4
         assert [x.name for x in hdulist] == ['PRIMARY', '', '', 'ASDF']
         asdf_hdu = hdulist['ASDF']
-        assert isinstance(asdf_hdu, fits.hdu.base.NonstandardExtHDU)
+        assert isinstance(asdf_hdu, fits_embed._AsdfHDU)
         assert asdf_hdu.data.tostring().startswith(b'#ASDF')
         assert len(asdf_hdu.data) % 2880 == 0
 

--- a/docs/asdf/examples.rst
+++ b/docs/asdf/examples.rst
@@ -475,8 +475,11 @@ ASDF-in-FITS format.
 
 .. runcode:: hidden
 
-    with open('content.asdf', 'wb') as fd:
-        fd.write(hdulist['ASDF'].data.tostring())
+    from astropy.io import fits
+
+    with fits.open('embedded_asdf.fits') as new_hdulist:
+        with open('content.asdf', 'wb') as fd:
+            fd.write(new_hdulist['ASDF'].data.tostring())
 
 The special ASDF extension in the resulting FITS file looks like the
 following.  Note that the data source of the arrays uses the ``fits:``


### PR DESCRIPTION
The motivation for this update was a problem report from the archive. They pointed out that storing ASDF metadata in an `IMAGE` HDU goes against convention and would likely lead to incorrect handling of the data when the resulting file is processed by FITS readers.

It was originally proposed to instead use the `FOREIGN` extension. However, this convention [has already been defined](https://arxiv.org/abs/1201.1829), and it seemed too restrictive to have to conform to this convention, especially since there is not already an implementation in `astropy`.

Instead, it was agreed that we would create a new `ASDF` extension for storing ASDF metadata in FITS files. This PR contains the implementation of the corresponding HDU, which is nearly identical to the `FitsHDU` in `astropy.io.fits`. In this case, the `XTENSION` keyword is `ASDF`. The ASDF library writes and expects to read extensions with an `EXTNAME` of `ASDF`.

The `AsdfInFits` implementation has been updated to write new files using the new convention by default. However, it is still capable of reading older files using the `IMAGE` extension, and it is still possible to optionally write files using the `IMAGE` extension as well.

I expect that these changes will break a lot of tests in the JWST pipeline, so I will make sure that everyone is on board before hitting the merge button.

This closes #336.