### PR TITLE
More improvements and cleanup in setup script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CHANGES.rst
 
 include ez_setup.py
 include ah_bootstrap.py
+include setup_helpers.py
 include setup.cfg
 
 recursive-include *.pyx *.c *.pxd

--- a/setup.py
+++ b/setup.py
@@ -2,40 +2,27 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
-import sys
-import glob
 import builtins
-import subprocess as sp
 
-import ah_bootstrap
 from setuptools import setup
 
+from setup_helpers import (get_package_info, generate_version_file,
+                           read_metadata, read_readme)
 
-from astropy_helpers.setup_helpers import (
-    register_commands, get_debug_option, get_package_info)
+from astropy_helpers.setup_helpers import register_commands
 from astropy_helpers.git_helpers import get_git_devstr
-from astropy_helpers.version_helpers import _get_version_py_str
 
-# Get some values from the setup.cfg
-from configparser import ConfigParser
-conf = ConfigParser()
-conf.read(['setup.cfg'])
-metadata = dict(conf.items('metadata'))
-
-PACKAGENAME = metadata.get('package_name', 'packagename')
+metadata = read_metadata('setup.cfg')
+PACKAGE_NAME = metadata.get('package_name', 'asdf')
 DESCRIPTION = metadata.get('description', 'package description')
 AUTHOR = metadata.get('author', '')
 AUTHOR_EMAIL = metadata.get('author_email', '')
 LICENSE = metadata.get('license', 'unknown')
 URL = metadata.get('url', '')
 
-def readme():
-    with open('README.md') as ff:
-        return ff.read()
-
 # Store the package name in a built-in variable so it's easy
 # to get from other parts of the setup infrastructure
-builtins._PACKAGE_NAME_ = 'asdf'
+builtins._PACKAGE_NAME_ = PACKAGE_NAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 VERSION = '1.3.2.dev'
@@ -46,51 +33,15 @@ RELEASE = 'dev' not in VERSION
 if not RELEASE:
     VERSION += get_git_devstr(False)
 
-# Get root of asdf-standard documents
-ASDF_STANDARD_ROOT = os.environ.get('ASDF_STANDARD_ROOT', 'asdf-standard')
-
 # Populate the dict of setup command overrides; this should be done before
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
-cmdclassd = register_commands('asdf', VERSION, RELEASE)
+cmdclassd = register_commands(PACKAGE_NAME, VERSION, RELEASE)
 
-# Freeze build information in version.py
-# We no longer use generate_version_py from astropy_helpers because it imports
-# the asdf module, and we no longer want to enable that kind of bad behavior
-def generate_version_file():
-    version_py = os.path.join(os.path.curdir, 'asdf', 'version.py')
-    with open(version_py, 'w') as f:
-        f.write(_get_version_py_str('asdf', VERSION, None, RELEASE, False))
-generate_version_file()
+# Dynamically generate version.py file distributed with package
+generate_version_file(os.path.curdir, PACKAGE_NAME, VERSION, RELEASE)
 
-
-# Get configuration information from all of the various subpackages.
-# See the docstring for setup_helpers.update_package_files for more
-# details.
 package_info = get_package_info()
-
-# Add the project-global data
-package_info['package_data'].setdefault('asdf', []).append('data/*')
-
-# The schemas come from a git submodule, so we deal with them here
-schema_root = os.path.join(ASDF_STANDARD_ROOT, "schemas")
-
-package_info['package_dir']['asdf.schemas'] = schema_root
-package_info['packages'].append('asdf.schemas')
-
-# The reference files come from a git submodule, so we deal with them here
-reference_file_root = os.path.join(ASDF_STANDARD_ROOT, "reference_files")
-if not os.path.exists(reference_file_root):
-    ret = sp.call(['git', 'submodule', 'update', '--init', ASDF_STANDARD_ROOT])
-    if ret != 0 or not os.path.exists(reference_file_root):
-        sys.stderr.write("Failed to initialize 'asdf-standard' submodule\n")
-        sys.exit(ret or 1)
-
-package_info['package_dir']['asdf.reference_files'] = reference_file_root
-for dirname in os.listdir(reference_file_root):
-    package_info['package_dir']['asdf.reference_files.' + dirname] = os.path.join(
-        reference_file_root, dirname)
-package_info['packages'].append('asdf.reference_files')
 
 #Define entry points for command-line scripts
 entry_points = {}
@@ -107,7 +58,7 @@ if os.getenv('CI'):
     extras_require.extend(['lz4>=0.10'])
 
 
-setup(name=PACKAGENAME,
+setup(name=PACKAGE_NAME,
       version=VERSION,
       description=DESCRIPTION,
       python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
@@ -124,7 +75,7 @@ setup(name=PACKAGENAME,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,
       url=URL,
-      long_description=readme(),
+      long_description=read_readme('README.md'),
       cmdclass=cmdclassd,
       zip_safe=False,
       use_2to3=True,

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import glob
 import os
 import sys
+import glob
 import builtins
 import subprocess as sp
 
@@ -14,7 +14,7 @@ from setuptools import setup
 from astropy_helpers.setup_helpers import (
     register_commands, get_debug_option, get_package_info)
 from astropy_helpers.git_helpers import get_git_devstr
-from astropy_helpers.version_helpers import generate_version_py
+from astropy_helpers.version_helpers import _get_version_py_str
 
 from astropy_helpers import test_helpers
 def _null_validate(self):
@@ -60,8 +60,14 @@ ASDF_STANDARD_ROOT = os.environ.get('ASDF_STANDARD_ROOT', 'asdf-standard')
 cmdclassd = register_commands('asdf', VERSION, RELEASE)
 
 # Freeze build information in version.py
-generate_version_py('asdf', VERSION, RELEASE,
-                    get_debug_option('asdf'))
+# We no longer use generate_version_py from astropy_helpers because it imports
+# the asdf module, and we no longer want to enable that kind of bad behavior
+def generate_version_file():
+    version_py = os.path.join(os.path.curdir, 'asdf', 'version.py')
+    with open(version_py, 'w') as f:
+        f.write(_get_version_py_str('asdf', VERSION, None, RELEASE, False))
+generate_version_file()
+
 
 # Treat everything in scripts except README.rst as a script to be installed
 scripts = [fname for fname in glob.glob(os.path.join('scripts', '*'))

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,6 @@ from astropy_helpers.setup_helpers import (
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import _get_version_py_str
 
-from astropy_helpers import test_helpers
-def _null_validate(self):
-    pass
-test_helpers.AstropyTest._validate_required_deps = _null_validate
-
 # Get some values from the setup.cfg
 from configparser import ConfigParser
 conf = ConfigParser()
@@ -69,11 +64,6 @@ def generate_version_file():
 generate_version_file()
 
 
-# Treat everything in scripts except README.rst as a script to be installed
-scripts = [fname for fname in glob.glob(os.path.join('scripts', '*'))
-           if os.path.basename(fname) != 'README.rst']
-
-
 # Get configuration information from all of the various subpackages.
 # See the docstring for setup_helpers.update_package_files for more
 # details.
@@ -112,18 +102,14 @@ entry_points['asdf_extensions'] = [
 ]
 
 # Add the dependencies which are not strictly needed but enable otherwise skipped tests
-extra_requires = []
+extras_require = []
 if os.getenv('CI'):
-    extra_requires.extend(['lz4>=0.10'])
+    extras_require.extend(['lz4>=0.10'])
 
-# Note that requires and provides should not be included in the call to
-# ``setup``, since these are now deprecated. See this link for more details:
-# https://groups.google.com/forum/#!topic/astropy-dev/urYO8ckB2uM
 
 setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
-      scripts=scripts,
       python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
       install_requires=[
           'semantic_version>=2.3.1',
@@ -132,7 +118,7 @@ setup(name=PACKAGENAME,
           'six>=1.9.0',
           'numpy>=1.8',
           'astropy>=1.3',
-      ] + extra_requires,
+      ] + extras_require,
       tests_require=['pytest-astropy'],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -1,0 +1,70 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import os
+import sys
+import subprocess as sp
+
+import ah_bootstrap
+from astropy_helpers.setup_helpers import get_package_info as _get_package_info
+from astropy_helpers.version_helpers import _get_version_py_str
+
+from configparser import ConfigParser
+
+
+__all__ = [ 'generate_version_file', 'get_package_info', 'read_metadata',
+           'read_readme' ]
+
+# Get root of asdf-standard documents
+ASDF_STANDARD_ROOT = os.environ.get('ASDF_STANDARD_ROOT', 'asdf-standard')
+
+
+# Freeze build information in version.py
+# We no longer use generate_version_py from astropy_helpers because it imports
+# the asdf module, and we no longer want to enable that kind of bad behavior
+def generate_version_file(package_dir, package_name, version, release):
+    version_py = os.path.join(package_dir, package_name, 'version.py')
+    with open(version_py, 'w') as f:
+        f.write(_get_version_py_str('asdf', version, None, release, False))
+
+
+# Get configuration information from all of the various subpackages.
+# See the docstring for setup_helpers.update_package_files for more details.
+def get_package_info():
+    package_info = _get_package_info()
+
+    # Add the project-global data
+    package_info['package_data'].setdefault('asdf', []).append('data/*')
+
+    # The schemas come from a git submodule, so we deal with them here
+    schema_root = os.path.join(ASDF_STANDARD_ROOT, "schemas")
+
+    package_info['package_dir']['asdf.schemas'] = schema_root
+    package_info['packages'].append('asdf.schemas')
+
+    # The reference files come from a git submodule, so we deal with them here
+    reference_file_root = os.path.join(ASDF_STANDARD_ROOT, "reference_files")
+    if not os.path.exists(reference_file_root):
+        ret = sp.call(['git', 'submodule', 'update', '--init', ASDF_STANDARD_ROOT])
+        if ret != 0 or not os.path.exists(reference_file_root):
+            sys.stderr.write("Failed to initialize 'asdf-standard' submodule\n")
+            sys.exit(ret or 1)
+
+    package_info['package_dir']['asdf.reference_files'] = reference_file_root
+    for dirname in os.listdir(reference_file_root):
+        package_info['package_dir']['asdf.reference_files.' + dirname] = os.path.join(
+            reference_file_root, dirname)
+    package_info['packages'].append('asdf.reference_files')
+
+    return package_info
+
+
+# Get some values from the setup.cfg
+def read_metadata(config_filename):
+    conf = ConfigParser()
+    conf.read([config_filename])
+    return dict(conf.items('metadata'))
+
+
+def read_readme(readme_filename):
+    with open(readme_filename) as ff:
+        return ff.read()


### PR DESCRIPTION
This moves some of the functionality that was previously in `setup.py` into a new file called `setup_helpers.py`. It also unties us a little bit more from some of the weirder parts of `astropy_helpers`. The main motivation was to stop using the parts of `astropy_helpers` that actually import `asdf` as part of the setup script, since this is generally considered to be bad practice.

As a result, this fixed a fairly minor but annoying bug that was introduced by #408.