### PR TITLE
Install git hook to automatically update asdf-standard submodule

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@
 - Fix bug that caused serialized FITS tables to be duplicated in embedded ASDF
   HDU. [#411]
 
+- Install client-side git hook to automatically update ``asdf-standard`` when
+  changing branches. [#420]
+
 1.3.2 (unreleased)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import builtins
 from setuptools import setup
 
 from setup_helpers import (get_package_info, generate_version_file,
-                           read_metadata, read_readme)
+                           read_metadata, read_readme, create_git_hooks)
 
 from astropy_helpers.setup_helpers import register_commands
 from astropy_helpers.git_helpers import get_git_devstr
@@ -63,6 +63,9 @@ extras_require = []
 if os.getenv('CI'):
     extras_require.extend(['lz4>=0.10'])
 
+# This enables the asdf-standard submodule to be updated automatically
+# However, this will not currently work on Windows
+create_git_hooks(os.path.curdir)
 
 setup(name=PACKAGE_NAME,
       version=VERSION,

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -14,7 +14,7 @@ from configparser import ConfigParser
 
 
 __all__ = [ 'generate_version_file', 'get_package_info', 'read_metadata',
-           'read_readme' ]
+           'read_readme', 'create_git_hooks' ]
 
 # Get root of asdf-standard documents
 ASDF_STANDARD_ROOT = os.environ.get('ASDF_STANDARD_ROOT', 'asdf-standard')
@@ -85,3 +85,19 @@ def read_metadata(config_filename):
 def read_readme(readme_filename):
     with open(readme_filename) as ff:
         return ff.read()
+
+
+_hook_script = """#!/bin/bash
+set -eu
+git submodule update asdf-standard
+echo "Updated asdf-standard"
+"""
+
+def create_git_hooks(root_directory):
+    hook_dir = os.path.join(root_directory, '.git', 'hooks')
+    for hook_name in ['post-checkout', 'post-merge']:
+        hook_path = os.path.join(hook_dir, hook_name)
+        if not os.path.exists(hook_path):
+            flags = os.O_CREAT | os.O_WRONLY
+            with open(os.open(hook_path, flags, 0o770), 'w') as ff:
+                ff.write(_hook_script)


### PR DESCRIPTION
This PR adds some logic to `setup.py` to install git hooks for `post-checkout` and `post-merge`. The `post-checkout` hook makes sure that the `asdf-standard` submodule is updated automatically whenever a new branch is checked out. The `post-merge` hook should make sure that `asdf-standard` is updated automatically whenever pulling from a remote.

On the one hand, I think this is pretty clever (if I say so myself). On the other hand, it's maybe too clever, especially since git client hooks can introduce security vulnerabilities. (These particular hooks don't, but the possibility seems to make people wary).

cc @Cadair 