### PR TITLE
Allow import and use of module from source directory and development build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@
   ``.update`` method of ``AsdfInFits``, even though it didn't appear to be
   working previously. [#412]
 
+- Allow package to be imported and used from source directory and builds in
+  development mode. [#420]
+
 1.3.2 (unreleased)
 ------------------
 

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -8,8 +8,15 @@ from . import constants
 from . import util
 
 
-SCHEMA_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), 'schemas'))
+def find_schema_path():
+    dirname = os.path.dirname(__file__)
+
+    # This means we are working within a development build
+    if os.path.exists(os.path.join(dirname, '..', 'asdf-standard')):
+        return os.path.join(dirname, '..', 'asdf-standard', 'schemas')
+
+    # Otherwise, we return the installed location
+    return os.path.join(dirname, 'schemas')
 
 
 class Resolver(object):
@@ -103,7 +110,7 @@ class Resolver(object):
 DEFAULT_URL_MAPPING = [
     (constants.STSCI_SCHEMA_URI_BASE,
      util.filepath_to_url(
-         os.path.join(SCHEMA_PATH, 'stsci.edu')) +
+         os.path.join(find_schema_path(), 'stsci.edu')) +
          '/{url_suffix}.yaml')]
 DEFAULT_TAG_TO_URL_MAPPING = [
     (constants.STSCI_SCHEMA_TAG_BASE,


### PR DESCRIPTION
This is a relatively simple fix that allows the package to be imported and used from the source directory. It also is necessary to support builds in development mode, which was only recently supported in #409.

This partially addresses #414.