### PR TITLE
Ignore open file in FITS test for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ minversion = 3.1
 norecursedirs = build docs/_build
 doctest_plus = enabled
 remote_data_strict = True
+open_files_ignore = test.fits
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
I believe the problem is at the FITS level, and so it is difficult to address in ASDF.

A better way to handle this will be available when https://github.com/astropy/pytest-openfiles/pull/10 is merged and released.