### PR TITLE
fix tag creation in schema tester

### DIFF
--- a/asdf/tests/schema_tester.py
+++ b/asdf/tests/schema_tester.py
@@ -105,6 +105,7 @@ class AsdfSchemaExampleItem(pytest.Item):
     def _find_standard_version(self):
         filename = self.filename
         components = filename[filename.find('schemas') + 1:].split(os.path.sep)
+        tag = "tag:" + ":".join(["{}" for i in range(len(components[1:]))])
         tag = 'tag:{}:{}'.format(components[1], '/'.join(components[2:]))
         name, version = asdftypes.split_tag_version(tag.replace('.yaml', ''))
 


### PR DESCRIPTION
@drdavella This problem surfaced when using the schemas tester in gwcs. To find the tag the tester splits the path to the schema assuming 2 levels of nested directories (like asdf's schemas). With this change the tag is created dynamically.