### PR TITLE
Improvements to test infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
         - PIP_DEPENDENCIES='pytest-astropy pytest-faulthandler'
         - CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4'
         - GWCS_GIT='git+git://github.com/spacetelescope/gwcs.git#egg=gwcs'
+        - MAIN_CMD='python setup.py'
         - SETUP_CMD='test --remote-data'
 
     matrix:
@@ -49,6 +50,9 @@ matrix:
         - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11 SETUP_CMD='test'
         - env: NUMPY_VERSION=1.12 SETUP_CMD='test'
 
+        # run a test using native pytest
+        - env: MAIN_CMD='pytest' SETUP_CMD=''
+
         # latest stable versions
         - env: NUMPY_VERSION=stable SETUP_CMD='test'
 
@@ -69,7 +73,7 @@ install:
     - python setup.py install
 
 script:
-   - python setup.py $SETUP_CMD
+   - $MAIN_CMD $SETUP_CMD
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -1,12 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-
 import pytest
 
-from .... import asdf
-
-from ....tests import helpers
+import asdf
+from asdf.tests import helpers
 
 
 def test_invalid_complex():

--- a/asdf/tags/core/tests/test_external_reference.py
+++ b/asdf/tags/core/tests/test_external_reference.py
@@ -1,5 +1,8 @@
-from ..external_reference import ExternalArrayReference
-from ....tests import helpers
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from asdf.tags.core.external_reference import ExternalArrayReference
+from asdf.tests import helpers
 
 
 def test_roundtrip_external_array(tmpdir):

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -8,7 +8,7 @@ import pytest
 
 from jsonschema import ValidationError
 
-from .... import asdf
+import asdf
 
 
 def test_history():

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -431,17 +431,19 @@ def test_unicode_to_list(tmpdir):
 
 
 def test_inline_masked_array(tmpdir):
+    testfile = os.path.join(str(tmpdir), 'masked.asdf')
+
     tree = {'test': ma.array([1, 2, 3], mask=[0, 1, 0])}
 
     f = asdf.AsdfFile(tree)
     f.set_array_storage(tree['test'], 'inline')
-    f.write_to('masked.asdf')
+    f.write_to(testfile)
 
-    with asdf.AsdfFile.open('masked.asdf') as f2:
+    with asdf.AsdfFile.open(testfile) as f2:
         assert len(list(f2.blocks.internal_blocks)) == 0
         assert_array_equal(f.tree['test'], f2.tree['test'])
 
-    with open('masked.asdf', 'rb') as fd:
+    with open(testfile, 'rb') as fd:
         assert b'null' in fd.read()
 
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -16,11 +16,10 @@ import jsonschema
 
 import yaml
 
-from ....tests import helpers, CustomTestType
-from .... import asdf
-from .... import util
-
-from .. import ndarray
+import asdf
+from asdf import util
+from asdf.tests import helpers, CustomTestType
+from asdf.tags.core import ndarray
 
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-
 import pytest
 import warnings
 
@@ -16,8 +15,8 @@ from astropy import time
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
 
-from .... import AsdfFile
-from ....tests import helpers
+from asdf import AsdfFile
+from asdf.tests import helpers
 
 
 @pytest.mark.parametrize('version', ['1.0.0', '1.1.0', '1.2.0'])

--- a/asdf/tests/schema_tester.py
+++ b/asdf/tests/schema_tester.py
@@ -160,16 +160,20 @@ class AsdfSchemaExampleItem(pytest.Item):
 
 
 def pytest_collect_file(path, parent):
-    schema_root = parent.config.getini('asdf_schema_root')
-    if not schema_root:
+    schema_roots = parent.config.getini('asdf_schema_root').split()
+    if not schema_roots:
         return
 
     skip_names = parent.config.getini('asdf_schema_skip_names')
 
-    schema_root = str(os.path.join(str(parent.config.rootdir), schema_root))
+    schema_roots = [os.path.join(str(parent.config.rootdir), root)
+                        for root in schema_roots]
 
-    if path.ext == '.yaml' and str(path).startswith(schema_root):
-        if path.purebasename in skip_names:
-            return None
+    if path.ext != '.yaml':
+        return None
 
-        return AsdfSchemaFile(path, parent)
+    for root in schema_roots:
+        if str(path).startswith(root) and path.purebasename not in skip_names:
+            return AsdfSchemaFile(path, parent)
+
+    return None

--- a/asdf/tests/schema_tester.py
+++ b/asdf/tests/schema_tester.py
@@ -8,8 +8,6 @@ import pytest
 
 import numpy as np
 
-from astropy.tests.helper import catch_warnings
-
 import asdf
 from asdf import AsdfFile
 from asdf import asdftypes
@@ -143,7 +141,8 @@ class AsdfSchemaExampleItem(pytest.Item):
         b._array_storage = "streamed"
 
         try:
-            with catch_warnings() as w:
+            with pytest.warns(None) as w:
+                import warnings
                 ff._open_impl(ff, buff)
             # Do not tolerate any warnings that occur during schema validation
             assert len(w) == 0, helpers.display_warnings(w)

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -7,11 +7,11 @@ import os
 import sys
 import pytest
 
-from .. import asdf
-from .. import asdftypes
-from .. import extension
-from .. import util
-from .. import versioning
+import asdf
+from asdf import asdftypes
+from asdf import extension
+from asdf import util
+from asdf import versioning
 
 from . import helpers, CustomTestType
 

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -14,7 +14,6 @@ from .. import util
 from .. import versioning
 
 from . import helpers, CustomTestType
-from astropy.tests.helper import catch_warnings
 
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
@@ -95,7 +94,7 @@ a: !core/complex-42.0.0
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with catch_warnings() as warning:
+    with pytest.warns(None) as warning:
         with asdf.AsdfFile.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
 
@@ -106,7 +105,7 @@ a: !core/complex-42.0.0
 
     # Make sure warning is repeatable
     buff.seek(0)
-    with catch_warnings() as warning:
+    with pytest.warns(None) as warning:
         with asdf.AsdfFile.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
 
@@ -117,7 +116,7 @@ a: !core/complex-42.0.0
 
     # Make sure the warning does not occur if it is being ignored (default)
     buff.seek(0)
-    with catch_warnings() as warning:
+    with pytest.warns(None) as warning:
         with asdf.AsdfFile.open(buff) as ff:
             assert isinstance(ff.tree['a'], complex)
 
@@ -131,7 +130,7 @@ a: !core/complex-1.0.1
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with catch_warnings() as warning:
+    with pytest.warns(None) as warning:
         with asdf.AsdfFile.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
 
@@ -151,7 +150,7 @@ a: !core/complex-42.0.0
     with open(testfile, 'wb') as handle:
         handle.write(buff.read())
 
-    with catch_warnings() as w:
+    with pytest.warns(None) as w:
         with asdf.AsdfFile.open(testfile, ignore_version_mismatch=False) as ff:
             assert ff._fname == "file://{}".format(testfile)
             assert isinstance(ff.tree['a'], complex)
@@ -200,7 +199,7 @@ flow_thing:
     d: 3.14
 """
     buff = helpers.yaml_to_asdf(yaml)
-    with catch_warnings() as w:
+    with pytest.warns(None) as w:
         data = asdf.AsdfFile.open(
             buff, ignore_version_mismatch=False,
             extensions=CustomFlowExtension())
@@ -336,7 +335,7 @@ undefined_data:
         - !core/complex-1.0.0 3.14j
 """
     buff = helpers.yaml_to_asdf(yaml)
-    with catch_warnings() as warning:
+    with pytest.warns(None) as warning:
         afile = asdf.AsdfFile.open(buff)
         missing = afile.tree['undefined_data']
 
@@ -355,7 +354,7 @@ undefined_data:
 
     # Make sure no warning occurs if explicitly ignored
     buff.seek(0)
-    with catch_warnings() as warning:
+    with pytest.warns(None) as warning:
         afile = asdf.AsdfFile.open(buff, ignore_unrecognized_tag=True)
     assert len(warning) == 0
 
@@ -424,7 +423,7 @@ flow_thing:
     b: 3.14
 """
     old_buff = helpers.yaml_to_asdf(old_yaml)
-    with catch_warnings() as warning:
+    with pytest.warns(None) as warning:
         asdf.AsdfFile.open(old_buff, extensions=CustomFlowExtension())
 
     assert len(warning) == 1, helpers.display_warnings(warning)
@@ -590,7 +589,7 @@ flow_thing:
 """
     buff = helpers.yaml_to_asdf(yaml)
 
-    with catch_warnings() as _warnings:
+    with pytest.warns(None) as _warnings:
         data = asdf.AsdfFile.open(buff, extensions=CustomFlowExtension())
 
     assert len(_warnings) == 1

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -9,8 +9,10 @@ import numpy as np
 
 import pytest
 
-from .. import asdf, compression
-from .. import generic_io
+import asdf
+from asdf import compression
+from asdf import generic_io
+
 from ..tests import helpers
 
 

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -13,7 +13,6 @@ from numpy.testing import assert_array_equal
 astropy = pytest.importorskip('astropy')
 from astropy.io import fits
 from astropy.table import Table
-from astropy.tests.helper import catch_warnings
 
 from .. import asdf
 from .. import fits_embed
@@ -312,7 +311,7 @@ def test_bad_input(tmpdir):
 def test_version_mismatch_file():
     testfile = os.path.join(TEST_DATA_PATH, 'version_mismatch.fits')
 
-    with catch_warnings() as w:
+    with pytest.warns(None) as w:
         with asdf.AsdfFile.open(testfile,
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
@@ -323,12 +322,12 @@ def test_version_mismatch_file():
         "'{}', but latest supported version is 1.0.0".format(testfile))
 
     # Make sure warning does not occur when warning is ignored (default)
-    with catch_warnings() as w:
+    with pytest.warns(None) as w:
         with asdf.AsdfFile.open(testfile) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
     assert len(w) == 0, display_warnings(w)
 
-    with catch_warnings() as w:
+    with pytest.warns(None) as w:
         with fits_embed.AsdfInFits.open(testfile,
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
@@ -338,7 +337,7 @@ def test_version_mismatch_file():
         "'{}', but latest supported version is 1.0.0".format(testfile))
 
     # Make sure warning does not occur when warning is ignored (default)
-    with catch_warnings() as w:
+    with pytest.warns(None) as w:
         with fits_embed.AsdfInFits.open(testfile) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
     assert len(w) == 0, display_warnings(w)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -122,9 +122,9 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
             assert_tree_match(asdf_in_fits.tree, ff2.tree)
 
             ff = asdf.AsdfFile(copy.deepcopy(ff2.tree))
-            ff.write_to('test.asdf')
+            ff.write_to(os.path.join(str(tmpdir), 'test.asdf'))
 
-    with asdf.AsdfFile.open('test.asdf') as ff:
+    with asdf.AsdfFile.open(os.path.join(str(tmpdir), 'test.asdf')) as ff:
         assert_tree_match(asdf_in_fits.tree, ff.tree)
 
 

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -14,9 +14,10 @@ astropy = pytest.importorskip('astropy')
 from astropy.io import fits
 from astropy.table import Table
 
-from .. import asdf
-from .. import fits_embed
-from .. import open as asdf_open
+import asdf
+from asdf import fits_embed
+from asdf import open as asdf_open
+
 from .helpers import assert_tree_match, yaml_to_asdf, display_warnings
 
 

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -11,9 +11,10 @@ import urllib.request as urllib_request
 
 import numpy as np
 
-from .. import asdf
-from .. import generic_io
-from .. import util
+import asdf
+from asdf import util
+from asdf import generic_io
+from asdf.asdf import is_asdf_file
 
 from . import helpers
 # The only reason for importing these is to use them in the fixture below
@@ -763,5 +764,5 @@ def test_is_asdf(tmpdir):
     hdul.append(imhdu)
     path = os.path.join(str(tmpdir), 'test.fits')
     hdul.writeto(path)
-    assert not asdf.is_asdf_file(path)
-    assert asdf.is_asdf_file(asdf.AsdfFile())
+    assert not is_asdf_file(path)
+    assert is_asdf_file(asdf.AsdfFile())

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -9,15 +9,16 @@ from astropy.modeling import models
 
 import pytest
 
-from .. import asdf
-from .. import block
-from .. import constants
-from .. import extension
-from .. import generic_io
-from .. import treeutil
-from .. import versioning
+import asdf
+from asdf import block
+from asdf import constants
+from asdf import extension
+from asdf import generic_io
+from asdf import treeutil
+from asdf import versioning
+from asdf.exceptions import AsdfDeprecationWarning
+
 from ..tests.helpers import assert_tree_match
-from ..exceptions import AsdfDeprecationWarning
 
 
 def test_no_yaml_end_marker(tmpdir):

--- a/asdf/tests/test_reference.py
+++ b/asdf/tests/test_reference.py
@@ -223,7 +223,9 @@ def test_make_reference(tmpdir):
         assert ff.tree['ref']._uri == 'external.asdf#f~0o~0o~1/a'
 
 
-def test_internal_reference():
+def test_internal_reference(tmpdir):
+    testfile = os.path.join(str(tmpdir), 'test.asdf')
+
     tree = {
         'foo': 2,
         'bar': {'$ref': '#'}
@@ -239,7 +241,7 @@ def test_internal_reference():
         'foo': 2
     }
     ff = asdf.AsdfFile(
-        tree, uri=util.filepath_to_url(os.path.abspath("test.asdf")))
+        tree, uri=util.filepath_to_url(os.path.abspath(testfile)))
     ff.tree['bar'] = ff.make_reference([])
     buff = io.BytesIO()
     ff.write_to(buff)

--- a/asdf/tests/test_reference.py
+++ b/asdf/tests/test_reference.py
@@ -10,11 +10,10 @@ from numpy.testing import assert_array_equal
 
 import pytest
 
-from .. import asdf
-from .. import reference
-from .. import util
-
-from ..tags.core import ndarray
+import asdf
+from asdf import reference
+from asdf import util
+from asdf.tags.core import ndarray
 
 from .helpers import assert_tree_match
 

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -23,7 +23,6 @@ from asdf import util
 from asdf import yamlutil
 
 from asdf.tests import helpers
-from astropy.tests.helper import catch_warnings
 
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
@@ -279,7 +278,7 @@ custom: !<tag:nowhere.org:custom/custom-1.0.0>
     # This should cause a warning but not an error because without explicitly
     # providing an extension, our custom type will not be recognized and will
     # simply be converted to a raw type.
-    with catch_warnings() as warning:
+    with pytest.warns(None) as warning:
         with asdf.AsdfFile.open(buff):
             pass
     assert len(warning) == 1
@@ -508,7 +507,7 @@ custom: !<tag:nowhere.org:custom/missing-1.1.0>
   b: {foo: 42}
     """
     buff = helpers.yaml_to_asdf(yaml)
-    with catch_warnings() as w:
+    with pytest.warns(None) as w:
         with asdf.AsdfFile.open(buff, extensions=[DefaultTypeExtension()]) as ff:
             assert ff.tree['custom']['b']['foo'] == 42
 

--- a/asdf/tests/test_stream.py
+++ b/asdf/tests/test_stream.py
@@ -10,9 +10,9 @@ from numpy.testing import assert_array_equal
 
 import pytest
 
-from .. import asdf
-from .. import generic_io
-from .. import stream
+import asdf
+from asdf import generic_io
+from asdf import stream
 
 
 def test_stream():

--- a/asdf/tests/test_suite.py
+++ b/asdf/tests/test_suite.py
@@ -10,7 +10,6 @@ from asdf import open as asdf_open
 from asdf import versioning
 
 from .helpers import assert_tree_match, display_warnings
-from astropy.tests.helper import catch_warnings
 
 
 def get_test_id(reference_file_path):
@@ -48,7 +47,7 @@ def _compare_trees(name_without_ext, expect_warnings=False):
                 # Make sure to only suppress warnings when they are expected.
                 # However, there's still a chance of missing warnings that we
                 # actually care about here.
-                with catch_warnings(RuntimeWarning) as w:
+                with pytest.warns(RuntimeWarning) as w:
                     _compare_func()
             else:
                 _compare_func()

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -5,7 +5,7 @@
 import pytest
 from itertools import combinations
 
-from ..versioning import AsdfVersion, AsdfSpec
+from asdf.versioning import AsdfVersion, AsdfSpec
 
 
 def test_version_constructor():

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -10,9 +10,9 @@ import pytest
 
 import yaml
 
-from .. import asdf
-from .. import tagged
-from .. import treeutil
+import asdf
+from asdf import tagged
+from asdf import treeutil
 
 from . import helpers
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,32 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
+import os
+import pytest
+from _pytest.doctest import DoctestItem
 
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 enable_deprecations_as_exceptions()
+
+@pytest.fixture(autouse=True)
+def _docdir(request):
+    """
+    Make sure that doctests run in a temporary directory so that any files that
+    are created as part of the test get removed automatically.
+    """
+
+    # Trigger ONLY for the doctests.
+    if isinstance(request.node, DoctestItem):
+
+        # Get the fixture dynamically by its name.
+        tmpdir = request.getfuncargvalue('tmpdir')
+
+        # Chdir only for the duration of the test.
+        olddir = os.getcwd()
+        tmpdir.chdir()
+        yield
+        os.chdir(olddir)
+
+    else:
+        # For normal tests, we have to yield, since this is a yield-fixture.
+        yield

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,13 +8,14 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-testpaths = asdf docs
+testpaths = asdf docs asdf-standard/schemas
 minversion = 3.1
 norecursedirs = build docs/_build
 doctest_plus = enabled
 remote_data_strict = True
 open_files_ignore = test.fits
-asdf_schema_root = asdf/schemas
+# Account for both the astropy test runner case and the native pytest case
+asdf_schema_root = asdf-standard/schemas asdf/schemas
 asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
 addopts = --doctest-rst
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ remote_data_strict = True
 open_files_ignore = test.fits
 asdf_schema_root = asdf/schemas
 asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
+addopts = --doctest-rst
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This closes #245, closes #308, and closes #356.

I think this also enables us to take care of #153 if we so choose. However, this is an all-or-nothing decision. It means we won't be able to use the Astropy test runner at all (which is not necessarily a bad thing).