### PR TITLE
Optional top-level validation with custom schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@
 
 1.4.0 (unreleased)
 ------------------
-- Add and ``ExternalArrayReference`` type for referencing arrays in external files. [#400]
+
+- Add an ``ExternalArrayReference`` type for referencing arrays in external files. [#400]
 
 - Improve the way URIs are detected for ASDF-in-FITS files in order to fix bug
   with reading gzipped ASDF-in-FITS files. [#416]
@@ -39,6 +40,10 @@
   development mode. [#420]
 
 - Add command to ``asdftool`` for querying installed extensions. [#418]
+
+- Implement optional top-level validation pass using custom schema. This can be
+  used to ensure that particular ASDF files follow custom conventions beyond
+  those enforced by the standard. [#442]
 
 1.3.2 (unreleased)
 ------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -10,6 +10,7 @@ import warnings
 import importlib
 
 import numpy as np
+from jsonschema import ValidationError
 
 from . import block
 from . import constants
@@ -533,7 +534,13 @@ class AsdfFile(versioning.VersionedMixin):
         tree = reference.find_references(tree, self)
         if not do_not_fill_defaults:
             schema.fill_defaults(tree, self)
-        self._validate(tree)
+
+        try:
+            self._validate(tree)
+        except ValidationError:
+            self.close()
+            raise
+
         tree = yamlutil.tagged_tree_to_custom_tree(tree, self, _force_raw_types)
 
         self._tree = tree

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -286,7 +286,8 @@ class AsdfFile(versioning.VersionedMixin):
     @tree.setter
     def tree(self, tree):
         asdf_object = AsdfObject(tree)
-        self._validate(asdf_object)
+        # Only perform custom validation if the tree is not empty
+        self._validate(asdf_object, custom=bool(tree))
         self._tree = asdf_object
 
     def __getitem__(self, key):
@@ -302,12 +303,12 @@ class AsdfFile(versioning.VersionedMixin):
         """
         return self._comments
 
-    def _validate(self, tree):
+    def _validate(self, tree, custom=True):
         tagged_tree = yamlutil.custom_tree_to_tagged_tree(
             tree, self)
         schema.validate(tagged_tree, self)
         # Perform secondary validation pass if requested
-        if self._custom_schema:
+        if custom and self._custom_schema:
             schema.validate(tagged_tree, self, self._custom_schema)
 
     def validate(self):

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -33,10 +33,6 @@ else:  # pragma: no cover
 __all__ = ['validate', 'fill_defaults', 'remove_defaults', 'check_schema']
 
 
-SCHEMA_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), 'schemas'))
-
-
 PYTHON_TYPE_TO_YAML_TAG = {
     None: 'null',
     str: 'str',
@@ -60,14 +56,10 @@ def _type_to_tag(type_):
     for base in type_.mro():
         if base in PYTHON_TYPE_TO_YAML_TAG:
             return PYTHON_TYPE_TO_YAML_TAG[base]
+    return None
 
 
 def validate_tag(validator, tagname, instance, schema):
-    # Shortcut: If the instance is a subclass of YAMLObject then we know it
-    # should have a yaml_tag attribute attached; otherwise we have to use a
-    # hack of reserializing the object and seeing what tags get attached to it
-    # (though there may be a better way than this).
-
     if hasattr(instance, '_tag'):
         instance_tag = instance._tag
     else:

--- a/asdf/tests/data/custom_schema.yaml
+++ b/asdf/tests/data/custom_schema.yaml
@@ -1,0 +1,31 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+title: |
+  Top-level custom schema used for testing.
+
+description: |
+  This schema is used to test the custom schema validation mechanism in ASDF.
+
+type: object
+properties:
+  foo:
+    description: |
+      Your generic kind of foo.
+    type: object
+    properties:
+      x:
+        type: number
+      y:
+        type: number
+
+  bar:
+    type: object
+    properties:
+      a:
+        type: string
+      b:
+        type: string
+
+required: [foo, bar]
+additionalProperties: true

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -542,3 +542,46 @@ def test_assert_roundtrip_with_extension(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, extensions=[CustomTypeExtension()])
 
     assert called_custom_assert_equal[0] is True
+
+
+def test_custom_validation_bad(tmpdir):
+    custom_schema_path = os.path.join(TEST_DATA_PATH, 'custom_schema.yaml')
+    asdf_file = os.path.join(str(tmpdir), 'out.asdf')
+
+    # This tree does not conform to the custom schema
+    tree = {'stuff': 42, 'other_stuff': 'hello'}
+
+    # Creating file without custom schema should pass
+    with asdf.AsdfFile(tree) as ff:
+        ff.write_to(asdf_file)
+
+    # Creating file using custom schema should fail
+    with pytest.raises(ValidationError):
+        with asdf.AsdfFile(tree, custom_schema=custom_schema_path) as ff:
+            pass
+
+    # Opening file without custom schema should pass
+    with asdf.open(asdf_file) as ff:
+        pass
+
+    # Opening file with custom schema should fail
+    with pytest.raises(ValidationError):
+        with asdf.open(asdf_file, custom_schema=custom_schema_path) as ff:
+            pass
+
+
+def test_custom_validation_good(tmpdir):
+    custom_schema_path = os.path.join(TEST_DATA_PATH, 'custom_schema.yaml')
+    asdf_file = os.path.join(str(tmpdir), 'out.asdf')
+
+    # This tree conforms to the custom schema
+    tree = {
+        'foo': {'x': 42, 'y': 10},
+        'bar': {'a': 'hello', 'b': 'banjo'}
+    }
+
+    with asdf.AsdfFile(tree, custom_schema=custom_schema_path) as ff:
+        ff.write_to(asdf_file)
+
+    with asdf.open(asdf_file, custom_schema=custom_schema_path) as ff:
+        pass


### PR DESCRIPTION
This closes #440. It adds an argument `custom_schema` to `Asdf.open` and also the `asdf.AsdfFile` constructor. The argument value should be the path to a custom schema that will be used in a secondary validation pass. This is intended to allow users to ensure that particular ASDF files follow custom conventions beyond those enforced by the standard.

This PR can probably be merged as-is (after review), but it may be useful to provide additional features/functionality in the future.

cc @Cadair 