### PR TITLE
Update core schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@
   used to ensure that particular ASDF files follow custom conventions beyond
   those enforced by the standard. [#442]
 
+- Remove restrictions affecting top-level attributes ``data``, ``wcs``, and
+  ``fits``. Bump top-level ASDF schema version to v1.1.0. [#444]
+
 1.3.2 (2018-02-22)
 ------------------
 

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -7,6 +7,7 @@ from ...asdftypes import AsdfType
 
 class AsdfObject(dict, AsdfType):
     name = 'core/asdf'
+    version = '1.1.0'
 
 
 class Software(dict, AsdfType):

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -235,7 +235,7 @@ def yaml_to_asdf(yaml_content, yaml_headers=True, standard_version=None):
 %YAML 1.1
 %TAG ! tag:stsci.edu:asdf/
 --- !core/asdf-{0}
-""".format('1.0.0', standard_version).encode('ascii'))
+""".format(AsdfObject.version, standard_version).encode('ascii'))
     buff.write(yaml_content)
     if yaml_headers:
         buff.write(b"\n...\n")

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -67,19 +67,6 @@ class TagReferenceType(asdftypes.CustomType):
         return node
 
 
-def test_violate_toplevel_schema():
-    tree = {'fits': 'This does not look like a FITS file'}
-
-    with pytest.raises(ValidationError):
-        asdf.AsdfFile(tree)
-
-    ff = asdf.AsdfFile()
-    ff.tree['fits'] = 'This does not look like a FITS file'
-    with pytest.raises(ValidationError):
-        buff = io.BytesIO()
-        ff.write_to(buff)
-
-
 @pytest.mark.importorskip('astropy')
 def test_tagging_scalars():
     yaml = """

--- a/docs/asdf/examples.rst
+++ b/docs/asdf/examples.rst
@@ -58,41 +58,7 @@ the array, but the actual array content is in a binary block.
 Schema validation
 -----------------
 
-In the current draft of the ASDF schema, there are very few elements
-defined at the top-level -- for the most part, the top-level can
-contain any elements.  One of the few specified elements is ``data``:
-it must be an array, and is used to specify the "main" data content
-(for some definition of "main") so that tools that merely want to view
-or preview the ASDF file have a standard location to find the most
-interesting data.  If you set this to anything but an array, ``asdf``
-will complain::
-
-    >>> from asdf import AsdfFile
-    >>> tree = {'data': 'Not an array'}
-    >>> AsdfFile(tree)  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    ...
-    ValidationError: mismatched tags, wanted
-    'tag:stsci.edu:asdf/core/ndarray-1.0.0', got
-    'tag:yaml.org,2002:str'
-    ...
-
-This validation happens only when a `AsdfFile` is instantiated, read
-or saved, so it's still possible to get the tree into an invalid
-intermediate state::
-
-    >>> from asdf import AsdfFile
-    >>> ff = AsdfFile()
-    >>> ff.tree['data'] = 'Not an array'
-    >>> # The ASDF file is now invalid, but asdf will tell us when
-    >>> # we write it out.
-    >>> ff.write_to('test.asdf')  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    ...
-    ValidationError: mismatched tags, wanted
-    'tag:stsci.edu:asdf/core/ndarray-1.0.0', got
-    'tag:yaml.org,2002:str'
-    ...
+This section needs to be updated later.
 
 Sharing of data
 ---------------


### PR DESCRIPTION
This fixes #426. It removes the restrictions on the top-level `data`, `wcs` and `fits` attributes. If such restrictions are still desirable for certain files, then the `custom_schema` option introduced in #442 should be used to impose additional restrictions.

@nden, @perrygreenfield I'm not sure if we have come to a final decision about this, but I wanted to introduce the changes for comments before moving forward.

This should be merged in conjunction with https://github.com/spacetelescope/asdf-standard/pull/155.

The documentation on schema validation should be updated before this is merged.

cc @Cadair 