### PR TITLE
Test against Astropy v3.0 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - PYTHON_VERSION=3.6
-        - ASTROPY_VERSION=development
+        - ASTROPY_VERSION=stable
         - NUMPY_VERSION=stable
         - PIP_DEPENDENCIES='pytest-astropy pytest-faulthandler'
         - CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4'
@@ -51,7 +51,8 @@ matrix:
         - env: NUMPY_VERSION=1.12 SETUP_CMD='test'
 
         # run a test using native pytest
-        - env: MAIN_CMD='pytest' SETUP_CMD=''
+        # also test against development version of Astropy
+        - env: MAIN_CMD='pytest' SETUP_CMD='' ASTROPY_VERSION=development
 
         # latest stable versions
         - env: NUMPY_VERSION=stable SETUP_CMD='test'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       SETUP_CMD: "test"
       NUMPY_VERSION: "stable"
-      ASTROPY_VERSION: "development"
+      ASTROPY_VERSION: "stable"
       GWCS_GIT: "git+git://github.com/spacetelescope/gwcs.git#egg=gwcs"
       CONDA_DEPENDENCIES: "semantic_version jsonschema pyyaml six lz4"
       PIP_DEPENDENCIES: "pytest-astropy pytest-faulthandler"
@@ -29,6 +29,10 @@ environment:
         platform: x64
 
       - PYTHON_VERSION: "3.6"
+        platform: x64
+
+      - PYTHON_VERSION: "3.6"
+        ASTROPY_VERSION: "stable"
         platform: x64
 
       # Tests against development version of numpy may fail


### PR DESCRIPTION
Now that `astropy-3.0` is available, run CI tests against the stable version by default. Also added test case for development version.