### PR TITLE
Disable 2to3 on v1.3.x release series

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,6 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
       entry_points=entry_points,
       **package_info
 )


### PR DESCRIPTION
This is required for compatibility with newer versions of `astropy-helpers`. This should fix #447.