### PR TITLE
Allow basic testing with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ htmlcov
 .coverage
 MANIFEST
 
+# Tox
+.tox
+.pytest_cache
+
 # Sphinx
 docs/api
 docs/_build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst
+include README.md
 include CHANGES.rst
 
 include ez_setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py36-{stable,dev}
+[testenv]
+deps=
+    pytest
+    stable: astropy
+    stable: gwcs
+    pytest-astropy
+    pytest-sugar
+commands=
+    dev: pip install --no-deps git+git://github.com/astropy/astropy
+    dev: pip install --no-deps git+git://github.com/spacetelescope/gwcs
+    pytest


### PR DESCRIPTION
While `tox` isn't a great long-term solution for testing since it doesn't currently support conda, it is useful for doing tests locally across multiple environments.