### PR TITLE
Fix failing WCS tests

### DIFF
--- a/asdf/tags/wcs/tests/data/test_frames-1.1.0.asdf
+++ b/asdf/tags/wcs/tests/data/test_frames-1.1.0.asdf
@@ -1,0 +1,97 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.1.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.0.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 1.3.3}
+frames:
+- !wcs/celestial_frame-1.1.0
+  axes_names: [lon, lat]
+  name: CelestialFrame
+  reference_frame: {type: ICRS}
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [lon, lat]
+  name: CelestialFrame
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: FK5}
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [lon, lat]
+  name: CelestialFrame
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
+      00:00:00.000', type: FK4}
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [lon, lat]
+  name: CelestialFrame
+  reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
+      00:00:00.000', type: FK4_noeterms}
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [lon, lat]
+  name: CelestialFrame
+  reference_frame: {type: galactic}
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [x, y, z]
+  axes_order: [0, 1, 2]
+  name: CelestialFrame
+  reference_frame:
+    galcen_coord: !wcs/icrs_coord-1.1.0
+      dec: {value: -28.936175}
+      ra:
+        value: 266.4051
+        wrap_angle: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 deg, value: 360.0}
+    galcen_distance: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 5.0}
+    galcen_v_sun:
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 11.1}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 232.24}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 7.25}
+    roll: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 deg, value: 3.0}
+    type: galactocentric
+    z_sun: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 pc, value: 3.0}
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [lon, lat]
+  name: CelestialFrame
+  reference_frame:
+    obsgeoloc:
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 3.0856775814671916e+16}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 9.257032744401574e+16}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 6.1713551629343834e+19}
+    obsgeovel:
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 2.0}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 1.0}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 8.0}
+    obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
+    type: GCRS
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [lon, lat]
+  name: CelestialFrame
+  reference_frame: {obstime: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: CIRS}
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [x, y, z]
+  axes_order: [0, 1, 2]
+  name: CelestialFrame
+  reference_frame: {obstime: !time/time-1.1.0 '2022-01-03 00:00:00.000', type: ITRS}
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+- !wcs/celestial_frame-1.1.0
+  axes_names: [lon, lat]
+  name: CelestialFrame
+  reference_frame:
+    equinox: !time/time-1.1.0 J2000.000
+    obsgeoloc:
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 3.0856775814671916e+16}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 9.257032744401574e+16}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 6.1713551629343834e+19}
+    obsgeovel:
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 2.0}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 1.0}
+    - !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 8.0}
+    obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
+    type: precessed_geocentric
+  unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+...

--- a/asdf/tags/wcs/tests/data/test_wcs-1.0.0.asdf
+++ b/asdf/tags/wcs/tests/data/test_wcs-1.0.0.asdf
@@ -1,0 +1,46 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.0.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.0.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 1.3.3}
+gw1: !wcs/wcs-1.0.0
+  name: ''
+  steps:
+  - !wcs/step-1.0.0
+    frame: detector
+    transform: !transform/concatenate-1.1.0
+      forward:
+      - !transform/shift-1.1.0 {offset: 12.4}
+      - !transform/shift-1.1.0 {offset: -2.0}
+  - !wcs/step-1.0.0 {frame: icrs}
+gw2: !wcs/wcs-1.0.0
+  name: ''
+  steps:
+  - !wcs/step-1.0.0
+    frame: detector
+    transform: !transform/concatenate-1.1.0
+      forward:
+      - !transform/shift-1.1.0 {offset: 12.4}
+      - !transform/shift-1.1.0 {offset: -2.0}
+  - !wcs/step-1.0.0 {frame: icrs}
+gw3: !wcs/wcs-1.0.0
+  name: ''
+  steps:
+  - !wcs/step-1.0.0
+    frame: !wcs/frame-1.1.0
+      axes_names: [x, y]
+      name: detector
+      unit: [!unit/unit-1.0.0 pixel, !unit/unit-1.0.0 pixel]
+    transform: !transform/concatenate-1.1.0
+      forward:
+      - !transform/shift-1.1.0 {offset: 12.4}
+      - !transform/shift-1.1.0 {offset: -2.0}
+  - !wcs/step-1.0.0
+    frame: !wcs/celestial_frame-1.0.0
+      axes_names: [lon, lat]
+      name: icrs
+      reference_frame: {type: ICRS}
+      unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+...

--- a/asdf/tags/wcs/tests/data/test_wcs-1.1.0.asdf
+++ b/asdf/tags/wcs/tests/data/test_wcs-1.1.0.asdf
@@ -1,0 +1,46 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.1.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.0.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 1.3.3}
+gw1: !wcs/wcs-1.0.0
+  name: ''
+  steps:
+  - !wcs/step-1.0.0
+    frame: detector
+    transform: !transform/concatenate-1.1.0
+      forward:
+      - !transform/shift-1.1.0 {offset: 12.4}
+      - !transform/shift-1.1.0 {offset: -2.0}
+  - !wcs/step-1.0.0 {frame: icrs}
+gw2: !wcs/wcs-1.0.0
+  name: ''
+  steps:
+  - !wcs/step-1.0.0
+    frame: detector
+    transform: !transform/concatenate-1.1.0
+      forward:
+      - !transform/shift-1.1.0 {offset: 12.4}
+      - !transform/shift-1.1.0 {offset: -2.0}
+  - !wcs/step-1.0.0 {frame: icrs}
+gw3: !wcs/wcs-1.0.0
+  name: ''
+  steps:
+  - !wcs/step-1.0.0
+    frame: !wcs/frame-1.1.0
+      axes_names: [x, y]
+      name: detector
+      unit: [!unit/unit-1.0.0 pixel, !unit/unit-1.0.0 pixel]
+    transform: !transform/concatenate-1.1.0
+      forward:
+      - !transform/shift-1.1.0 {offset: 12.4}
+      - !transform/shift-1.1.0 {offset: -2.0}
+  - !wcs/step-1.0.0
+    frame: !wcs/celestial_frame-1.1.0
+      axes_names: [lon, lat]
+      name: icrs
+      reference_frame: {type: ICRS}
+      unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+...

--- a/asdf/tags/wcs/tests/setup_package.py
+++ b/asdf/tags/wcs/tests/setup_package.py
@@ -1,0 +1,5 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+def get_package_data():  # pragma: no cover
+    return { str(_PACKAGE_NAME_ + '.tags.wcs.tests'): ['data/*.asdf'] }

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -5,7 +5,7 @@ import pytest
 import warnings
 
 gwcs = pytest.importorskip('gwcs')
-astropy = pytest.importorskip('astropy', minversion='1.3.3')
+astropy = pytest.importorskip('astropy', minversion='3.0.0')
 
 from astropy.modeling import models
 from astropy import coordinates as coord

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -32,11 +32,10 @@ def test_read_wcs(version):
     GWCS."""
 
     filename = os.path.join(TEST_DATA_PATH, "test_wcs-{}.asdf".format(version))
-    tree = asdf.open(filename)
-
-    assert isinstance(tree['gw1'], wcs.WCS)
-    assert isinstance(tree['gw2'], wcs.WCS)
-    assert isinstance(tree['gw3'], wcs.WCS)
+    with asdf.open(filename) as tree:
+        assert isinstance(tree['gw1'], wcs.WCS)
+        assert isinstance(tree['gw2'], wcs.WCS)
+        assert isinstance(tree['gw3'], wcs.WCS)
 
 
 @pytest.mark.parametrize('version', ['1.0.0', '1.1.0', '1.2.0'])
@@ -70,10 +69,9 @@ def test_frames(tmpdir):
     frames have moved to Astropy and gwcs."""
 
     filename = os.path.join(TEST_DATA_PATH, "test_frames-1.1.0.asdf")
-    tree = asdf.open(filename)
-
-    for frame in tree['frames']:
-        assert isinstance(frame, cf.CoordinateFrame)
+    with asdf.open(filename) as tree:
+        for frame in tree['frames']:
+            assert isinstance(frame, cf.CoordinateFrame)
 
 
 def test_backwards_compat_galcen():

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
+import os
 import pytest
 import warnings
 
@@ -15,28 +16,27 @@ from astropy import time
 from gwcs import coordinate_frames as cf
 from gwcs import wcs
 
+import asdf
 from asdf import AsdfFile
 from asdf.tests import helpers
 
 
-@pytest.mark.parametrize('version', ['1.0.0', '1.1.0', '1.2.0'])
-def test_create_wcs(tmpdir, version):
-    m1 = models.Shift(12.4) & models.Shift(-2)
-    m2 = models.Scale(2) & models.Scale(-2)
-    icrs = cf.CelestialFrame(name='icrs', reference_frame=coord.ICRS())
-    det = cf.Frame2D(name='detector', axes_order=(0,1))
-    gw1 = wcs.WCS(output_frame='icrs', input_frame='detector', forward_transform=m1)
-    gw2 = wcs.WCS(output_frame='icrs', forward_transform=m1)
-    gw3 = wcs.WCS(output_frame=icrs, input_frame=det, forward_transform=m1)
+TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 
-    tree = {
-        'gw1': gw1,
-        'gw2': gw2,
-        'gw3': gw3
-    }
 
-    write_options = dict(version=version)
-    helpers.assert_roundtrip_tree(tree, tmpdir, write_options=write_options)
+@pytest.mark.parametrize('version', ['1.0.0', '1.1.0'])
+def test_read_wcs(version):
+    """Simple test to make sure that we can read older versions of files
+    containing WCS objects. We do not test against versions of the ASDF format
+    more recent than 1.1.0 since the schemas and tags have moved to Astropy and
+    GWCS."""
+
+    filename = os.path.join(TEST_DATA_PATH, "test_wcs-{}.asdf".format(version))
+    tree = asdf.open(filename)
+
+    assert isinstance(tree['gw1'], wcs.WCS)
+    assert isinstance(tree['gw2'], wcs.WCS)
+    assert isinstance(tree['gw3'], wcs.WCS)
 
 
 @pytest.mark.parametrize('version', ['1.0.0', '1.1.0', '1.2.0'])
@@ -62,83 +62,18 @@ def test_composite_frame(tmpdir, version):
     write_options = dict(version=version)
     helpers.assert_roundtrip_tree(tree, tmpdir, write_options=write_options)
 
-def create_test_frames():
-    """Creates an array of frames to be used for testing."""
 
-    # Suppress warnings from astropy that are caused by having 'dubious' dates
-    # that are too far in the future. It's not a concern for the purposes of
-    # unit tests. See issue #5809 on the astropy GitHub for discussion.
-    from astropy._erfa import ErfaWarning
-    warnings.simplefilter("ignore", ErfaWarning)
+def test_frames(tmpdir):
+    """Simple check to make sure we can still read older files with frames.
+    Serialization of these frames was only introduced in v1.1.0, and we do not
+    test any subsequent ASDF versions since the schemas and tags for those
+    frames have moved to Astropy and gwcs."""
 
-    frames = [
-        cf.Frame2D(name='detector', axes_order=(0,1)),
+    filename = os.path.join(TEST_DATA_PATH, "test_frames-1.1.0.asdf")
+    tree = asdf.open(filename)
 
-        cf.CelestialFrame(reference_frame=coord.ICRS()),
-
-        cf.CelestialFrame(
-            reference_frame=coord.FK5(equinox=time.Time('2010-01-01'))),
-
-        cf.CelestialFrame(
-            reference_frame=coord.FK4(
-                equinox=time.Time('2010-01-01'),
-                obstime=time.Time('2015-01-01'))
-            ),
-
-        cf.CelestialFrame(
-            reference_frame=coord.FK4NoETerms(
-                equinox=time.Time('2010-01-01'),
-                obstime=time.Time('2015-01-01'))
-            ),
-
-        cf.CelestialFrame(
-            reference_frame=coord.Galactic()),
-
-        cf.CelestialFrame(
-            reference_frame=coord.Galactocentric(
-                # A default galcen_coord is used since none is provided here
-                galcen_distance=5.0*u.m,
-                z_sun=3*u.pc,
-                roll=3*u.deg)
-            ),
-
-        cf.CelestialFrame(
-            reference_frame=coord.GCRS(
-                obstime=time.Time('2010-01-01'),
-                obsgeoloc=[1, 3, 2000] * u.pc,
-                obsgeovel=[2, 1, 8] * (u.m/u.s))),
-
-        cf.CelestialFrame(
-            reference_frame=coord.CIRS(
-                obstime=time.Time('2010-01-01'))),
-
-        cf.CelestialFrame(
-            reference_frame=coord.ITRS(
-                obstime=time.Time('2022-01-03'))),
-
-        cf.CelestialFrame(
-            reference_frame=coord.PrecessedGeocentric(
-                obstime=time.Time('2010-01-01'),
-                obsgeoloc=[1, 3, 2000] * u.pc,
-                obsgeovel=[2, 1, 8] * (u.m/u.s)))
-    ]
-
-    return frames
-
-
-@pytest.mark.parametrize('version', ['1.0.0', '1.1.0', '1.2.0'])
-def test_frames(tmpdir, version):
-    # Version 1.0.0 test currently fails. It may be the case that some of the
-    # frame types simply weren't supported in version 1.0.0.
-    if version == '1.0.0':
-        pytest.xfail()
-
-    tree = {
-        'frames': create_test_frames()
-    }
-
-    write_options = dict(version=version)
-    helpers.assert_roundtrip_tree(tree, tmpdir, write_options=write_options)
+    for frame in tree['frames']:
+        assert isinstance(frame, cf.CoordinateFrame)
 
 
 def test_backwards_compat_galcen():

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ deps=
 commands=
     dev: pip install --no-deps git+git://github.com/astropy/astropy
     dev: pip install --no-deps git+git://github.com/spacetelescope/gwcs
-    pytest
+    pytest {posargs}


### PR DESCRIPTION
Ever since new WCS-related schemas were updated in Astropy (https://github.com/astropy/astropy/pull/7079) and gwcs (https://github.com/spacetelescope/gwcs/pull/127), WCS-related tests have been failing in ASDF. This is because we have been attempting to round-trip older versions of files against newer schemas and tags, which doesn't make sense. Instead, we should simply try to read older files and do a few sanity checks, just to make sure that we maintain backwards compatibility when reading.