### PR TITLE
Fix CustomType inheritance in custom type used in test

### DIFF
--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -224,24 +224,13 @@ def test_versioned_writing():
 
     versioning.supported_versions.append(versioning.AsdfVersion('42.0.0'))
 
-    # Currently this class cannot inherit directly from ComplexType because if
-    # it does it pollutes ASDF's built-in extension and causes later tests that
-    # rely on ComplexType to fail. However, if CustomType is ever implemented
-    # as an abstract base class, then it will be possible to use it as a mix-in
-    # and also inherit from ComplexType. This means the only method/attribute
-    # that will need to be explicitly defined will be 'version'.
-    class FancyComplexType(asdftypes.CustomType):
-        name = ComplexType.name
+    class FancyComplexType(ComplexType, asdftypes.CustomType):
         version = (42, 0, 0)
-        types = ComplexType.types
 
-        @classmethod
-        def to_tree(cls, node, ctx):
-            return ComplexType.to_tree(node, ctx)
-
-        @classmethod
-        def from_tree(cls, tree, ctx):
-            return ComplexType.from_tree(tree, ctx)
+    # This is a sanity check to ensure that the custom FancyComplexType does
+    # not get added to ASDF's built-in extension, since this would cause any
+    # subsequent tests that rely on ComplexType to fail.
+    assert not issubclass(FancyComplexType, asdftypes.AsdfTypeMeta)
 
     class FancyComplexExtension(object):
         @property


### PR DESCRIPTION
This fix was motivated by #304. While it does not address that issue directly, it does mean the underlying assumptions are no longer valid. So it closes #304.