### PR TITLE
Use XTENSION=FOREIGN for ASDF-in-FITS

### DIFF
--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -37,7 +37,17 @@ class _AsdfHDU(fits.hdu.base.NonstandardExtHDU):
     an XTENSION keyword) of ASDF.
     """
 
-    _extension = ASDF_EXTENSION_NAME
+    # Use the FOREIGN keyword here purely in an effort to pass fitsverify.
+    # This HDU does not actually conform to the FOREIGN convention as described
+    # at https://fits.gsfc.nasa.gov/registry/foreign.html. However, the
+    # fitsverify program provided by NASA's FITS office appears to validate
+    # HDUs with the FOREIGN keyword if they otherwise conform to the IMAGE
+    # standard. To make things even more confusing, fitsverify does NOT appear
+    # to validate an HDU that actually conforms to the FOREIGN convention. It
+    # also does not validate an HDU that usese XTENSION=ASDF. We hope to
+    # eventually sort things out with the FITS office, but in the meantime, we
+    # want users of fitsverify to be able to validate our files.
+    _extension = 'FOREIGN'
 
     @classmethod
     def from_buff(cls, buff, compress=False, **kwargs):
@@ -71,7 +81,7 @@ class _AsdfHDU(fits.hdu.base.NonstandardExtHDU):
             ('PCOUNT', 0, 'number of parameters'),
             ('GCOUNT', 1, 'number of groups'),
             ('COMPRESS', compress, 'Uses gzip compression'),
-            ('EXTNAME', cls._extension, 'Name of ASDF extension'),
+            ('EXTNAME', 'ASDF', 'Name of ASDF extension'),
         ]
 
         header = Header(cards)


### PR DESCRIPTION
Use the `FOREIGN` keyword in ASDF-in-FITS HDUs purely in an effort to pass `fitsverify`. 

The new HDU does not actually conform to the `FOREIGN` convention as described [here](https://fits.gsfc.nasa.gov/registry/foreign.html). However, the `fitsverify` program provided by NASA's FITS office appears to validate HDUs with the `FOREIGN` keyword if they otherwise conform to the `IMAGE` standard. 

To make things even more confusing, `fitsverify` does NOT appear to validate an HDU that actually conforms to the `FOREIGN` convention. It also does not validate an HDU that uses `XTENSION=ASDF`. We hope to eventually sort things out with the FITS office, but in the meantime, we want users of `fitsverify` to be able to validate our files.

If you need to convince yourself that this actually works now, open a Python interpreter and try the following:
```python
from asdf.tests.test_fits_embed import create_asdf_in_fits
asdf_in_fits = create_asdf_in_fits()
asdf_in_fits.write_to('asdf.fits')
```

You can open the new file `asdf.fits` to confirm that there is in fact an HDU with `XTENSION=FOREIGN`, and it holds the contents of the ASDF file. You can also run `fitsverify` against this file to confirm that it passes validation.

cc @stscicrawford
