### PR TITLE
Fix bug with new history format

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -203,8 +203,10 @@ class AsdfFile(versioning.VersionedMixin):
 
     def _update_extension_history(self):
 
-        if 'history' not in self.tree or 'extensions' not in self.tree['history']:
+        if 'history' not in self.tree:
             self.tree['history'] = dict(extensions=[])
+        elif 'extensions' not in self.tree['history']:
+            self.tree['history']['extensions'] = []
 
         for extension in self.type_index.get_extensions_used():
             ext_name = util.get_class_name(extension)

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -61,6 +61,28 @@ def test_history():
 
     assert isinstance(ff.tree['history']['entries'][0]['time'], datetime.datetime)
 
+def test_history_to_file(tmpdir):
+
+    tmpfile = str(tmpdir.join('history.asdf'))
+
+    with asdf.AsdfFile() as ff:
+        ff.add_history_entry('This happened',
+                             {'name': 'my_tool',
+                              'homepage': 'http://nowhere.com',
+                              'author': 'John Doe',
+                              'version': '2.0'})
+        ff.write_to(tmpfile)
+
+    with asdf.open(tmpfile) as ff:
+        assert 'entries' in ff.tree['history']
+        assert 'extensions' in ff.tree['history']
+        assert len(ff.tree['history']['entries']) == 1
+
+        entry = ff.tree['history']['entries'][0]
+        assert entry['description'] == 'This happened'
+        assert entry['software']['name'] == 'my_tool'
+        assert entry['software']['version'] == '2.0'
+
 
 def test_old_history(tmpdir):
     """Make sure that old versions of the history format are still accepted"""


### PR DESCRIPTION
Automatically writing the extension metadata was accidentally overwriting any history entries that the user provided.