### PR TITLE
Make the build reproducible

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -3,6 +3,8 @@
 
 
 import io
+import os
+import time
 import re
 import copy
 import datetime
@@ -1177,9 +1179,13 @@ class AsdfFile(versioning.VersionedMixin):
         elif software is not None:
             software = Software(software)
 
+        time_ = datetime.datetime.utcfromtimestamp(
+            int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+        )
+
         entry = HistoryEntry({
             'description': description,
-            'time': datetime.datetime.utcnow()
+            'time': time_,
         })
 
         if software is not None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,13 @@ except ImportError:
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
 
+# Ensure documentation examples are determinstically random.
+import numpy
+try:
+    numpy.random.seed(int(os.environ['SOURCE_DATE_EPOCH']))
+except KeyError:
+    pass
+
 # Get configuration information from setup.cfg
 try:
     from ConfigParser import ConfigParser


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed that `asdf` could not be built reproducibly.

This is due to it including nondeterminstically random output as well as the current build time in the documentation.

This was originally filed in Debian as #895737 [1].

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/895737

Signed-off-by: Chris Lamb <lamby@debian.org>