### PR TITLE
Use BINTABLE HDU for storing ASDF-in-FITS

### DIFF
--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -46,12 +46,4 @@ from jsonschema import ValidationError
 class ValidationError(ValidationError):
     pass
 
-try:
-    from astropy.io import fits
-except ImportError:
-    pass
-else:
-    from .fits_embed import _AsdfHDU
-    fits.register_hdu(_AsdfHDU)
-
 open = AsdfFile.open

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -380,3 +380,12 @@ def test_extension_check():
     with pytest.raises(RuntimeError):
         with asdf.AsdfFile.open(testfile, strict_extension_check=True) as ff:
             pass
+
+def test_verify_with_astropy(tmpdir):
+    tmpfile = str(tmpdir.join('asdf.fits'))
+
+    with create_asdf_in_fits() as aif:
+        aif.write_to(tmpfile)
+
+    with fits.open(tmpfile) as hdu:
+        hdu.verify('exception')

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -89,7 +89,7 @@ def test_embed_asdf_in_fits_file(tmpdir, backwards_compat):
             assert isinstance(asdf_hdu, fits.ImageHDU)
             assert asdf_hdu.data.tostring().strip().endswith(b'...')
         else:
-            assert isinstance(asdf_hdu, fits_embed._AsdfHDU)
+            assert isinstance(asdf_hdu, fits.BinTableHDU)
 
         with fits_embed.AsdfInFits.open(hdulist2) as ff2:
             assert_tree_match(tree, ff2.tree)
@@ -113,7 +113,7 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
         assert len(hdulist) == 4
         assert [x.name for x in hdulist] == ['PRIMARY', '', '', 'ASDF']
         asdf_hdu = hdulist['ASDF']
-        assert isinstance(asdf_hdu, fits_embed._AsdfHDU)
+        assert isinstance(asdf_hdu, fits.BinTableHDU)
         assert asdf_hdu.data.tostring().startswith(b'#ASDF')
 
         with fits_embed.AsdfInFits.open(hdulist) as ff2:


### PR DESCRIPTION
This is intended to resolve https://github.com/STScI-JWST/jwst/issues/1807. After contacting NASA's FITS office, it seems like we should avoid the use of `FOREIGN` since it is an old convention and is not well supported. In fact, it does not seem to be properly validated by `fitsverify`.

cc @stscicrawford, @hbushouse, @perrygreenfield 