### PR TITLE
Allow test suite to run even when package is not installed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - Add API function for retrieving history entries. [#501]
 
+2.0.1 (unreleased)
+------------------
+
+- Allow test suite to run even when package is not installed. [#502]
+
 2.0.0 (2018-04-19)
 ------------------
 


### PR DESCRIPTION
This allows the package to be tested in environments where it can't first be installed (e.g. the Debian build environment).

In order to make this work, simply define `ASDF_TEST_BUILD` before running `pytest`. 

@olebole this should solve the issue you reported in #498 and #499. I hope to release this in bugfix v2.0.1 sometime this week.