### PR TITLE
Allow serialization of broadcasted ndarrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - Add API function for retrieving history entries. [#501]
 
+2.0.2 (unreleased)
+------------------
+
+- Allow serialization of broadcasted ``numpy`` arrays. [#507]
+
 2.0.1 (2018-05-08)
 ------------------
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -372,7 +372,7 @@ class GenericFile(object):
     """
 
     def write_array(self, array):
-        _array_tofile(None, self.write, array)
+        _array_tofile(None, self.write, np.ascontiguousarray(array))
 
     def seek(self, offset, whence=0):
         """

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -751,7 +751,7 @@ class RealFile(RandomAccessFile):
             arr.flush()
             self.fast_forward(len(arr.data))
         else:
-            _array_tofile(self._fd, self._fd.write, arr)
+            _array_tofile(self._fd, self._fd.write, np.ascontiguousarray(arr))
 
     def can_memmap(self):
         return True

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -386,14 +386,19 @@ class NDArrayType(AsdfType):
     @classmethod
     def to_tree(cls, data, ctx):
         base = util.get_array_base(data)
-        block = ctx.blocks.find_or_create_block_for_array(data, ctx)
         shape = data.shape
         dtype = data.dtype
         offset = data.ctypes.data - base.ctypes.data
-        if data.flags[b'C_CONTIGUOUS']:
-            strides = None
-        else:
-            strides = data.strides
+        strides = None
+
+        if not data.flags.c_contiguous:
+            # We do not want to encode strides for broadcasted arrays
+            if not all(data.strides):
+                data = np.ascontiguousarray(data)
+            else:
+                strides = data.strides
+
+        block = ctx.blocks.find_or_create_block_for_array(data, ctx)
 
         result = {}
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -803,3 +803,9 @@ def test_tagged_object_array(tmpdir):
         objdata.flat[i] = Quantity(i, 'angstrom')
 
     helpers.assert_roundtrip_tree({'bizbaz': objdata}, tmpdir)
+
+
+def test_broadcasted_array(tmpdir):
+    attrs = np.broadcast_arrays(np.array([10,20]), np.array(10), np.array(10))
+    tree = {'one': attrs[1] }#, 'two': attrs[1], 'three': attrs[2]}
+    helpers.assert_roundtrip_tree(tree, tmpdir)


### PR DESCRIPTION
The solution in this PR is simply to create a contiguous copy of the broadcasted array and save it to disk. While this uses more memory on disk than strictly required by `numpy`, we need to account for the fact that broadcasting is a concept that is specific to `numpy` and may not translate to other implementations of ASDF. For this reason, it seems to make the most sense to create a copy of the broadcasted array so that it is available for other implementations.

This fixes #506.

cc @Cadair 