### PR TITLE
Use importlib resources for accessing test data.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
         - PYTHON_VERSION=3.6
         - ASTROPY_VERSION=stable
         - NUMPY_VERSION=stable
-        - PIP_DEPENDENCIES='pytest-faulthandler'
+        - PIP_DEPENDENCIES='pytest-faulthandler importlib_resources'
         - CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4 pytest-astropy'
         - GWCS_GIT='git+git://github.com/spacetelescope/gwcs.git#egg=gwcs'
         - GWCS_PIP='gwcs'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       GWCS_GIT: "git+git://github.com/spacetelescope/gwcs.git#egg=gwcs"
       GWCS_PIP: "gwcs"
       CONDA_DEPENDENCIES: "semantic_version jsonschema pyyaml six lz4 pytest-astropy"
-      PIP_DEPENDENCIES: "pytest-faulthandler"
+      PIP_DEPENDENCIES: "pytest-faulthandler importlib_resources"
       PYTHON_ARCH: "64"
 
   matrix:

--- a/asdf/commands/tests/data/__init__.py
+++ b/asdf/commands/tests/data/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/asdf/commands/tests/test_diff.py
+++ b/asdf/commands/tests/test_diff.py
@@ -4,25 +4,28 @@
 
 import os
 import io
+from functools import partial
 
 import numpy as np
 import pytest
 
 from ... import AsdfFile
+from ...tests import helpers
+
 from .. import main, diff
 
-
-TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
+from . import data as test_data
+get_test_data_path = partial(helpers.get_test_data_path, module=test_data)
 
 
 def _assert_diffs_equal(filenames, result_file, minimal=False):
     iostream = io.StringIO()
 
-    file_paths = ["{}/{}".format(TEST_DATA_PATH, name) for name in filenames]
+    file_paths = [get_test_data_path(name) for name in filenames]
     diff(file_paths, minimal=minimal, iostream=iostream)
     iostream.seek(0)
 
-    result_path = "{}/{}".format(TEST_DATA_PATH, result_file)
+    result_path = get_test_data_path(result_file)
     with open(result_path, 'r') as handle:
         assert handle.read() == iostream.read()
 
@@ -46,10 +49,10 @@ def test_file_not_found():
     # Try to open files that exist but are not valid asdf
     filenames = ['frames.diff', 'blocks.diff']
     with pytest.raises(RuntimeError):
-        diff(["{}/{}".format(TEST_DATA_PATH, name) for name in filenames], False)
+        diff([get_test_data_path(name) for name in filenames], False)
 
 def test_diff_command():
     filenames = ['frames0.asdf', 'frames1.asdf']
-    paths = ["{}/{}".format(TEST_DATA_PATH, name) for name in filenames]
+    paths = [get_test_data_path(name) for name in filenames]
 
     assert main.main_from_args(['diff'] + paths) == 0

--- a/asdf/tags/core/tests/data/__init__.py
+++ b/asdf/tags/core/tests/data/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -21,8 +21,8 @@ from asdf import util
 from asdf.tests import helpers, CustomTestType
 from asdf.tags.core import ndarray
 
-
-TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
+from . import data as test_data
+TEST_DATA_PATH = helpers.get_test_data_path('', module=test_data)
 
 
 # These custom types and the custom extension are here purely for the purpose

--- a/asdf/tags/wcs/tests/data/__init__.py
+++ b/asdf/tags/wcs/tests/data/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/asdf/tags/wcs/tests/test_wcs.py
+++ b/asdf/tags/wcs/tests/test_wcs.py
@@ -4,6 +4,7 @@
 import os
 import pytest
 import warnings
+from functools import partial
 
 gwcs = pytest.importorskip('gwcs')
 astropy = pytest.importorskip('astropy', minversion='3.0.0')
@@ -26,8 +27,8 @@ import asdf
 from asdf import AsdfFile
 from asdf.tests import helpers
 
-
-TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
+from . import data as test_data
+get_test_data_path = partial(helpers.get_test_data_path, module=test_data)
 
 
 @pytest.mark.parametrize('version', ['1.0.0', '1.1.0'])
@@ -37,7 +38,7 @@ def test_read_wcs(version):
     more recent than 1.1.0 since the schemas and tags have moved to Astropy and
     GWCS."""
 
-    filename = os.path.join(TEST_DATA_PATH, "test_wcs-{}.asdf".format(version))
+    filename = get_test_data_path("test_wcs-{}.asdf".format(version))
     with asdf.open(filename) as tree:
         assert isinstance(tree['gw1'], wcs.WCS)
         assert isinstance(tree['gw2'], wcs.WCS)
@@ -75,7 +76,7 @@ def test_frames(tmpdir):
     test any subsequent ASDF versions since the schemas and tags for those
     frames have moved to Astropy and gwcs."""
 
-    filename = os.path.join(TEST_DATA_PATH, "test_frames-1.1.0.asdf")
+    filename = get_test_data_path("test_frames-1.1.0.asdf")
     with asdf.open(filename) as tree:
         for frame in tree['frames']:
             assert isinstance(frame, cf.CoordinateFrame)

--- a/asdf/tests/data/__init__.py
+++ b/asdf/tests/data/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -56,7 +56,7 @@ def get_test_data_path(name, module=None):
         module = test_data
 
     with resources.path(module, name) as path:
-        return path
+        return str(path)
 
 
 def assert_tree_match(old_tree, new_tree, ctx=None,

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -33,8 +33,30 @@ except ImportError:
     INTERNET_OFF = False
 
 
-__all__ = ['assert_tree_match', 'assert_roundtrip_tree', 'yaml_to_asdf',
-           'get_file_sizes', 'display_warnings']
+if sys.version_info >= (3, 7):
+    from importlib import resources
+else:
+    try:
+        import importlib_resources as resources
+    except ImportError:
+        resources = None
+
+
+__all__ = ['get_test_data_path', 'assert_tree_match', 'assert_roundtrip_tree',
+           'yaml_to_asdf', 'get_file_sizes', 'display_warnings']
+
+
+def get_test_data_path(name, module=None):
+    if resources is None:
+        raise RuntimeError("The importlib_resources package is required to get"
+                           " test data on systems with Python < 3.7")
+
+    if module is None:
+        from . import data as test_data
+        module = test_data
+
+    with resources.path(module, name) as path:
+        return path
 
 
 def assert_tree_match(old_tree, new_tree, ctx=None,

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -16,7 +16,7 @@ from asdf import versioning
 from . import helpers, CustomTestType
 
 
-TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
+TEST_DATA_PATH = str(helpers.get_test_data_path(''))
 
 
 def test_custom_tag():

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -18,10 +18,7 @@ import asdf
 from asdf import fits_embed
 from asdf import open as asdf_open
 
-from .helpers import assert_tree_match, display_warnings
-
-
-TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
+from .helpers import assert_tree_match, display_warnings, get_test_data_path
 
 
 def create_asdf_in_fits():
@@ -282,7 +279,7 @@ def test_asdf_open(tmpdir):
             compare_asdfs(asdf_in_fits, ff)
 
 def test_open_gzipped():
-    testfile = os.path.join(TEST_DATA_PATH, 'asdf.fits.gz')
+    testfile = get_test_data_path('asdf.fits.gz')
 
     # Opening as an HDU should work
     with fits.open(testfile) as ff:
@@ -308,7 +305,7 @@ def test_bad_input(tmpdir):
 @pytest.mark.skipif(sys.platform.startswith('win'),
     reason='Avoid path manipulation on Windows')
 def test_version_mismatch_file():
-    testfile = os.path.join(TEST_DATA_PATH, 'version_mismatch.fits')
+    testfile = str(get_test_data_path('version_mismatch.fits'))
 
     with pytest.warns(None) as w:
         with asdf.AsdfFile.open(testfile,
@@ -360,7 +357,7 @@ def test_serialize_table(tmpdir):
         assert data._source.startswith('fits:')
 
 def test_extension_check():
-    testfile = os.path.join(TEST_DATA_PATH, 'extension_check.fits')
+    testfile = get_test_data_path('extension_check.fits')
 
     with pytest.warns(None) as warnings:
         with asdf.AsdfFile.open(testfile) as ff:

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -25,9 +25,6 @@ from asdf import yamlutil
 from asdf.tests import helpers
 
 
-TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
-
-
 class CustomExtension:
     """
     This is the base class that is used for extensions for custom tag
@@ -45,7 +42,7 @@ class CustomExtension:
     @property
     def url_mapping(self):
         return [('http://nowhere.org/schemas/custom/',
-                 util.filepath_to_url(TEST_DATA_PATH) +
+                 util.filepath_to_url(helpers.get_test_data_path('')) +
                  '/{url_suffix}.yaml')]
 
 
@@ -95,7 +92,7 @@ def test_read_json_schema():
     This was known to fail on Python 3.5 See issue #314 at
     https://github.com/spacetelescope/asdf/issues/314 for more details.
     """
-    json_schema = os.path.join(TEST_DATA_PATH, 'example_schema.json')
+    json_schema = helpers.get_test_data_path('example_schema.json')
     schema_tree = schema.load_schema(json_schema, resolve_references=True)
     schema.check_schema(schema_tree)
 
@@ -443,7 +440,7 @@ custom: !<tag:nowhere.org:custom/foreign_tag_reference-1.0.0>
 def test_self_reference_resolution():
     r = resolver.Resolver(CustomExtension().url_mapping, 'url')
     s = schema.load_schema(
-        os.path.join(TEST_DATA_PATH, 'self_referencing-1.0.0.yaml'),
+        helpers.get_test_data_path('self_referencing-1.0.0.yaml'),
         resolver=r,
         resolve_references=True)
     assert '$ref' not in repr(s)
@@ -536,7 +533,7 @@ def test_assert_roundtrip_with_extension(tmpdir):
 
 
 def test_custom_validation_bad(tmpdir):
-    custom_schema_path = os.path.join(TEST_DATA_PATH, 'custom_schema.yaml')
+    custom_schema_path = helpers.get_test_data_path('custom_schema.yaml')
     asdf_file = os.path.join(str(tmpdir), 'out.asdf')
 
     # This tree does not conform to the custom schema
@@ -562,7 +559,7 @@ def test_custom_validation_bad(tmpdir):
 
 
 def test_custom_validation_good(tmpdir):
-    custom_schema_path = os.path.join(TEST_DATA_PATH, 'custom_schema.yaml')
+    custom_schema_path = helpers.get_test_data_path('custom_schema.yaml')
     asdf_file = os.path.join(str(tmpdir), 'out.asdf')
 
     # This tree conforms to the custom schema


### PR DESCRIPTION
This is similar in concept to #514, except it is applied to test data files rather than the schemas.