### PR TITLE
Fix bug with out-of-line definitions when using custom schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@
 - Add workaround for Python OSX write limit bug
   (see https://bugs.python.org/issue24658). [#521]
 
+- Fix bug with custom schema validation when using out-of-line definitions in
+  schema file. [#522]
+
 2.0.1 (2018-05-08)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -93,7 +93,7 @@ class AsdfFile(versioning.VersionedMixin):
         """
 
         if custom_schema is not None:
-            self._custom_schema = schema.load_schema(custom_schema)
+            self._custom_schema = schema.load_custom_schema(custom_schema)
             schema.check_schema(self._custom_schema)
         else:
             self._custom_schema = None

--- a/asdf/tests/data/custom_schema_definitions.yaml
+++ b/asdf/tests/data/custom_schema_definitions.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/core/asdf-1.1.0"
+
+tag: "tag:stsci.edu:asdf/core/asdf-1.1.0"
+type: object
+properties:
+  thing:
+    $ref: "#/definitions/bizbaz"
+
+required: [thing]
+additionalProperties: true
+
+definitions:
+  bizbaz:
+    type: object
+    properties:
+      biz:
+        type: string
+      baz:
+        type: string

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -597,3 +597,19 @@ def test_custom_validation_good(tmpdir):
 
     with asdf.open(asdf_file, custom_schema=custom_schema_path) as ff:
         pass
+
+
+def test_custom_validation_with_definitions(tmpdir):
+    custom_schema_path = helpers.get_test_data_path('custom_schema_definitions.yaml')
+    asdf_file = os.path.join(str(tmpdir), 'out.asdf')
+
+    # This tree conforms to the custom schema
+    tree = {
+        'thing': { 'biz': 'hello', 'baz': 'world' }
+    }
+
+    with asdf.AsdfFile(tree, custom_schema=custom_schema_path) as ff:
+        ff.write_to(asdf_file)
+
+    with asdf.open(asdf_file, custom_schema=custom_schema_path) as ff:
+        pass

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -599,7 +599,7 @@ def test_custom_validation_good(tmpdir):
         pass
 
 
-def test_custom_validation_with_definitions(tmpdir):
+def test_custom_validation_with_definitions_good(tmpdir):
     custom_schema_path = helpers.get_test_data_path('custom_schema_definitions.yaml')
     asdf_file = os.path.join(str(tmpdir), 'out.asdf')
 
@@ -613,3 +613,31 @@ def test_custom_validation_with_definitions(tmpdir):
 
     with asdf.open(asdf_file, custom_schema=custom_schema_path) as ff:
         pass
+
+
+def test_custom_validation_with_definitions_bad(tmpdir):
+    custom_schema_path = helpers.get_test_data_path('custom_schema_definitions.yaml')
+    asdf_file = os.path.join(str(tmpdir), 'out.asdf')
+
+    # This tree does NOT conform to the custom schema
+    tree = {
+        'forb': { 'biz': 'hello', 'baz': 'world' }
+    }
+
+    # Creating file without custom schema should pass
+    with asdf.AsdfFile(tree) as ff:
+        ff.write_to(asdf_file)
+
+    # Creating file with custom schema should fail
+    with pytest.raises(ValidationError):
+        with asdf.AsdfFile(tree, custom_schema=custom_schema_path) as ff:
+            pass
+
+    # Opening file without custom schema should pass
+    with asdf.open(asdf_file) as ff:
+        pass
+
+    # Opening file with custom schema should fail
+    with pytest.raises(ValidationError):
+        with asdf.open(asdf_file, custom_schema=custom_schema_path) as ff:
+            pass


### PR DESCRIPTION
Custom schema validation was working previously, but only in certain limited cases. This makes custom schema validation more correct and robust.