### PR TITLE
Update complex number schema and add tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@
 
 - Store ASDF-in-FITS data inside a 1x1 BINTABLE HDU. [#519]
 
+2.0.3 (unreleased)
+------------------
+
+- Update asdf-standard to reflect more stringent (and, consequently, more
+  correct) requirements on the formatting of complex numbers. [#526]
+
 2.0.2 (2018-07-27)
 ------------------
 

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -42,8 +42,4 @@ from .tags.core.external_reference import ExternalArrayReference
 
 from jsonschema import ValidationError
 
-# TODO: there doesn't seem to be any reason to redefine this here
-class ValidationError(ValidationError):
-    pass
-
 open = AsdfFile.open

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -9,19 +9,23 @@ import asdf
 from asdf.tests import helpers
 
 
+def make_complex_asdf(string):
+    yaml = """
+a: !core/complex-1.0.0
+  {}
+    """.format(string)
+
+    return helpers.yaml_to_asdf(yaml)
+
+
 @pytest.mark.parametrize('invalid', [
     '3 + 4i', '3+-4i', '3-+4i', '3i+4i', 'X3+4iX', '3+X4i', '3+4', '3i+4'
     '3+4z', '3.+4i', '3+4.i', '3e-4.0+4i', '3+4e4.0i', ''
 ])
 def test_invalid_complex(invalid):
-    yaml = """
-a: !core/complex-1.0.0
-  {}
-    """.format(invalid)
 
-    buff = helpers.yaml_to_asdf(yaml)
     with pytest.raises(asdf.ValidationError):
-        with asdf.AsdfFile.open(buff):
+        with asdf.AsdfFile.open(make_complex_asdf(invalid)):
             pass
 
 
@@ -31,13 +35,8 @@ a: !core/complex-1.0.0
     'inf+infj', 'inf+infi', 'infj', 'infi', 'INFi', 'INFI', '3+infj', 'inf+4j',
 ])
 def test_valid_complex(valid):
-    yaml = """
-a: !core/complex-1.0.0
-  {}
-    """.format(valid)
 
-    buff = helpers.yaml_to_asdf(yaml)
-    with asdf.AsdfFile.open(buff) as af:
+    with asdf.AsdfFile.open(make_complex_asdf(valid)) as af:
         assert af.tree['a'] == complex(re.sub(r'[iI]$', r'j', valid))
 
 
@@ -46,13 +45,8 @@ a: !core/complex-1.0.0
     'nan+4j'
 ])
 def test_valid_nan_complex(valid):
-    yaml = """
-a: !core/complex-1.0.0
-  {}
-    """.format(valid)
 
-    buff = helpers.yaml_to_asdf(yaml)
-    with asdf.AsdfFile.open(buff) as af:
+    with asdf.AsdfFile.open(make_complex_asdf(valid)) as af:
         # Don't compare values since NANs are never equal
         pass
 

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -28,7 +28,7 @@ a: !core/complex-1.0.0
 @pytest.mark.parametrize('valid', [
     '3+4j', '(3+4j)', '.3+4j', '3+.4j', '3e10+4j', '3e-10+4j', '3+4e10j',
     '3.0+4j', '3+4.0j', '3.0+4.0j', '3+4e-10j', '3+4J', '3+4i', '3+4I', 'inf',
-    'inf+infj', 'inf+infi', 'infj', 'infi', 'INFi', 'INFI', '3+infj', 'inf+4j'
+    'inf+infj', 'inf+infi', 'infj', 'infi', 'INFi', 'INFI', '3+infj', 'inf+4j',
 ])
 def test_valid_complex(valid):
     yaml = """
@@ -39,6 +39,22 @@ a: !core/complex-1.0.0
     buff = helpers.yaml_to_asdf(yaml)
     with asdf.AsdfFile.open(buff) as af:
         assert af.tree['a'] == complex(re.sub(r'[iI]$', r'j', valid))
+
+
+@pytest.mark.parametrize('valid', [
+    'nan', 'nan+nanj', 'nan+nani', 'nanj', 'nani', 'NANi', 'NANI', '3+nanj',
+    'nan+4j'
+])
+def test_valid_nan_complex(valid):
+    yaml = """
+a: !core/complex-1.0.0
+  {}
+    """.format(valid)
+
+    buff = helpers.yaml_to_asdf(yaml)
+    with asdf.AsdfFile.open(buff) as af:
+        # Don't compare values since NANs are never equal
+        pass
 
 
 def test_roundtrip(tmpdir):

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -7,11 +7,14 @@ import asdf
 from asdf.tests import helpers
 
 
-def test_invalid_complex():
+@pytest.mark.parametrize('invalid', [
+    '3 + 4i', '3+-4i', '3-+4i', '3i+4i', 'X3+4iX', '3+X4i'
+])
+def test_invalid_complex(invalid):
     yaml = """
 a: !core/complex-1.0.0
-  3 + 4i
-    """
+  {}
+    """.format(invalid)
 
     buff = helpers.yaml_to_asdf(yaml)
     with pytest.raises(asdf.ValidationError):

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -8,7 +8,8 @@ from asdf.tests import helpers
 
 
 @pytest.mark.parametrize('invalid', [
-    '3 + 4i', '3+-4i', '3-+4i', '3i+4i', 'X3+4iX', '3+X4i'
+    '3 + 4i', '3+-4i', '3-+4i', '3i+4i', 'X3+4iX', '3+X4i', '3+4', '3i+4'
+    '3+4z', '3.+4i', '3+4.i', '3e-4.0+4i', '3+4e4.0i', ''
 ])
 def test_invalid_complex(invalid):
     yaml = """

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -14,7 +14,7 @@ a: !core/complex-1.0.0
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.raises(ValueError):
+    with pytest.raises(asdf.ValidationError):
         with asdf.AsdfFile.open(buff):
             pass
 

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -27,7 +27,8 @@ a: !core/complex-1.0.0
 
 @pytest.mark.parametrize('valid', [
     '3+4j', '(3+4j)', '.3+4j', '3+.4j', '3e10+4j', '3e-10+4j', '3+4e10j',
-    '3.0+4j', '3+4.0j', '3.0+4.0j', '3+4e-10j', '3+4J', '3+4i', '3+4I'
+    '3.0+4j', '3+4.0j', '3.0+4.0j', '3+4e-10j', '3+4J', '3+4i', '3+4I', 'inf',
+    'inf+infj', 'inf+infi', 'infj', 'infi', 'INFi', 'INFI', '3+infj', 'inf+4j'
 ])
 def test_valid_complex(valid):
     yaml = """
@@ -37,7 +38,7 @@ a: !core/complex-1.0.0
 
     buff = helpers.yaml_to_asdf(yaml)
     with asdf.AsdfFile.open(buff) as af:
-        assert af.tree['a'] == complex(re.sub(r'[iI]', r'j', valid))
+        assert af.tree['a'] == complex(re.sub(r'[iI]$', r'j', valid))
 
 
 def test_roundtrip(tmpdir):

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
+import re
+
 import pytest
 
 import asdf
@@ -21,6 +23,21 @@ a: !core/complex-1.0.0
     with pytest.raises(asdf.ValidationError):
         with asdf.AsdfFile.open(buff):
             pass
+
+
+@pytest.mark.parametrize('valid', [
+    '3+4j', '(3+4j)', '.3+4j', '3+.4j', '3e10+4j', '3e-10+4j', '3+4e10j',
+    '3.0+4j', '3+4.0j', '3.0+4.0j', '3+4e-10j', '3+4J', '3+4i', '3+4I'
+])
+def test_valid_complex(valid):
+    yaml = """
+a: !core/complex-1.0.0
+  {}
+    """.format(valid)
+
+    buff = helpers.yaml_to_asdf(yaml)
+    with asdf.AsdfFile.open(buff) as af:
+        assert af.tree['a'] == complex(re.sub(r'[iI]', r'j', valid))
 
 
 def test_roundtrip(tmpdir):


### PR DESCRIPTION
This PR addresses several outstanding problems with the schema for complex numbers. It adds much more thorough tests of the schema and ensures that improperly formatted complex numbers are detected by a schema validation error (which was not previously the case).

In a way, this is a fairly substantial change since it imposes much more stringent requirements on the format of complex numbers. However, since these requirements were implicit to begin with and should have been enforced in the first place, it seems unlikely that anyone is using files that are in conflict with the new rules.

This is closely related to https://github.com/spacetelescope/asdf-standard/pull/171 and integrates the updates to the schema that were introduced there.