### PR TITLE
Restrict jsonschema version to avoid using alpha release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,12 @@ matrix:
         - os: osx
           env: NUMPY_VERSION=stable SETUP_CMD='test'
 
+        # Test against latest version of jsonschema
+        - env: PIP_DEPENDENCIES='jsonschema pytest-faulthandler importlib_resources'
+
     allow_failures:
         - env: NUMPY_VERSION=development SETUP_CMD='test'
+        - env: PIP_DEPENDENCIES='jsonschema pytest-faulthandler importlib_resources'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(name=PACKAGE_NAME,
       install_requires=[
           'semantic_version>=2.3.1',
           'pyyaml>=3.10',
-          'jsonschema>=2.3.0',
+          'jsonschema>=2.3,<=2.6',
           'six>=1.9.0',
           'numpy>=1.8',
       ] + extras_require,


### PR DESCRIPTION
Now that `jsonschema` has an alpha release for 3.0, we need to restrict the maximum version of our dependency since the latest version appears to cause issues.

This PR also adds a test to travis that uses the latest version of jsonschema (it's allowed to fail for now).