### PR TITLE
Ensure when closing, to explicitly close data blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 - Update asdf-standard to reflect more stringent (and, consequently, more
   correct) requirements on the formatting of complex numbers. [#526]
 
+- Fix bug with dangling file handle when using ASDF-in-FITS. [#533]
+
 2.0.2 (2018-07-27)
 ------------------
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -1126,7 +1126,7 @@ class Block(object):
                 self._data.flush()
             if self._data._mmap is not None:
                 self._data._mmap.close()
-            self._data = None
+        self._data = None
 
 
 class UnloadedBlock(object):

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -386,3 +386,37 @@ def test_verify_with_astropy(tmpdir):
 
     with fits.open(tmpfile) as hdu:
         hdu.verify('exception')
+
+def test_dangling_file_handle(tmpdir):
+    """
+    This tests the bug fix introduced in #533. Without the bug fix, this test
+    will fail when running the test suite with pytest-openfiles.
+    """
+    import gc
+
+    fits_filename = str(tmpdir.join('dangling.fits'))
+
+    # Create FITS file to use for test
+    hdulist = fits.HDUList()
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
+    hdulist.writeto(fits_filename)
+    hdulist.close()
+
+    hdul = fits.open(fits_filename)
+    gc.collect()
+
+    ctx = asdf.AsdfFile()
+    gc.collect()
+
+    ctx.blocks.find_or_create_block_for_array(hdul[0].data, ctx)
+    gc.collect()
+
+    hdul.close()
+    gc.collect()
+
+    ctx.close()
+    gc.collect()
+
+    del ctx


### PR DESCRIPTION
This is to close out references to memory-mapped arrays that,
in the current context, not associated with a file. The `Block._memmapped`
is `False` but the `.data` is a memory-mapped array.

WIP spacetelescope/jwst#2282