### PR TITLE
Allow typing.NamedTuple to be serialized

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Store ASDF-in-FITS data inside a 1x1 BINTABLE HDU. [#519]
 
+- Allow implicit conversion of ``namedtuple`` into serializable types. [#534]
+
 2.0.3 (unreleased)
 ------------------
 

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -128,7 +128,7 @@ class Reference(AsdfType):
         pass
 
 
-def find_references(tree, ctx):
+def find_references(tree, ctx, ignore_implicit_conversion=False):
     """
     Find all of the JSON references in the tree, and convert them into
     `Reference` objects.
@@ -138,7 +138,8 @@ def find_references(tree, ctx):
             return Reference(tree['$ref'], json_id, asdffile=ctx)
         return tree
 
-    return treeutil.walk_and_modify(tree, do_find)
+    return treeutil.walk_and_modify(
+        tree, do_find, ignore_implicit_conversion=ignore_implicit_conversion)
 
 
 def resolve_references(tree, ctx, do_not_fill_defaults=False):

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -144,7 +144,8 @@ def assert_tree_match(old_tree, new_tree, ctx=None,
 
 
 def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
-                          raw_yaml_check_func=None, write_options={}, extensions=None,
+                          raw_yaml_check_func=None, write_options={},
+                          init_options={}, extensions=None,
                           tree_match_func='assert_equal'):
     """
     Assert that a given tree saves to ASDF and, when loaded back,
@@ -171,7 +172,7 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
 
     # First, test writing/reading a BytesIO buffer
     buff = io.BytesIO()
-    AsdfFile(tree, extensions=extensions).write_to(buff, **write_options)
+    AsdfFile(tree, extensions=extensions, **init_options).write_to(buff, **write_options)
     assert not buff.closed
     buff.seek(0)
     with AsdfFile.open(buff, mode='rw', extensions=extensions) as ff:
@@ -184,7 +185,7 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
             asdf_check_func(ff)
 
     buff.seek(0)
-    ff = AsdfFile(extensions=extensions)
+    ff = AsdfFile(extensions=extensions, **init_options)
     content = AsdfFile._open_impl(ff, buff, _get_yaml_content=True)
     buff.close()
     # We *never* want to get any raw python objects out
@@ -195,7 +196,7 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
         raw_yaml_check_func(content)
 
     # Then, test writing/reading to a real file
-    ff = AsdfFile(tree, extensions=extensions)
+    ff = AsdfFile(tree, extensions=extensions, **init_options)
     ff.write_to(fname, **write_options)
     with AsdfFile.open(fname, mode='rw', extensions=extensions) as ff:
         assert_tree_match(tree, ff.tree, ff, funcname=tree_match_func)
@@ -205,7 +206,7 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
     # Make sure everything works without a block index
     write_options['include_block_index'] = False
     buff = io.BytesIO()
-    AsdfFile(tree, extensions=extensions).write_to(buff, **write_options)
+    AsdfFile(tree, extensions=extensions, **init_options).write_to(buff, **write_options)
     assert not buff.closed
     buff.seek(0)
     with AsdfFile.open(buff, mode='rw', extensions=extensions) as ff:
@@ -219,7 +220,7 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
     if not INTERNET_OFF and not sys.platform.startswith('win'):
         server = RangeHTTPServer()
         try:
-            ff = AsdfFile(tree, extensions=extensions)
+            ff = AsdfFile(tree, extensions=extensions, **init_options)
             ff.write_to(os.path.join(server.tmpdir, 'test.asdf'), **write_options)
             with AsdfFile.open(server.url + 'test.asdf', mode='r',
                                extensions=extensions) as ff:

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import io
-from collections import OrderedDict
+from collections import namedtuple, OrderedDict
+from typing import NamedTuple
 
 import numpy as np
 
@@ -88,6 +89,17 @@ def test_arbitrary_python_object():
         ff.write_to(buff)
 
 
+def run_tuple_test(tree, tmpdir):
+    def check_asdf(asdf):
+        assert isinstance(asdf.tree['val'], list)
+
+    def check_raw_yaml(content):
+        assert b'tuple' not in content
+
+    helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf,
+                                  raw_yaml_check_func=check_raw_yaml)
+
+
 def test_python_tuple(tmpdir):
     # We don't want to store tuples as tuples, because that's not a
     # built-in YAML data type.  This test ensures that they are
@@ -97,14 +109,57 @@ def test_python_tuple(tmpdir):
         "val": (1, 2, 3)
     }
 
+    run_tuple_test(tree, tmpdir)
+
+
+def test_named_tuple_collections(tmpdir):
+    # Ensure that we are able to serialize a collections.namedtuple.
+
+    nt = namedtuple("TestNamedTuple1", ("one", "two", "three"))
+
+    tree = {
+        "val": nt(1, 2, 3)
+    }
+
+    run_tuple_test(tree, tmpdir)
+
+def test_named_tuple_typing(tmpdir):
+    # Ensure that we are able to serialize a typing.NamedTuple.
+
+    nt = NamedTuple("TestNamedTuple2",
+                    (("one", int), ("two", int), ("three", int)))
+    tree = {
+        "val": nt(1, 2, 3)
+    }
+
+    run_tuple_test(tree, tmpdir)
+
+
+def test_named_tuple_collections_recursive(tmpdir):
+    nt = namedtuple("TestNamedTuple3", ("one", "two", "three"))
+
+    tree = {
+        "val": nt(1, 2, np.ones(3))
+    }
+
     def check_asdf(asdf):
-        assert isinstance(asdf.tree['val'], list)
+        assert (asdf.tree['val'][2] == np.ones(3)).all()
 
-    def check_raw_yaml(content):
-        assert b'tuple' not in content
+    helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf)
 
-    helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf,
-                                  raw_yaml_check_func=check_raw_yaml)
+
+def test_named_tuple_typing_recursive(tmpdir):
+    nt = NamedTuple("TestNamedTuple4",
+                    (("one", int), ("two", int), ("three", np.ndarray)))
+
+    tree = {
+        "val": nt(1, 2, np.ones(3))
+    }
+
+    def check_asdf(asdf):
+        assert (asdf.tree['val'][2] == np.ones(3)).all()
+
+    helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf)
 
 
 def test_tags_removed_after_load(tmpdir):

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -134,8 +134,13 @@ def walk_and_modify(top, callback):
                 result = tag_object(tree._tag, result)
         elif isinstance(tree, (list, tuple)):
             seen.add(id_tree)
-            result = tree.__class__(
-                [recurse(val) for val in tree])
+            contents = [recurse(val) for val in tree]
+            try:
+                result = tree.__class__(contents)
+            except TypeError:
+                # the derived class' signature is different
+                # erase the type
+                result = contents
             seen.remove(id_tree)
             if hasattr(tree, '_tag'):
                 result = tag_object(tree._tag, result)
@@ -166,8 +171,13 @@ def walk_and_modify(top, callback):
                 result = tag_object(tree._tag, result)
         elif isinstance(tree, (list, tuple)):
             seen.add(id_tree)
-            result = tree.__class__(
-                [recurse_with_json_ids(val, json_id) for val in tree])
+            contents = [recurse_with_json_ids(val, json_id) for val in tree]
+            try:
+                result = tree.__class__(contents)
+            except TypeError:
+                # the derived class' signature is different
+                # erase the type
+                result = contents
             seen.remove(id_tree)
             if hasattr(tree, '_tag'):
                 result = tag_object(tree._tag, result)

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -5,6 +5,7 @@ Utility functions for managing tree-like data structures.
 """
 
 import inspect
+import warnings
 
 from .tagged import tag_object
 
@@ -175,8 +176,11 @@ def walk_and_modify(top, callback):
             try:
                 result = tree.__class__(contents)
             except TypeError:
-                # the derived class' signature is different
-                # erase the type
+                # The derived class signature is different, so simply store the
+                # list representing the contents. Currently this is primarly
+                # intended to handle namedtuple and NamedTuple instances.
+                msg = "Failed to serialize instance of {}, converting to list instead"
+                warnings.warn(msg.format(type(tree)))
                 result = contents
             seen.remove(id_tree)
             if hasattr(tree, '_tag'):

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -81,7 +81,7 @@ def iter_tree(top):
     return recurse(top)
 
 
-def walk_and_modify(top, callback):
+def walk_and_modify(top, callback, ignore_implicit_conversion=False):
     """Modify a tree by walking it with a callback function.  It also has
     the effect of doing a deep copy.
 
@@ -105,6 +105,13 @@ def walk_and_modify(top, callback):
 
         The callback is called on an instance after all of its
         children have been visited (depth-first order).
+
+    ignore_implicit_conversion : bool
+        Controls whether warnings should be issued when implicitly converting a
+        given type instance in the tree into a serializable object. The primary
+        case for this is currently `namedtuple`.
+
+        Defaults to `False`.
 
     Returns
     -------
@@ -179,8 +186,9 @@ def walk_and_modify(top, callback):
                 # The derived class signature is different, so simply store the
                 # list representing the contents. Currently this is primarly
                 # intended to handle namedtuple and NamedTuple instances.
-                msg = "Failed to serialize instance of {}, converting to list instead"
-                warnings.warn(msg.format(type(tree)))
+                if not ignore_implicit_conversion:
+                    msg = "Failed to serialize instance of {}, converting to list instead"
+                    warnings.warn(msg.format(type(tree)))
                 result = contents
             seen.remove(id_tree)
             if hasattr(tree, '_tag'):

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ open_files_ignore = test.fits asdf.fits
 # Account for both the astropy test runner case and the native pytest case
 asdf_schema_root = asdf-standard/schemas asdf/schemas
 asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
-addopts = --doctest-rst
+#addopts = --doctest-rst
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This allows to serialize `typing.NamedTuple`-s and other crazy inheritors from `list` and `tuple` which do not preserve the original constructor signature.

We catch `TypeError` in the constructor and use the auxiliary list.