### PR TITLE
Allow fortran-order arrays to be serialized

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@
 
 - Fix bug with dangling file handle when using ASDF-in-FITS. [#533]
 
+- Fix bug that prevented fortran-order arrays from being serialized properly.
+  [#539]
+
 2.0.2 (2018-07-27)
 ------------------
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -764,7 +764,10 @@ class Block(object):
 
     def __init__(self, data=None, uri=None, array_storage='internal', memmap=True):
         if isinstance(data, np.ndarray) and not data.flags.c_contiguous:
-            self._data = np.ascontiguousarray(data)
+            if data.flags.f_contiguous:
+                self._data = np.asfortranarray(data)
+            else:
+                self._data = np.ascontiguousarray(data)
         else:
             self._data = data
         self._uri = uri
@@ -867,7 +870,7 @@ class Block(object):
 
     def _calculate_checksum(self, data):
         m = hashlib.new('md5')
-        m.update(self.data)
+        m.update(np.ascontiguousarray(self.data))
         return m.digest()
 
     def validate_checksum(self):

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -870,7 +870,7 @@ class Block(object):
 
     def _calculate_checksum(self, data):
         m = hashlib.new('md5')
-        m.update(np.ascontiguousarray(self.data))
+        m.update(self.data.flatten())
         return m.digest()
 
     def validate_checksum(self):

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -376,7 +376,7 @@ class GenericFile(object):
     """
 
     def write_array(self, array):
-        _array_tofile(None, self.write, np.ascontiguousarray(array))
+        _array_tofile(None, self.write, array.ravel(order='A'))
 
     def seek(self, offset, whence=0):
         """
@@ -755,7 +755,7 @@ class RealFile(RandomAccessFile):
             arr.flush()
             self.fast_forward(len(arr.data))
         else:
-            _array_tofile(self._fd, self._fd.write, np.ascontiguousarray(arr))
+            _array_tofile(self._fd, self._fd.write, arr.ravel(order='A'))
 
     def can_memmap(self):
         return True

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -370,7 +370,7 @@ class NDArrayType(AsdfType):
             strides = node.get('strides', None)
             mask = node.get('mask', None)
 
-            return cls(source, shape, dtype, offset, strides, 'C', mask, ctx)
+            return cls(source, shape, dtype, offset, strides, 'A', mask, ctx)
 
         raise TypeError("Invalid ndarray description.")
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -809,3 +809,9 @@ def test_broadcasted_array(tmpdir):
     attrs = np.broadcast_arrays(np.array([10,20]), np.array(10), np.array(10))
     tree = {'one': attrs[1] }#, 'two': attrs[1], 'three': attrs[2]}
     helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_fortran_order(tmpdir):
+    array = np.array([[11,12,13], [21,22,23]], order='F')
+    tree = dict(data=array)
+    helpers.assert_roundtrip_tree(tree, tmpdir)


### PR DESCRIPTION
This fixes #538.