### PR TITLE
Add top-level keys method to access tree keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Allow implicit conversion of ``namedtuple`` into serializable types. [#534]
 
+- Add top-level ``keys`` method to ``AsdfFile`` to access tree keys. [#545]
+
 2.0.4 (unreleased)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -383,6 +383,9 @@ class AsdfFile(versioning.VersionedMixin):
         self._validate(asdf_object, custom=bool(tree))
         self._tree = asdf_object
 
+    def keys(self):
+        return self._tree.keys()
+
     def __getitem__(self, key):
         return self._tree[key]
 
@@ -1249,6 +1252,10 @@ class AsdfFile(versioning.VersionedMixin):
             return self.tree['history']['entries']
 
         return []
+
+
+# Inherit docstring from dictionary
+AsdfFile.keys.__doc__ = dict.keys.__doc__
 
 
 def is_asdf_file(fd):

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -1154,6 +1154,12 @@ def test_top_level_tree(small_tree):
     assert_tree_match(ff2.tree['tree'], ff2['tree'])
 
 
+def test_top_level_keys(small_tree):
+    tree = {'tree': small_tree}
+    ff = asdf.AsdfFile(tree)
+    assert ff.tree.keys() == ff.keys()
+
+
 def test_tag_to_schema_resolver_deprecation():
     ff = asdf.AsdfFile()
     with pytest.warns(AsdfDeprecationWarning):


### PR DESCRIPTION
This fixes #542.