### PR TITLE
Use tox for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ matrix:
         # Do a coverage test
         - env: TOXENV='coverage' TOX_ARGS=''
 
+        # Perform a sanity check of packaging using twine
+        - env: TOXENV='twine' TOX_ARGS=''
+
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - env: TOXENV='docbuild' TOX_ARGS=''

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,11 @@ matrix:
 
 
     allow_failures:
+        # There doesn't appear to be a stable version of numpy available for
+        # Py37 on Windows at the moment
+        - os: windows
+          env: TOXENV='py37-stable' TOX_ARGS='--remote-data'
+
         - env: TOXENV='py37-numpydev'
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,9 +85,3 @@ install:
 
 script:
    - $TOX_CMD $TOX_ARGS
-
-after_success:
-    # If coveralls.io is set up for this package, uncomment the line
-    # below and replace "packagename" with the name of your package.
-    # The coveragerc file may be customized as needed for your package.
-    - if [[ $TOXENV == 'coverage' ]]; then coveralls --rcfile='asdf/tests/coveragerc'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
           env: TOXENV='py35-stable'
 
         - os: windows
-          env: TOXENV='py36-stable'
+          env: TOXENV='py36-stable' TOX_ARGS='--remote-data'
 
         # Windows test against development version of numpy (this job can fail)
         - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
     include:
 
         # Do a coverage test
-        - env: TOXENV='py37-stable' TOX_ARGS='--coverage --open-files --remote-data'
+        - env: TOXENV='coverage' TOX_ARGS=''
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
@@ -90,4 +90,4 @@ after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    - if [[ $TOX_ARGS == '--coverage --open-files --remote-data' ]]; then coveralls --rcfile='asdf/tests/coveragerc'; fi
+    - if [[ $TOXENV == 'coverage' ]]; then coveralls --rcfile='asdf/tests/coveragerc'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,105 +21,73 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.6
-        - PYTEST_VERSION=3.10
-        - ASTROPY_VERSION=stable
-        - NUMPY_VERSION=stable
-        - ALL_PIP_DEPENDENCIES='pytest-faulthandler importlib_resources'
-        - PIP_DEPENDENCIES="$ALL_PIP_DEPENDENCIES"
-        - ALL_CONDA_DEPENDENCIES='semantic_version jsonschema pyyaml six lz4 pytest-astropy'
-        - CONDA_DEPENDENCIES="$ALL_CONDA_DEPENDENCIES"
-        - GWCS_GIT='git+git://github.com/spacetelescope/gwcs.git#egg=gwcs'
-        - GWCS_PIP='gwcs'
-        - RUN_CMD='pytest'
+        - TOX_CMD='tox --'
+        - TOX_ARGS='--remote-data'
 
     matrix:
         # Make sure that installation does not fail
-        - RUN_CMD='python setup.py install'
-        - PYTHON_VERSION=3.5
-        - PYTHON_VERSION=3.6 PYTEST_VERSION=3.8
-        - PYTHON_VERSION=3.7 PYTEST_VERSION=3.9 RUN_CMD='pytest --remote-data'
+        - TOXENV='py36-stable' TOX_CMD='tox --notest' TOX_ARGS=''
+        # Make sure README will display properly on pypi
+        - TOXENV='checkdocs'
+        - TOXENV='py35-stable'
+        - TOXENV='py36-stable'
+        - TOXENV='py37-stable'
 
 matrix:
     fast_finish: true
     include:
 
-        - env: PIP_DEPENDENCIES='twine' TWINE_CHECK=1
-
         # Do a coverage test
-        - env: COVERAGE=1
-               PIP_DEPENDENCIES="$ALL_PIP_DEPENDENCIES coverage coveralls"
+        - env: TOXENV='py37-stable' TOX_ARGS='--coverage --open-files --remote-data'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - env: RUN_CMD='python setup.py build_docs -w'
-               CONDA_DEPENDENCIES="$ALL_CONDA_DEPENDENCIES sphinx-astropy"
+        - env: TOXENV='docbuild' TOX_ARGS=''
 
         # Do a code style check
-        - env: RUN_CMD="flake8 asdf --count"
-               PIP_DEPENDENCIES="$ALL_PIP_DEPENDENCIES flake8"
+        - env: TOXENV='style' TOX_ARGS=''
 
         # try older numpy versions
-        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
-        - env: NUMPY_VERSION=1.12
+        - env: TOXENV='py35-numpy11'
+        - env: TOXENV='py36-numpy12'
 
-        # also test against development version of Astropy
-        - env: ASTROPY_VERSION=development GWCS_PIP="$GWCS_GIT"
-
-        # latest stable versions
-        - env: NUMPY_VERSION=stable
+        # also test against development versions of Astropy and GWCS
+        - env: TOXENV='py36-astropydev-gwcsdev'
 
         # Test against development version of numpy (this job can fail)
-        - env: NUMPY_VERSION=development
+        - env: TOXENV='py37-numpydev'
 
         # Try a run on OSX
         - os: osx
-          env: NUMPY_VERSION=stable
-
-        # Test against latest version of jsonschema
-        - env: PIP_DEPENDENCIES='jsonschema pytest-faulthandler importlib_resources'
-
-        # Run a series of tests on Windows
-        - os: windows
-          env: RUN_CMD='python setup.py install'
+          env: TOXENV='py37-stable'
 
         - os: windows
-          env: RUN_CMD='pytest --remote-data'
+          env: TOXENV='py37-stable' TOX_ARGS='--remote-data'
 
         - os: windows
-          env: PYTHON_VERSION=3.5
+          env: TOXENV='py35-stable'
 
         - os: windows
-          env: PYTHON_VERSION=3.6
+          env: TOXENV='py36-stable'
 
         # Windows test against development version of numpy (this job can fail)
         - os: windows
-          env: NUMPY_VERSION=development
+          env: TOXENV='py37-numpydev'
 
 
     allow_failures:
-        - env: NUMPY_VERSION=development
-        - env: PIP_DEPENDENCIES='jsonschema pytest-faulthandler importlib_resources'
+        - env: TOXENV='py37-numpydev'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-    - python -m pip install --no-deps $GWCS_PIP
-    - python setup.py install
+    - pip install tox tox-conda
 
 script:
-    - if [[ $TWINE_CHECK ]]; then
-        python setup.py build sdist;
-        twine check dist/*;
-      elif [[ $COVERAGE ]]; then
-        coverage run --source=asdf -m pytest --remote-data --open-files;
-        coverage report -m;
-      else
-        $RUN_CMD;
-      fi
+   - $TOX_CMD $TOX_ARGS
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    - if [[ $COVERAGE ]]; then coveralls --rcfile='asdf/tests/coveragerc'; fi
+    - if [[ $TOX_ARGS == '--coverage --open-files --remote-data' ]]; then coveralls --rcfile='asdf/tests/coveragerc'; fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,66 @@
 [tox]
-envlist = {py36,py37}-{stable,dev}
+envlist =
+    {py36,py37}-{stable,gwcsdev},py37-astropydev
+
 [testenv]
 deps=
-    py36: importlib_resources
-    pytest<=3.6
-    stable: astropy
-    stable: gwcs
-    pytest-astropy
     pytest-sugar
+    pytest-faulthandler
+    !astropydev: gwcs
+    py35,py36: importlib_resources
+    numpydev: git+git://github.com/numpy/numpy
+    gwcsdev,astropydev: git+git://github.com/astropy/astropy
+conda_deps=
+    pytest
+    pytest-astropy
+    !astropydev: astropy
+    numpy11: numpy=1.11
+    numpy12: numpy=1.12
+    !numpydev: numpy
+    numpydev,astropydev: cython
+conda_channels=
+    conda-forge
 commands=
-    dev: pip install --no-deps git+git://github.com/astropy/astropy
-    dev: pip install --no-deps git+git://github.com/spacetelescope/gwcs
+    gwcsdev: pip install --no-deps git+git://github.com/spacetelescope/gwcs
     pytest {posargs}
+
+[testenv:docbuild]
+basepython= python3.6
+conda_deps=
+    sphinx
+    graphviz
+    matplotlib
+    astropy
+commands=
+    python setup.py build_docs -w
+
+[testenv:checkdocs]
+basepython= python3.6
+deps=
+    collective.checkdocs
+    pygments
+commands=
+    python setup.py checkdocs
+
+[testenv:style]
+basepython= python3.6
+conda_deps=
+    flake8
+commands=
+    flake8 asdf --count
+
+[testenv:coverage]
+basepython= python3.7
+deps=
+    gwcs
+conda_deps=
+    pytest
+    pytest-astropy
+    astropy
+    coverage
+    coveralls
+commands=
+    coverage run --source=asdf -m pytest --remote-data --open-files
+    coverage report -m
+    coveralls --rcfile='asdf/tests/coveragerc'
+passenv= TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,19 @@ commands=
     gwcsdev: pip install --no-deps git+git://github.com/spacetelescope/gwcs
     pytest {posargs}
 
+[testenv:egg_info]
+deps=
+conda_deps=
+commands=
+    python setup.py egg_info
+
+[testenv:twine]
+deps=
+    twine
+conda_deps=
+commands=
+    twine check {distdir}/*
+
 [testenv:docbuild]
 basepython= python3.6
 conda_deps=


### PR DESCRIPTION
Now that a prototype of [tox-conda](https://github.com/drdavella/tox-conda) is available, we can try using it on CI. This has several major benefits:

* greatly simplifies the CI config file
* allows any test environment used by CI to be exactly reproduced locally, which should make debugging much easier