### PR TITLE
Make sure extension metadata is written in all cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 2.1.1 (unreleased)
 ------------------
 
+- Make sure extension metadata is written even when constructing the ASDF tree
+  on-the-fly. [#549]
 
 2.1.0 (2018-09-25)
 ------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -827,6 +827,7 @@ class AsdfFile(versioning.VersionedMixin):
         self._blocks.finalize(self)
 
         self._tree['asdf_library'] = get_asdf_library_info()
+        self._update_extension_history()
 
     def _serial_write(self, fd, pad_blocks, include_block_index):
         self._write_tree(self._tree, fd, pad_blocks)
@@ -911,8 +912,6 @@ class AsdfFile(versioning.VersionedMixin):
             The ASDF version to write out.  If not provided, it will
             write out in the latest version supported by asdf.
         """
-
-        self._update_extension_history()
 
         fd = self._fd
 
@@ -1053,8 +1052,6 @@ class AsdfFile(versioning.VersionedMixin):
             The ASDF version to write out.  If not provided, it will
             write out in the latest version supported by asdf.
         """
-
-        self._update_extension_history()
 
         original_fd = self._fd
 

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -286,3 +286,12 @@ def test_metadata_with_custom_extension(tmpdir):
             pass
 
     assert len(warnings) == 0
+
+    # Make sure that this works even when constructing the tree on-the-fly
+    tmpfile3 = str(tmpdir.join('custom_extension2.asdf'))
+    with asdf.AsdfFile(extensions=FractionExtension()) as ff:
+        ff.tree['fraction'] = fractions.Fraction(4, 5)
+        ff.write_to(tmpfile3)
+
+    with asdf.open(tmpfile3, extensions=FractionExtension()) as af:
+        assert len(af['history']['extensions']) == 2


### PR DESCRIPTION
Previously, extension metadata was not being tracked properly for the following use case:

```python
import asdf

af = asdf.AsdfFile()
af.tree['foo'] = ObjectUsingExternalExtension()
af.write_to('foo.asdf')
```

Extension metadata was only being recorded for the case where the fully constructed tree was passed to the `AsdfFile` constructor. This PR updates a test to make sure it works for both cases.