### PR TITLE
Properly validate large numpy integer literals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 - Make sure extension metadata is written even when constructing the ASDF tree
   on-the-fly. [#549]
 
+- Fix large integer validation when storing `numpy` integer literals in the
+  tree. [#553]
+
 2.1.0 (2018-09-25)
 ------------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -4,6 +4,7 @@
 import os
 import json
 import datetime
+from numbers import Integral
 from functools import lru_cache
 from collections import OrderedDict
 from urllib import parse as urlparse
@@ -457,7 +458,7 @@ def validate_large_literals(instance):
     """
     # We can count on 52 bits of precision
     for instance in treeutil.iter_tree(instance):
-        if (isinstance(instance, int) and (
+        if (isinstance(instance, (Integral)) and (
             instance > ((1 << 51) - 1) or
             instance < -((1 << 51) - 2))):
             raise ValidationError(

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -471,16 +471,22 @@ def test_self_reference_resolution():
     assert s['anyOf'][1] == s['anyOf'][0]
 
 
-def test_large_literals():
+@pytest.mark.parametrize('use_numpy', [False, True])
+def test_large_literals(use_numpy):
+
+    largeval = 1 << 53
+    if use_numpy:
+        largeval = np.uint64(largeval)
+
     tree = {
-        'large_int': (1 << 53),
+        'large_int': largeval,
     }
 
     with pytest.raises(ValidationError):
         asdf.AsdfFile(tree)
 
     tree = {
-        'large_array': np.array([(1 << 53)], np.uint64)
+        'large_array': np.array([largeval], np.uint64)
     }
 
     ff = asdf.AsdfFile(tree)


### PR DESCRIPTION
This fixes #551.