### PR TITLE
Fix issue causing subclass to be serialized by wrong extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@
 - Fix large integer validation when storing `numpy` integer literals in the
   tree. [#553]
 
+- Fix bug that caused subclass of external type to be serialized by the wrong
+  tag. [#560]
+
 2.1.0 (2018-09-25)
 ------------------
 

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -126,7 +126,11 @@ class _AsdfWriteTypeIndex(object):
                 # hierarchy than the existing subclass.
                 if subclass in self._class_by_subclass:
                     if issubclass(self._class_by_subclass[subclass], typ):
-                        continue
+                        # Allow for cases where a subclass tag is being
+                        # overridden by a tag from another extension.
+                        if (self._extension_by_cls[subclass] ==
+                                index._extension_by_type[asdftype]):
+                            continue
                 self._class_by_subclass[subclass] = typ
                 self._type_by_subclasses[subclass] = asdftype
                 self._extension_by_cls[subclass] = index._extension_by_type[asdftype]

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -231,4 +231,10 @@ class _DefaultExtensions:
     def package_metadata(self):
         return self._package_metadata
 
+    def reset(self):
+        """This will be used primarily for testing purposes."""
+        self._extensions = []
+        self._extension_list = None
+        self._package_metadata = {}
+
 default_extensions = _DefaultExtensions()

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -22,7 +22,7 @@ TEST_DATA_PATH = str(helpers.get_test_data_path(''))
 def test_custom_tag():
     import fractions
 
-    class FractionType(asdftypes.AsdfType):
+    class FractionType(asdftypes.CustomType):
         name = 'fraction'
         organization = 'nowhere.org'
         version = (1, 0, 0)
@@ -285,15 +285,15 @@ def test_longest_match():
 
 
 def test_module_versioning():
-    class NoModuleType(asdftypes.AsdfType):
+    class NoModuleType(asdftypes.CustomType):
         # It seems highly unlikely that this would be a real module
         requires = ['qkjvqdja']
 
-    class HasCorrectPytest(asdftypes.AsdfType):
+    class HasCorrectPytest(asdftypes.CustomType):
         # This means it requires 1.0.0 or greater, so it should succeed
         requires = ['pytest-1.0.0']
 
-    class DoesntHaveCorrectPytest(asdftypes.AsdfType):
+    class DoesntHaveCorrectPytest(asdftypes.CustomType):
         requires = ['pytest-91984.1.7']
 
     nmt = NoModuleType()

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -311,6 +311,7 @@ def test_bad_input(tmpdir):
 @pytest.mark.skipif(sys.platform.startswith('win'),
     reason='Avoid path manipulation on Windows')
 def test_version_mismatch_file():
+
     testfile = str(get_test_data_path('version_mismatch.fits'))
 
     with pytest.warns(None) as w:
@@ -318,7 +319,7 @@ def test_version_mismatch_file():
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
     # This is the warning that we expect from opening the FITS file
-    assert len(w) == 1
+    assert len(w) == 1, display_warnings(w)
     assert str(w[0].message) == (
         "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
         "'{}', but latest supported version is 1.0.0".format(testfile))

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -202,7 +202,7 @@ def test_schema_caching():
 
 
 def test_flow_style():
-    class CustomFlowStyleType(dict, asdftypes.AsdfType):
+    class CustomFlowStyleType(dict, asdftypes.CustomType):
         name = 'custom_flow'
         organization = 'nowhere.org'
         version = (1, 0, 0)
@@ -225,7 +225,7 @@ def test_flow_style():
 
 
 def test_style():
-    class CustomStyleType(str, asdftypes.AsdfType):
+    class CustomStyleType(str, asdftypes.CustomType):
         name = 'custom_style'
         organization = 'nowhere.org'
         version = (1, 0, 0)
@@ -267,7 +267,7 @@ def test_property_order():
 
 
 def test_invalid_nested():
-    class CustomType(str, asdftypes.AsdfType):
+    class CustomType(str, asdftypes.CustomType):
         name = 'custom'
         organization = 'nowhere.org'
         version = (1, 0, 0)
@@ -361,7 +361,7 @@ def test_default_check_in_schema():
 
 
 def test_fill_and_remove_defaults():
-    class DefaultType(dict, asdftypes.AsdfType):
+    class DefaultType(dict, asdftypes.CustomType):
         name = 'default'
         organization = 'nowhere.org'
         version = (1, 0, 0)
@@ -586,7 +586,7 @@ properties:
 @pytest.mark.importorskip('astropy')
 def test_type_missing_dependencies():
 
-    class MissingType(asdftypes.AsdfType):
+    class MissingType(asdftypes.CustomType):
         name = 'missing'
         organization = 'nowhere.org'
         version = (1, 1, 0)
@@ -614,7 +614,7 @@ custom: !<tag:nowhere.org:custom/missing-1.1.0>
 def test_assert_roundtrip_with_extension(tmpdir):
     called_custom_assert_equal = [False]
 
-    class CustomType(dict, asdftypes.AsdfType):
+    class CustomType(dict, asdftypes.CustomType):
         name = 'custom_flow'
         organization = 'nowhere.org'
         version = (1, 0, 0)


### PR DESCRIPTION
ASDF provides some built-in types. When an external extension is found that serializes the same types, that extension should override the corresponding built-in types. However, this wasn't happening in cases where the type to be serialized was actually a subclass of an extension type. This PR fixes that.

While fixing this, some other issues with the test infrastructure were exposed, which are also fixed here.

This PR still does **not** allow subclasses of extension types to be roundtripped. Instead, if a subclass is serialized, when reading the file, the base class serialized by the extension will be returned. This latter functionality will be forthcoming in a future PR.

This partially addresses #555.

cc @nden