### PR TITLE
Use decorators to serialize subclasses of known custom types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
   default. Add configuration setting and command line option to enable schema
   tests. [#676]
 
+- Enable handling of subclasses of known custom types by using decorators for
+  convenience. [#563]
+
 2.3.4 (unreleased)
 ------------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -72,6 +72,7 @@ def _type_to_tag(type_):
 
 
 def validate_tag(validator, tagname, instance, schema):
+
     if hasattr(instance, '_tag'):
         instance_tag = instance._tag
     else:

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -41,6 +41,11 @@ class ExtensionMetadata(AsdfType):
         return tree
 
 
+class SubclassMetadata(dict, AsdfType):
+    name = 'core/subclass_metadata'
+    version = '1.0.0'
+
+
 from .constant import ConstantType
 from .ndarray import NDArrayType
 from .complex import ComplexType

--- a/asdf/tests/__init__.py
+++ b/asdf/tests/__init__.py
@@ -5,7 +5,8 @@ This packages contains affiliated package tests.
 
 import numpy as np
 
-from .. import CustomType
+from .. import CustomType, util
+from .helpers import get_test_data_path
 
 
 class CustomTestType(CustomType):
@@ -46,3 +47,24 @@ def create_large_tree():
         'more': y
     }
     return tree
+
+
+class CustomExtension:
+    """
+    This is the base class that is used for extensions for custom tag
+    classes that exist only for the purposes of testing.
+    """
+    @property
+    def types(self):
+        return []
+
+    @property
+    def tag_mapping(self):
+        return [('tag:nowhere.org:custom',
+                 'http://nowhere.org/schemas/custom{tag_suffix}')]
+
+    @property
+    def url_mapping(self):
+        return [('http://nowhere.org/schemas/custom/',
+                 util.filepath_to_url(get_test_data_path('')) +
+                 '/{url_suffix}.yaml')]

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -15,7 +15,7 @@ from asdf import extension
 from asdf import util
 from asdf import versioning
 
-from . import helpers, CustomTestType
+from . import helpers, CustomTestType, CustomExtension
 
 
 TEST_DATA_PATH = str(helpers.get_test_data_path(''))
@@ -38,21 +38,10 @@ def test_custom_tag():
         def from_tree(cls, tree, ctx):
             return fractions.Fraction(tree[0], tree[1])
 
-    class FractionExtension:
+    class FractionExtension(CustomExtension):
         @property
         def types(self):
             return [FractionType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/',
-                     util.filepath_to_url(TEST_DATA_PATH) +
-                     '/{url_suffix}.yaml')]
 
     class FractionCallable(FractionExtension):
         @property
@@ -175,21 +164,10 @@ def test_version_mismatch_with_supported_versions():
         standard = 'custom'
         types = [CustomFlow]
 
-    class CustomFlowExtension:
+    class CustomFlowExtension(CustomExtension):
         @property
         def types(self):
             return [CustomFlowType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/',
-                     util.filepath_to_url(TEST_DATA_PATH) +
-                     '/{url_suffix}.yaml')]
 
     yaml = """
 flow_thing:
@@ -391,21 +369,10 @@ def test_newer_tag():
         def to_tree(cls, data, ctx):
             tree = dict(c=data.c, d=data.d)
 
-    class CustomFlowExtension:
+    class CustomFlowExtension(CustomExtension):
         @property
         def types(self):
             return [CustomFlowType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/',
-                     util.filepath_to_url(TEST_DATA_PATH) +
-                     '/{url_suffix}.yaml')]
 
     new_yaml = """
 flow_thing:
@@ -518,21 +485,10 @@ def test_supported_versions():
             else:
                 tree = dict(c=data.c, d=data.d)
 
-    class CustomFlowExtension:
+    class CustomFlowExtension(CustomExtension):
         @property
         def types(self):
             return [CustomFlowType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/',
-                     util.filepath_to_url(TEST_DATA_PATH) +
-                     '/{url_suffix}.yaml')]
 
     new_yaml = """
 flow_thing:
@@ -566,21 +522,10 @@ def test_unsupported_version_warning():
         standard = 'custom'
         types = [CustomFlow]
 
-    class CustomFlowExtension:
+    class CustomFlowExtension(CustomExtension):
         @property
         def types(self):
             return [CustomFlowType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/',
-                     util.filepath_to_url(TEST_DATA_PATH) +
-                     '/{url_suffix}.yaml')]
 
     yaml = """
 flow_thing:
@@ -725,21 +670,10 @@ def test_subclass_decorator_warning(tmpdir):
         def from_tree(cls, tree, ctx):
             return fractions.Fraction(tree[0], tree[1])
 
-    class FractionExtension(object):
+    class FractionExtension(CustomExtension):
         @property
         def types(self):
             return [FractionType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/',
-                     util.filepath_to_url(TEST_DATA_PATH) +
-                     '/{url_suffix}.yaml')]
 
     @FractionType.subclass
     class MyFraction(fractions.Fraction):

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -712,13 +712,16 @@ def test_subclass_decorator(tmpdir):
 
     # Now create a subclass
     @Fractional2dCoordType.subclass
-    class Subclass2dCoord(Fractional2dCoordType):
+    class Subclass2dCoord(Fractional2dCoord):
         pass
 
-    subclass_coord = Fractional2dCoord(Fraction(2, 3), Fraction(7, 9))
+    subclass_coord = Subclass2dCoord(Fraction(2, 3), Fraction(7, 9))
     tree = dict(coord=subclass_coord)
 
     with asdf.AsdfFile(tree, extensions=extension) as af:
+        af.write_to(tmpfile)
+
+    with asdf.open(tmpfile, extensions=extension) as af:
         assert isinstance(af['coord'], Subclass2dCoord)
         assert af['coord'].x == subclass_coord.x
         assert af['coord'].y == subclass_coord.y

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -646,7 +646,6 @@ def test_extension_override_subclass(tmpdir):
     with open(tmpfile, 'rb') as ff:
         contents = str(ff.read())
         assert gwcs.tags.WCSType.yaml_tag in contents
-        assert asdf.tags.wcs.WCSType.yaml_tag not in contents
 
 
 def test_tag_without_schema(tmpdir):
@@ -710,7 +709,7 @@ def test_subclass_decorator(tmpdir):
 
     tmpfile = str(tmpdir.join('fraction.asdf'))
 
-    class FractionType(asdftypes.AsdfType):
+    class FractionType(types.AsdfType):
         name = 'fraction'
         organization = 'nowhere.org'
         version = (1, 0, 0)

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -22,28 +22,7 @@ from asdf import schema
 from asdf import util
 from asdf import yamlutil
 
-from asdf.tests import helpers
-
-
-class CustomExtension:
-    """
-    This is the base class that is used for extensions for custom tag
-    classes that exist only for the purposes of testing.
-    """
-    @property
-    def types(self):
-        return []
-
-    @property
-    def tag_mapping(self):
-        return [('tag:nowhere.org:custom',
-                 'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-    @property
-    def url_mapping(self):
-        return [('http://nowhere.org/schemas/custom/',
-                 util.filepath_to_url(helpers.get_test_data_path('')) +
-                 '/{url_suffix}.yaml')]
+from asdf.tests import helpers, CustomExtension
 
 
 class TagReferenceType(types.CustomType):

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -426,6 +426,36 @@ class ExtensionType:
 
     @classmethod
     def subclass(cls, *args, attribute='subclass'):
+        """
+        Decorator to enable serialization of a subclass of an existing type.
+
+        Use this method to decorate subclasses of custom types that are already
+        handled by an existing ASDF tag class. This enables subclasses of known
+        types to be properly serialized without having to write an entirely
+        separate tag class for the subclass.
+
+        This feature can only be used for tagged types where the underlying
+        YAML representation of the type is an object (i.e. a Python `dict`). It
+        will not work for nodes that are basic types.
+
+        The subclass metadata is stored in a new attribute of the YAML node. By
+        default the attribute name is "subclass", but it is customizable by
+        using the optional `attribute` keyword argument of the decorator.
+
+        The schema of the base custom type is used for validation. This feature
+        will not work if the base schema disallows additional attributes.
+
+        It is incumbent upon the user to avoid name conflicts with attributes
+        that already exist in the representation of the base custom class. For
+        example, a base class may use the attribute "subclass" for some other
+        purpose, in which case it would be necessary to provide a different
+        custom attribute name here.
+
+        Parameters
+        ----------
+        attribute : `str`
+            Custom attribute name used to store subclass metadata in this node.
+        """
 
         def decorator(subclass):
             cls._subclass_map[subclass.__name__] = (attribute, subclass)
@@ -438,6 +468,24 @@ class ExtensionType:
 
     @classmethod
     def subclass_property(cls, attribute):
+        """
+        Decorator to enable serialization of custom subclass attributes.
+
+        Use this decorator to serialize attributes that are specific to a
+        subclass of a custom type that is already handled by an existing ASDF
+        tag class. This decorator will only work on subclasses that have been
+        decorated with the `~asdf.AsdfTypes.subclass` decorator.
+
+        Methods that are decorated in this way are treated as properties (see
+        `property`). The name of the property **must** correspond to a keyword
+        argument of the subclass constructor.
+
+        The property will be serialized as a YAML object attribute with the
+        same name. Users are responsible for ensuring that any and all
+        additional subclass properties conform to the schema of the base custom
+        type and do not conflict with existing attributes.
+        """
+
         return AsdfSubclassProperty(attribute)
 
 

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+import inspect
 import importlib
 from collections import defaultdict
 

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -3,6 +3,7 @@
 
 import re
 import inspect
+import warnings
 import importlib
 from collections import defaultdict
 

--- a/docs/asdf/extensions.rst
+++ b/docs/asdf/extensions.rst
@@ -534,6 +534,57 @@ Note that the implementation of ``to_tree`` is not conditioned on
 ``cls.version`` since we do not need to convert new ``Person`` objects back to
 the older version of the schema.
 
+Handling subclasses
+*******************
+
+By default, if a custom type is serialized by an ASDF tag class, then all
+subclasses of that type can also be serialized. However, no attributes that are
+specific to the subclass will be stored in the file. When reading the file, an
+instance of the base custom type will be returned instead of the subclass that
+was written.
+
+To properly handle subclasses of custom types already recognized by ASDF, it is
+necessary to implement a separate tag class that is specific to the subclass to
+be serialized.
+
+However, this can be burdensome, especially if multiple subclasses need to be
+handled. Version 2.4.0 of the `asdf` package introduces a new way to handle
+subclasses of custom types using decorators.
+
+.. attention::
+
+   This feature was introduced in version 2.4.0 and is **experimental**. The
+   API may change in future versions.
+
+In previous examples we wrote a tag class for the built-in type
+`fractions.Fraction`. Let's create a subclass of this type that we wish to
+be able to serialize in ASDF. We have already defined ``FractionType`` which
+handles the serialization of `fractions.Fraction`. We will use decorators to
+indicate how to properly serialize the subclass:
+
+.. code-block:: python
+
+   @FractionType.subclass
+   class NamedFraction(fractions.Fraction):
+      """
+      A very contrived example, indeed.
+      """
+      def __init__(self, *args, name='', **kwargs):
+         super().__init__(*args, **kwargs)
+         self._name = name
+
+      @FractionType.subclass_property
+      def name(self):
+         return self._name
+
+The decorators we use are defined as class methods of the ``FractionType`` tag
+class. By using these we enable round-trip serialization of our custom subclass
+type. See `asdf.CustomType.subclass` and `asdf.CustomType.subclass_property`
+for additional details.
+
+Note that this feature is currently not reflected in the ASDF Standard, which
+means that other implementations of ASDF may not preserve subclass information.
+
 Creating custom schemas
 -----------------------
 


### PR DESCRIPTION
This resolves #446 and also resolves #555.

More work is required, and there also needs to be some more discussion in order to determine whether this would better be supported by some updates to the standard. Also, we need to evaluate current examples in GWCS, Astropy, and possibly Sunpy to evaluate how this can be improved.

cc @nden, @Cadair 