### PR TITLE
Address warnings when using pytest 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - PYTHON_VERSION=3.6
-        - PYTEST_VERSION=3.6
+        - PYTEST_VERSION=3.7
         - ASTROPY_VERSION=stable
         - NUMPY_VERSION=stable
         - PIP_DEPENDENCIES='pytest-faulthandler importlib_resources'
@@ -39,7 +39,7 @@ env:
         - PIP_DEPENDENCIES='collective.checkdocs pygments' SETUP_CMD='checkdocs'
         - PYTHON_VERSION=3.5 SETUP_CMD='test'
         - PYTHON_VERSION=3.6 SETUP_CMD='test'
-        - PYTHON_VERSION=3.7 SETUP_CMD='test'
+        - PYTHON_VERSION=3.7 PYTEST_VERSION=3.8 SETUP_CMD='test'
 
 matrix:
     include:
@@ -62,6 +62,7 @@ matrix:
         # also test against development version of Astropy
         - env: MAIN_CMD='pytest' SETUP_CMD='' ASTROPY_VERSION=development
                GWCS_PIP="$GWCS_GIT"
+               PYTEST_VERSION=3.8
 
         # latest stable versions
         - env: NUMPY_VERSION=stable SETUP_CMD='test'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
 
   global:
       PYTHON: "C:\\conda"
+      PYTEST_VERSION: "3.7"
       MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       SETUP_CMD: "test"
@@ -29,20 +30,22 @@ environment:
         NUMPY_VERSION: "1.12.0"
         platform: x64
 
-      - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.7"
+        PYTEST_VERSION: "3.7"
         platform: x64
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"
         platform: x64
 
-      - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.7"
+        PYTEST_VERSION: "3.7"
         ASTROPY_VERSION: "development"
         GWCS_PIP: "%GWCS_GIT%"
         platform: x64
 
       # Tests against development version of numpy may fail
-      - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.7"
         NUMPY_VERSION: "development"
         platform: x64
 

--- a/asdf/conftest.py
+++ b/asdf/conftest.py
@@ -21,11 +21,6 @@ packagename = os.path.basename(os.path.dirname(__file__))
 TESTED_VERSIONS[packagename] = version.version
 
 
-pytest_plugins = [
-    'asdf.tests.schema_tester'
-]
-
-
 try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
     PYTEST_HEADER_MODULES['jsonschema'] = 'jsonschema'

--- a/asdf/tests/__init__.py
+++ b/asdf/tests/__init__.py
@@ -3,6 +3,8 @@
 This packages contains affiliated package tests.
 """
 
+import numpy as np
+
 from .. import CustomType
 
 
@@ -20,3 +22,27 @@ class CustomTestType(CustomType):
     @classmethod
     def from_tree(cls, tree, ctx):
         return tree
+
+
+def create_small_tree():
+    x = np.arange(0, 10, dtype=np.float)
+    tree = {
+        'science_data': x,
+        'subset': x[3:-3],
+        'skipping': x[::2],
+        'not_shared': np.arange(10, 0, -1, dtype=np.uint8)
+    }
+    return tree
+
+
+def create_large_tree():
+    # These are designed to be big enough so they don't fit in a
+    # single block, but not so big that RAM/disk space for the tests
+    # is enormous.
+    x = np.random.rand(256, 256)
+    y = np.random.rand(16, 16, 16)
+    tree = {
+        'science_data': x,
+        'more': y
+    }
+    return tree

--- a/asdf/tests/conftest.py
+++ b/asdf/tests/conftest.py
@@ -4,28 +4,14 @@
 import pytest
 import numpy as np
 
+from . import create_small_tree, create_large_tree
+
 
 @pytest.fixture
 def small_tree():
-    x = np.arange(0, 10, dtype=np.float)
-    tree = {
-        'science_data': x,
-        'subset': x[3:-3],
-        'skipping': x[::2],
-        'not_shared': np.arange(10, 0, -1, dtype=np.uint8)
-    }
-    return tree
+    return create_small_tree()
 
 
 @pytest.fixture
 def large_tree():
-    # These are designed to be big enough so they don't fit in a
-    # single block, but not so big that RAM/disk space for the tests
-    # is enormous.
-    x = np.random.rand(256, 256)
-    y = np.random.rand(16, 16, 16)
-    tree = {
-        'science_data': x,
-        'more': y
-    }
-    return tree
+    return create_large_tree()

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -16,12 +16,10 @@ from asdf import util
 from asdf import generic_io
 from asdf.asdf import is_asdf_file
 
-from . import helpers
-# The only reason for importing these is to use them in the fixture below
-from .conftest import small_tree, large_tree
+from . import helpers, create_small_tree, create_large_tree
 
 
-@pytest.fixture(params=[small_tree, large_tree])
+@pytest.fixture(params=[create_small_tree, create_large_tree])
 def tree(request):
     return request.param()
 

--- a/asdf/tests/test_suite.py
+++ b/asdf/tests/test_suite.py
@@ -14,7 +14,7 @@ from .helpers import assert_tree_match, display_warnings
 
 def get_test_id(reference_file_path):
     """Helper function to return the informative part of a schema path"""
-    path = os.path.normpath(reference_file_path)
+    path = os.path.normpath(str(reference_file_path))
     return os.path.sep.join(path.split(os.path.sep)[-3:])
 
 def collect_reference_files():

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,11 @@ from astropy.tests.helper import enable_deprecations_as_exceptions
 
 enable_deprecations_as_exceptions()
 
+pytest_plugins = [
+    'asdf.tests.schema_tester'
+]
+
+
 @pytest.fixture(autouse=True)
 def _docdir(request):
     """

--- a/conftest.py
+++ b/conftest.py
@@ -19,7 +19,7 @@ def _docdir(request):
     if isinstance(request.node, DoctestItem):
 
         # Get the fixture dynamically by its name.
-        tmpdir = request.getfuncargvalue('tmpdir')
+        tmpdir = request.getfixturevalue('tmpdir')
 
         # Chdir only for the duration of the test.
         olddir = os.getcwd()


### PR DESCRIPTION
Also update CI matrices to test against newer versions of pytest and python.