### PR TITLE
Allow tree to be created even when schema is missing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@
 - Fix bug that occurred when attempting to open invalid file but Astropy import
   fails while checking for ASDF-in-FITS. [#562]
 
+- Fix bug that caused tree creation to fail when unable to locate a schema file
+  for an unknown tag. This now simply causes a warning, and the offending node
+  is converted to basic Python data structures. [#571]
+
 2.1.0 (2018-09-25)
 ------------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -4,6 +4,7 @@
 import os
 import json
 import datetime
+import warnings
 from numbers import Integral
 from functools import lru_cache
 from collections import OrderedDict
@@ -218,7 +219,12 @@ def _create_validator(validators=YAML_VALIDATORS):
                 if tag is not None:
                     schema_path = self.ctx.resolver(tag)
                     if schema_path != tag:
-                        s = load_schema(schema_path, self.ctx.resolver)
+                        try:
+                            s = load_schema(schema_path, self.ctx.resolver)
+                        except FileNotFoundError:
+                            msg = "Unable to locate schema file for '{}': '{}'"
+                            warnings.warn(msg.format(tag, schema_path))
+                            s = {}
                         if s:
                             with self.resolver.in_scope(schema_path):
                                 for x in super(ASDFValidator, self).iter_errors(instance, s):

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -753,9 +753,15 @@ a: !core/doesnt_exist-1.0.0
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with asdf.open(buff) as af:
-        assert af['a'] == 'hello'
-
+    with pytest.warns(None) as w:
+        with asdf.open(buff) as af:
+            assert str(af['a']) == 'hello'
+        # Currently there are 3 warnings since one occurs on each of the
+        # validation passes. It would be good to consolidate these eventually
+        assert len(w) == 3, helpers.display_warnings(w)
+        assert str(w[0].message).startswith("Unable to locate schema file")
+        assert str(w[1].message).startswith("Unable to locate schema file")
+        assert str(w[2].message).startswith(af['a']._tag)
 
     # This is a more realistic case since we're using an external extension
     yaml = """
@@ -764,5 +770,10 @@ a: !<tag:nowhere.org:custom/doesnt_exist-1.0.0>
   """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with asdf.open(buff, extensions=CustomExtension()) as af:
-        assert af['a'] == 'hello'
+    with pytest.warns(None) as w:
+        with asdf.open(buff, extensions=CustomExtension()) as af:
+            assert str(af['a']) == 'hello'
+        assert len(w) == 3, helpers.display_warnings(w)
+        assert str(w[0].message).startswith("Unable to locate schema file")
+        assert str(w[1].message).startswith("Unable to locate schema file")
+        assert str(w[2].message).startswith(af['a']._tag)


### PR DESCRIPTION
Previously an error occurred in the case where a node was tagged with a type from a known extension, but the type itself was unknown. This could happen, for example, in the case where the type is provided by a more recent version of a package, but only the older version of the package is installed.

Now, just a warning occurs, and the affected node is returned as a basic Python tree.