### PR TITLE
Add lazy_load parameter to open()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,13 +6,13 @@
   constructor. It can also be controlled with the existing
   ``set_array_storage`` method of ``AsdfFile`` and the ``all_array_storage``
   argument to ``AsdfFile.write_to``. [#557]
-- Add new parameter `lazy_load` to ``AsdfFile.open``. It is ``True`` by
+- Add new parameter ``lazy_load`` to ``AsdfFile.open``. It is ``True`` by
   default and preserves the default behavior. ``False`` detaches the
   loaded tree from the underlying file: all blocks are fully read and
   numpy arrays are materialized. Thus it becomes safe to close the file
-  and continue using ``AsdfFile.tree``. However, `copy_arrays` parameter
+  and continue using ``AsdfFile.tree``. However, ``copy_arrays`` parameter
   is still effective and the active memory maps may still require the file
-  to stay open in case `copy_arrays` is ``False``. [#573]
+  to stay open in case ``copy_arrays`` is ``False``. [#573]
 
 2.1.1 (unreleased)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@
   constructor. It can also be controlled with the existing
   ``set_array_storage`` method of ``AsdfFile`` and the ``all_array_storage``
   argument to ``AsdfFile.write_to``. [#557]
+- Add new parameter `lazy_load` to ``AsdfFile.open``. It is ``True`` by
+  default and preserves the default behavior. ``False`` detaches the
+  loaded tree from the underlying file: all blocks are fully read and
+  numpy arrays are materialized. Thus it becomes safe to close the file
+  and continue using ``AsdfFile.tree``. However, `copy_arrays` parameter
+  is still effective and the active memory maps may still require the file
+  to stay open in case `copy_arrays` is ``False``. [#573]
 
 2.1.1 (unreleased)
 ------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -90,13 +90,18 @@ class AsdfFile(versioning.VersionedMixin):
 
         copy_arrays : bool, optional
             When `False`, when reading files, attempt to memmap underlying data
-            arrays when possible.
+            arrays when possible. Please note that the file must be opened
+            in "rw" mode; "r" will result a SIGSEGV.
 
         lazy_load : bool, optional
-            When `True` and the read file is seekable, underlying data arrays
-            will be materialized when they are used for the first time.
-            This implies that the file should stay open during the lifetime
-            of the tree.
+            When `True` and the underlying file handle is seekable, data
+            arrays will only be loaded lazily: i.e. when they are accessed
+            for the first time. In this case the underlying file must stay
+            open during the lifetime of the tree. Setting to False causes
+            all data arrays to be loaded up front, which means that they
+            can be accessed even after the underlying file is closed.
+            Note: even if `lazy_load` is `False`, `copy_arrays` is still taken
+            into account.
 
         custom_schema : str, optional
             Path to a custom schema file that will be used for a secondary
@@ -755,13 +760,18 @@ class AsdfFile(versioning.VersionedMixin):
 
         copy_arrays : bool, optional
             When `False`, when reading files, attempt to memmap underlying data
-            arrays when possible.
+            arrays when possible. Please note that the file must be opened
+            in "rw" mode; "r" will result a SIGSEGV.
 
         lazy_load : bool, optional
-            When `True` and the read file is seekable, underlying data arrays
-            will be materialized when they are used for the first time.
-            This implies that the file should stay open during the lifetime
-            of the tree.
+            When `True` and the underlying file handle is seekable, data
+            arrays will only be loaded lazily: i.e. when they are accessed
+            for the first time. In this case the underlying file must stay
+            open during the lifetime of the tree. Setting to False causes
+            all data arrays to be loaded up front, which means that they
+            can be accessed even after the underlying file is closed.
+            Note: even if `lazy_load` is `False`, `copy_arrays` is still taken
+            into account.
 
         custom_schema : str, optional
             Path to a custom schema file that will be used for a secondary

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -90,8 +90,7 @@ class AsdfFile(versioning.VersionedMixin):
 
         copy_arrays : bool, optional
             When `False`, when reading files, attempt to memmap underlying data
-            arrays when possible. Please note that the file must be opened
-            in "rw" mode; "r" will result a SIGSEGV.
+            arrays when possible.
 
         lazy_load : bool, optional
             When `True` and the underlying file handle is seekable, data
@@ -760,8 +759,7 @@ class AsdfFile(versioning.VersionedMixin):
 
         copy_arrays : bool, optional
             When `False`, when reading files, attempt to memmap underlying data
-            arrays when possible. Please note that the file must be opened
-            in "rw" mode; "r" will result a SIGSEGV.
+            arrays when possible.
 
         lazy_load : bool, optional
             When `True` and the underlying file handle is seekable, data

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -51,7 +51,7 @@ class AsdfFile(versioning.VersionedMixin):
     def __init__(self, tree=None, uri=None, extensions=None, version=None,
                  ignore_version_mismatch=True, ignore_unrecognized_tag=False,
                  ignore_implicit_conversion=False, copy_arrays=False,
-                 custom_schema=None, inline_threshold=None):
+                 lazy_load=True, custom_schema=None, inline_threshold=None):
         """
         Parameters
         ----------
@@ -92,6 +92,12 @@ class AsdfFile(versioning.VersionedMixin):
             When `False`, when reading files, attempt to memmap underlying data
             arrays when possible.
 
+        lazy_load : bool, optional
+            When `True` and the read file is seekable, underlying data arrays
+            will be materialized when they are used for the first time.
+            This implies that the file should stay open during the lifetime
+            of the tree.
+
         custom_schema : str, optional
             Path to a custom schema file that will be used for a secondary
             validation pass. This can be used to ensure that particular ASDF
@@ -122,8 +128,9 @@ class AsdfFile(versioning.VersionedMixin):
         self._fd = None
         self._closed = False
         self._external_asdf_by_uri = {}
-        self._blocks = block.BlockManager(self, copy_arrays=copy_arrays,
-                                          inline_threshold=inline_threshold)
+        self._blocks = block.BlockManager(
+            self, copy_arrays=copy_arrays, inline_threshold=inline_threshold,
+            lazy_load=lazy_load)
         self._uri = None
         if tree is None:
             self.tree = {}
@@ -706,6 +713,7 @@ class AsdfFile(versioning.VersionedMixin):
              ignore_unrecognized_tag=False,
              _force_raw_types=False,
              copy_arrays=False,
+             lazy_load=True,
              custom_schema=None,
              strict_extension_check=False,
              ignore_missing_extensions=False):
@@ -749,6 +757,12 @@ class AsdfFile(versioning.VersionedMixin):
             When `False`, when reading files, attempt to memmap underlying data
             arrays when possible.
 
+        lazy_load : bool, optional
+            When `True` and the read file is seekable, underlying data arrays
+            will be materialized when they are used for the first time.
+            This implies that the file should stay open during the lifetime
+            of the tree.
+
         custom_schema : str, optional
             Path to a custom schema file that will be used for a secondary
             validation pass. This can be used to ensure that particular ASDF
@@ -775,7 +789,8 @@ class AsdfFile(versioning.VersionedMixin):
         self = cls(extensions=extensions,
                    ignore_version_mismatch=ignore_version_mismatch,
                    ignore_unrecognized_tag=ignore_unrecognized_tag,
-                   copy_arrays=copy_arrays, custom_schema=custom_schema)
+                   copy_arrays=copy_arrays, lazy_load=lazy_load,
+                   custom_schema=custom_schema)
 
         return cls._open_impl(
             self, fd, uri=uri, mode=mode,

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -193,6 +193,21 @@ class BlockManager(object):
         for block in self._inline_blocks:
             yield block
 
+    @property
+    def memmap(self):
+        """
+        The flag which indicates whether the arrays are memory mapped
+        to the underlying file.
+        """
+        return self._memmap
+
+    @property
+    def lazy_load(self):
+        """
+        The flag which indicates whether the blocks are lazily read.
+        """
+        return self._lazy_load
+
     def has_blocks_with_offset(self):
         """
         Returns `True` if any of the internal blocks currently have an
@@ -204,7 +219,7 @@ class BlockManager(object):
         return False
 
     def _new_block(self):
-        return Block(memmap=self._memmap, lazy_load=self._lazy_load)
+        return Block(memmap=self.memmap, lazy_load=self.lazy_load)
 
     def _sort_blocks_by_offset(self):
         def sorter(x):
@@ -518,13 +533,13 @@ class BlockManager(object):
         for offset in offsets[1:-1]:
             self._internal_blocks.append(
                 UnloadedBlock(fd, offset,
-                              memmap=self._memmap, lazy_load=self._lazy_load))
+                              memmap=self.memmap, lazy_load=self.lazy_load))
 
         # We already read the last block in the file -- no need to read it again
         self._internal_blocks.append(block)
 
         # Materialize the internal blocks if we are not lazy
-        if not self._lazy_load:
+        if not self.lazy_load:
             self.finish_reading_internal_blocks()
 
     def get_external_filename(self, filename, index):

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -33,7 +33,8 @@ class BlockManager(object):
     """
     Manages the `Block`s associated with a ASDF file.
     """
-    def __init__(self, asdffile, copy_arrays=False, inline_threshold=None):
+    def __init__(self, asdffile, copy_arrays=False, inline_threshold=None,
+                 lazy_load=True):
         self._asdffile = weakref.ref(asdffile)
 
         self._internal_blocks = []
@@ -56,6 +57,7 @@ class BlockManager(object):
         self._data_to_block_mapping = {}
         self._validate_checksums = False
         self._memmap = not copy_arrays
+        self._lazy_load = lazy_load
 
     def __len__(self):
         """
@@ -201,6 +203,9 @@ class BlockManager(object):
                 return True
         return False
 
+    def _new_block(self):
+        return Block(memmap=self._memmap, lazy_load=self._lazy_load)
+
     def _sort_blocks_by_offset(self):
         def sorter(x):
             if x.offset is None:
@@ -212,7 +217,7 @@ class BlockManager(object):
     def _read_next_internal_block(self, fd, past_magic=False):
         # This assumes the file pointer is at the beginning of the
         # block, (or beginning + 4 if past_magic is True)
-        block = Block(memmap=self._memmap).read(
+        block = self._new_block().read(
             fd, past_magic=past_magic,
             validate_checksum=self._validate_checksums)
         if block is not None:
@@ -262,22 +267,23 @@ class BlockManager(object):
         This is called before updating a file, since updating requires
         knowledge of all internal blocks in the file.
         """
-        if len(self._internal_blocks):
-            for i, block in enumerate(self._internal_blocks):
-                if isinstance(block, UnloadedBlock):
-                    block.load()
+        if not self._internal_blocks:
+            return
+        for i, block in enumerate(self._internal_blocks):
+            if isinstance(block, UnloadedBlock):
+                block.load()
 
-            last_block = self._internal_blocks[-1]
+        last_block = self._internal_blocks[-1]
 
-            # Read all of the remaining blocks in the file, if any
-            if (last_block._fd is not None and
-                last_block._fd.seekable()):
-                last_block._fd.seek(last_block.end_offset)
-                while True:
-                    last_block = self._read_next_internal_block(
-                        last_block._fd, False)
-                    if last_block is None:
-                        break
+        # Read all of the remaining blocks in the file, if any
+        if (last_block._fd is not None and
+            last_block._fd.seekable()):
+            last_block._fd.seek(last_block.end_offset)
+            while True:
+                last_block = self._read_next_internal_block(
+                    last_block._fd, False)
+                if last_block is None:
+                    break
 
     def write_internal_blocks_serial(self, fd, pad_blocks=False):
         """
@@ -499,7 +505,7 @@ class BlockManager(object):
         # make sure it makes sense.
         fd.seek(offsets[-1], generic_io.SEEK_SET)
         try:
-            block = Block(memmap=self._memmap).read(fd)
+            block = self._new_block().read(fd)
         except (ValueError, IOError):
             return
 
@@ -511,10 +517,15 @@ class BlockManager(object):
         # objects
         for offset in offsets[1:-1]:
             self._internal_blocks.append(
-                UnloadedBlock(fd, offset, memmap=self._memmap))
+                UnloadedBlock(fd, offset,
+                              memmap=self._memmap, lazy_load=self._lazy_load))
 
         # We already read the last block in the file -- no need to read it again
         self._internal_blocks.append(block)
+
+        # Materialize the internal blocks if we are not lazy
+        if not self._lazy_load:
+            self.finish_reading_internal_blocks()
 
     def get_external_filename(self, filename, index):
         """
@@ -788,7 +799,8 @@ class Block(object):
         ('checksum', '16s')
     ])
 
-    def __init__(self, data=None, uri=None, array_storage='internal', memmap=True):
+    def __init__(self, data=None, uri=None, array_storage='internal',
+                 memmap=True, lazy_load=True):
         if isinstance(data, np.ndarray) and not data.flags.c_contiguous:
             if data.flags.f_contiguous:
                 self._data = np.asfortranarray(data)
@@ -806,6 +818,7 @@ class Block(object):
         self._checksum = None
         self._should_memmap = memmap
         self._memmapped = False
+        self._lazy_load = lazy_load
 
         self.update_size()
         self._allocated = self._size
@@ -943,10 +956,10 @@ class Block(object):
         """
         Read a Block from the given Python file-like object.
 
-        If the file is seekable, the reading or memmapping of the
-        actual data is postponed until an array requests it.  If the
-        file is a stream, the data will be read into memory
-        immediately.
+        If the file is seekable and lazy_load is True, the reading
+        or memmapping of the actual data is postponed until an array
+        requests it.  If the file is a stream or lazy_load is False,
+        the data will be read into memory immediately.
 
         Parameters
         ----------
@@ -1012,19 +1025,27 @@ class Block(object):
             # If the file is seekable, we can delay reading the actual
             # data until later.
             self._fd = fd
-            self._header_size = header_size
             self._offset = offset
+            self._header_size = header_size
             if header['flags'] & constants.BLOCK_FLAG_STREAMED:
                 # Support streaming blocks
-                fd.fast_forward(-1)
                 self._array_storage = 'streamed'
-                self._data_size = self._size = self._allocated = \
-                    (fd.tell() - self.data_offset) + 1
+                if self._lazy_load:
+                    fd.fast_forward(-1)
+                    self._data_size = self._size = self._allocated = \
+                        (fd.tell() - self.data_offset) + 1
+                else:
+                    self._data = fd.read_into_array(-1)
+                    self._data_size = self._size = self._allocated = len(self._data)
             else:
-                fd.fast_forward(header['allocated_size'])
                 self._allocated = header['allocated_size']
                 self._size = header['used_size']
                 self._data_size = header['data_size']
+                if self._lazy_load:
+                    fd.fast_forward(header['allocated_size'])
+                else:
+                    self._data = self._read_data(fd, self._size, self._data_size)
+                    fd.fast_forward(self._allocated - self._size)
         else:
             # If the file is a stream, we need to get the data now.
             if header['flags'] & constants.BLOCK_FLAG_STREAMED:
@@ -1033,9 +1054,9 @@ class Block(object):
                 self._data = fd.read_into_array(-1)
                 self._data_size = self._size = self._allocated = len(self._data)
             else:
-                self._data_size = header['data_size']
-                self._size = header['used_size']
                 self._allocated = header['allocated_size']
+                self._size = header['used_size']
+                self._data_size = header['data_size']
                 self._data = self._read_data(fd, self._size, self._data_size)
                 fd.fast_forward(self._allocated - self._size)
             fd.close()
@@ -1165,7 +1186,7 @@ class UnloadedBlock(object):
     full-fledged block whenever the underlying data or more detail is
     requested.
     """
-    def __init__(self, fd, offset, memmap=True):
+    def __init__(self, fd, offset, memmap=True, lazy_load=True):
         self._fd = fd
         self._offset = offset
         self._data = None
@@ -1176,6 +1197,7 @@ class UnloadedBlock(object):
         self._checksum = None
         self._should_memmap = memmap
         self._memmapped = False
+        self._lazy_load = lazy_load
 
     def __len__(self):
         self.load()

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -240,7 +240,7 @@ class NDArrayType(AsdfType):
         self._offset = offset
         self._strides = strides
         self._order = order
-        if not asdffile.blocks._lazy_load:
+        if not asdffile.blocks.lazy_load:
             self._make_array()
 
     def _make_array(self):

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -240,6 +240,8 @@ class NDArrayType(AsdfType):
         self._offset = offset
         self._strides = strides
         self._order = order
+        if not asdffile.blocks._lazy_load:
+            self._make_array()
 
     def _make_array(self):
         if self._array is None:

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -96,14 +96,16 @@ def test_byteorder(tmpdir):
         }
 
     def check_asdf(asdf):
-        tree = asdf.tree
+        my_tree = asdf.tree
+        for endian in ('bigendian', 'little'):
+            assert my_tree[endian].dtype == tree[endian].dtype
 
         if sys.byteorder == 'little':
-            assert tree['bigendian'].dtype.byteorder == '>'
-            assert tree['little'].dtype.byteorder == '='
+            assert my_tree['bigendian'].dtype.byteorder == '>'
+            assert my_tree['little'].dtype.byteorder == '='
         else:
-            assert tree['bigendian'].dtype.byteorder == '='
-            assert tree['little'].dtype.byteorder == '<'
+            assert my_tree['bigendian'].dtype.byteorder == '='
+            assert my_tree['little'].dtype.byteorder == '<'
 
     def check_raw_yaml(content):
         assert b'byteorder: little' in content

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -243,6 +243,14 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
     if asdf_check_func:
         asdf_check_func(ff)
 
+    # Now repeat with copy_arrays=False and a real file to test mmap()
+    AsdfFile(tree, extensions=extensions, **init_options).write_to(fname, **write_options)
+    with AsdfFile.open(fname, mode='rw', extensions=extensions, copy_arrays=False,
+                       lazy_load=False) as ff:
+        assert_tree_match(tree, ff.tree, ff, funcname=tree_match_func)
+        if asdf_check_func:
+            asdf_check_func(ff)
+
 def yaml_to_asdf(yaml_content, yaml_headers=True, standard_version=None):
     """
     Given a string of YAML content, adds the extra pre-

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -20,9 +20,9 @@ except ImportError:
     CartesianDifferential = None
 
 from ..asdf import AsdfFile, get_asdf_library_info
+from ..block import Block
 from .httpserver import RangeHTTPServer
 from ..extension import default_extensions
-from .. import util
 from .. import versioning
 
 from ..tags.core import AsdfObject
@@ -238,6 +238,10 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
         AsdfFile(tree, extensions=extensions, **init_options).write_to(buff, **write_options)
         buff.seek(0)
         ff = AsdfFile.open(buff, extensions=extensions, copy_arrays=True, lazy_load=False)
+        # Ensure that all the blocks are loaded
+        for block in ff.blocks._internal_blocks:
+            assert isinstance(block, Block)
+            assert block._data is not None
     # The underlying file is closed at this time and everything should still work
     assert_tree_match(tree, ff.tree, ff, funcname=tree_match_func)
     if asdf_check_func:
@@ -247,6 +251,9 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
     AsdfFile(tree, extensions=extensions, **init_options).write_to(fname, **write_options)
     with AsdfFile.open(fname, mode='rw', extensions=extensions, copy_arrays=False,
                        lazy_load=False) as ff:
+        for block in ff.blocks._internal_blocks:
+            assert isinstance(block, Block)
+            assert block._data is not None
         assert_tree_match(tree, ff.tree, ff, funcname=tree_match_func)
         if asdf_check_func:
             asdf_check_func(ff)

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -233,6 +233,15 @@ def assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
         finally:
             server.finalize()
 
+    # Now don't be lazy and check that nothing breaks
+    with io.BytesIO() as buff:
+        AsdfFile(tree, extensions=extensions, **init_options).write_to(buff, **write_options)
+        buff.seek(0)
+        ff = AsdfFile.open(buff, extensions=extensions, copy_arrays=True, lazy_load=False)
+    # The underlying file is closed at this time and everything should still work
+    assert_tree_match(tree, ff.tree, ff, funcname=tree_match_func)
+    if asdf_check_func:
+        asdf_check_func(ff)
 
 def yaml_to_asdf(yaml_content, yaml_headers=True, standard_version=None):
     """


### PR DESCRIPTION
This allows loading ASDF files, then closing the file
and still retaining full access to the tree objects.

Signed-off-by: Vadim Markovtsev <vadim@sourced.tech>