### PR TITLE
Better error message for AsdfFile.update in readonly mode

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -896,7 +896,9 @@ class AsdfFile(versioning.VersionedMixin):
 
         if not fd.writable():
             raise IOError(
-                "Can not update, since associated file is read-only")
+                "Can not update, since associated file is read-only. Make "
+                "sure that the AsdfFile was opened with mode='rw' and the "
+                "underlying file handle is writable.")
 
         if version is not None:
             self.version = version


### PR DESCRIPTION
This resolves #469.

Thanks to #579, this error should occur less often since by default `asdf.open` will attempt to determine the appropriate write mode for the file. In most cases, the default mode will be `'rw'`.