### PR TITLE
Do not allow builtin extension to override subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,13 @@
 - Add readonly protection to memory mapped arrays when the underlying file
   handle is readonly. [#579]
 
+2.1.2 (unreleased)
+------------------
+
+- Fix a regression that was introduced in v2.1.1: do not allow the builtin
+  extension to override tags for subclasses that were provided by an extension
+  from another package. [#591]
+
 2.1.1 (2018-11-01)
 ------------------
 

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -120,17 +120,26 @@ class _AsdfWriteTypeIndex(object):
             self._extension_by_cls[cls] = index._extension_by_type[typ]
 
         def add_subclasses(typ, asdftype):
+
             for subclass in util.iter_subclasses(typ):
                 # Do not overwrite the tag type for an existing subclass if the
                 # new tag serializes a class that is higher in the type
                 # hierarchy than the existing subclass.
                 if subclass in self._class_by_subclass:
                     if issubclass(self._class_by_subclass[subclass], typ):
+
+                        from asdf.extension import BuiltinExtension
+                        ext_by_type = index._extension_by_type[asdftype]
+                        # Do not allow the BuiltinExtension to override types
+                        # from other packages
+                        if isinstance(ext_by_type, BuiltinExtension):
+                            continue
+
                         # Allow for cases where a subclass tag is being
                         # overridden by a tag from another extension.
-                        if (self._extension_by_cls[subclass] ==
-                                index._extension_by_type[asdftype]):
+                        if (self._extension_by_cls[subclass] == ext_by_type):
                             continue
+
                 self._class_by_subclass[subclass] = typ
                 self._type_by_subclasses[subclass] = asdftype
                 self._extension_by_cls[subclass] = index._extension_by_type[asdftype]


### PR DESCRIPTION
In particular, those that were introced by an extension from an external package.

This fixes a regression that was introduced in `2.1.1` and was first discovered in the Astropy test suite (see [here](https://travis-ci.org/astropy/astropy/jobs/449635171)).