### PR TITLE
Update schemas to reflect removal of domain from Astropy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ open_files_ignore = test.fits asdf.fits
 # Account for both the astropy test runner case and the native pytest case
 asdf_schema_root = asdf-standard/schemas asdf/schemas
 asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
+asdf_schema_skip_examples = domain-1.0.0
 #addopts = --doctest-rst
 
 [ah_bootstrap]


### PR DESCRIPTION
This fixes #592.

It requires https://github.com/spacetelescope/asdf-standard/pull/181 to be merged first.