### PR TITLE
Do not automatically add subclasses of ndarray to type index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,13 @@
 - Add readonly protection to memory mapped arrays when the underlying file
   handle is readonly. [#579]
 
+2.1.2 (unreleased)
+------------------
+
+- Fix a regression that was introduced in v2.1.1: do not automatically add
+  subclasses of ``numpy.ndarray`` to the type index since this can have
+  unexpected consequences. [#595]
+
 2.1.1 (2018-11-01)
 ------------------
 

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -13,6 +13,7 @@ from copy import copy
 
 from functools import lru_cache
 
+import asdf
 from . import tagged
 from . import util
 from .versioning import AsdfVersion, AsdfSpec, get_version_map, default_version
@@ -131,6 +132,7 @@ class _AsdfWriteTypeIndex(object):
                         if (self._extension_by_cls[subclass] ==
                                 index._extension_by_type[asdftype]):
                             continue
+
                 self._class_by_subclass[subclass] = typ
                 self._type_by_subclasses[subclass] = asdftype
                 self._extension_by_cls[subclass] = index._extension_by_type[asdftype]
@@ -139,7 +141,10 @@ class _AsdfWriteTypeIndex(object):
             add_type_to_index(asdftype, asdftype)
             for typ in asdftype.types:
                 add_type_to_index(typ, asdftype)
-                add_subclasses(typ, asdftype)
+                # Do not automatically add subclasses of numpy.ndarray since
+                # this could have unexpected (and undesirable) consequences
+                if not asdftype == asdf.tags.core.NDArrayType:
+                    add_subclasses(typ, asdftype)
 
             if asdftype.handle_dynamic_subclasses:
                 for typ in asdftype.types:

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
+from importlib.util import find_spec
 
 import numpy as np
 from numpy import ma
@@ -215,6 +216,8 @@ def numpy_array_to_list(array):
 class NDArrayType(AsdfType):
     name = 'core/ndarray'
     types = [np.ndarray, ma.MaskedArray]
+    if find_spec('astropy'):
+        types.append('astropy.io.fits.FITS_rec')
 
     def __init__(self, source, shape, dtype, offset, strides,
                  order, mask, asdffile):


### PR DESCRIPTION
This resolves an issue that was first reported in Astropy in https://github.com/astropy/astropy/pull/8064.