### PR TITLE
Fix bug in logic for overriding subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@
 - Add readonly protection to memory mapped arrays when the underlying file
   handle is readonly. [#579]
 
+2.1.2 (unreleased)
+------------------
+
+- Fix bug in logic for determining when to override subclasses of types
+  serialized by a tag. [#596]
+
 2.1.1 (2018-11-01)
 ------------------
 

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -125,12 +125,15 @@ class _AsdfWriteTypeIndex(object):
                 # new tag serializes a class that is higher in the type
                 # hierarchy than the existing subclass.
                 if subclass in self._class_by_subclass:
-                    if issubclass(self._class_by_subclass[subclass], typ):
+                    if issubclass(self._class_by_subclass[subclass], subclass):
                         # Allow for cases where a subclass tag is being
-                        # overridden by a tag from another extension.
+                        # overridden by a tag from another extension. Do NOT
+                        # prevent the override in these cases (which case
+                        # corresponds to the implicit 'else' of this 'if').
                         if (self._extension_by_cls[subclass] ==
                                 index._extension_by_type[asdftype]):
                             continue
+
                 self._class_by_subclass[subclass] = typ
                 self._type_by_subclasses[subclass] = asdftype
                 self._extension_by_cls[subclass] = index._extension_by_type[asdftype]


### PR DESCRIPTION
This fixes a bug first exposed by https://github.com/astropy/astropy/pull/8064.