### PR TITLE
Fix default mode assumption when opening files with new API

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1239,19 +1239,14 @@ def _check_and_set_mode(fileobj, asdf_mode):
         raise ValueError(msg.format(asdf_mode))
 
     if asdf_mode is None:
-        if isinstance(fileobj, str):
-            parsed = generic_io.urlparse.urlparse(fileobj)
-            if parsed.scheme in ['http', 'https']:
-                return 'r'
-            return 'rw'
         if isinstance(fileobj, io.IOBase):
             return 'rw' if fileobj.writable() else 'r'
 
         if isinstance(fileobj, generic_io.GenericFile):
             return fileobj.mode
 
-        # This is the safest default since it allows for memory mapping
-        return 'rw'
+        # This is the safest assumption for the default fallback
+        return 'r'
 
     return asdf_mode
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -828,17 +828,17 @@ def test_readonly(tmpdir):
         # Make sure we're actually writing to an internal array for this test
         af.write_to(tmpfile, all_array_storage='internal')
 
-    # This should be perfectly fine
+    # Opening in read mode (the default) should mean array is readonly
     with asdf.open(tmpfile) as af:
-        assert af['data'].flags.writeable == True
-        af['data'][0] = 40
-
-    # Opening in read mode should mean array is readonly
-    with asdf.open(tmpfile, mode='r') as af:
         assert af['data'].flags.writeable == False
         with pytest.raises(ValueError) as err:
             af['data'][0] = 41
             assert str(err) == 'assignment destination is read-only'
+
+    # This should be perfectly fine
+    with asdf.open(tmpfile, mode='rw') as af:
+        assert af['data'].flags.writeable == True
+        af['data'][0] = 40
 
     # Copying the arrays makes it safe to write to the underlying array
     with asdf.open(tmpfile, mode='r', copy_arrays=True) as af:

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -1319,3 +1319,22 @@ def test_warning_deprecated_open(tmpdir):
     with pytest.warns(AsdfDeprecationWarning):
         with asdf.AsdfFile.open(tmpfile) as af:
             assert_tree_match(tree, af.tree)
+
+
+def test_open_readonly(tmpdir):
+
+    tmpfile = str(tmpdir.join('readonly.asdf'))
+
+    tree = dict(foo=42, bar='hello', baz=np.arange(20))
+    with asdf.AsdfFile(tree) as af:
+        af.write_to(tmpfile, all_array_storage='internal')
+
+    os.chmod(tmpfile, 0o440)
+    assert os.access(tmpfile, os.W_OK) == False
+
+    with asdf.open(tmpfile) as af:
+        assert af['baz'].flags.writeable == False
+
+    with pytest.raises(PermissionError):
+        with asdf.open(tmpfile, mode='rw'):
+            pass


### PR DESCRIPTION
The `asdf.open` API now uses a more sensible default mode (related to #578). This fixes #602.

cc @jdavies-st, @bernie-simon 