### PR TITLE
Revert inline threshold option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,6 @@
 2.3.0 (unreleased)
 ------------------
 
-- Small numeric arrays are now automatically stored inline. This behavior can
-  be overridden using the new ``inline_threshold`` argument to the ``AsdfFile``
-  constructor. It can also be controlled with the existing
-  ``set_array_storage`` method of ``AsdfFile`` and the ``all_array_storage``
-  argument to ``AsdfFile.write_to``. [#557]
 
 - Storage of arbitrary precision integers is now provided by
   ``asdf.IntegerType``.  Reading a file with integer literals that are too

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -51,8 +51,7 @@ class AsdfFile(versioning.VersionedMixin):
     def __init__(self, tree=None, uri=None, extensions=None, version=None,
                  ignore_version_mismatch=True, ignore_unrecognized_tag=False,
                  ignore_implicit_conversion=False, copy_arrays=False,
-                 lazy_load=True, custom_schema=None, inline_threshold=None,
-                 _readonly=False):
+                 lazy_load=True, custom_schema=None, _readonly=False):
         """
         Parameters
         ----------
@@ -109,10 +108,7 @@ class AsdfFile(versioning.VersionedMixin):
             files follow custom conventions beyond those enforced by the
             standard.
 
-        inline_threshold : int, optional
-            Optional threshold size below which arrays will automatically be
-            stored inline. Defaults to {0}.
-        """.format(block._DEFAULT_INLINE_THRESHOLD_SIZE)
+        """
 
         if custom_schema is not None:
             self._custom_schema = schema.load_custom_schema(custom_schema)
@@ -134,8 +130,8 @@ class AsdfFile(versioning.VersionedMixin):
         self._closed = False
         self._external_asdf_by_uri = {}
         self._blocks = block.BlockManager(
-            self, copy_arrays=copy_arrays, inline_threshold=inline_threshold,
-            lazy_load=lazy_load, readonly=_readonly)
+            self, copy_arrays=copy_arrays, lazy_load=lazy_load,
+            readonly=_readonly)
         self._uri = None
         if tree is None:
             self.tree = {}

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -26,9 +26,6 @@ from . import util
 from . import yamlutil
 
 
-_DEFAULT_INLINE_THRESHOLD_SIZE = 50
-
-
 class BlockManager(object):
     """
     Manages the `Block`s associated with a ASDF file.
@@ -48,11 +45,6 @@ class BlockManager(object):
             'inline': self._inline_blocks,
             'streamed': self._streamed_blocks
         }
-
-        if inline_threshold is not None:
-            self._inline_threshold_size = inline_threshold
-        else:
-            self._inline_threshold_size = _DEFAULT_INLINE_THRESHOLD_SIZE
 
         self._data_to_block_mapping = {}
         self._validate_checksums = False
@@ -753,7 +745,8 @@ class BlockManager(object):
         block : Block
         """
         from .tags.core import ndarray
-        if (isinstance(arr, ndarray.NDArrayType) and arr.block is not None):
+        if (isinstance(arr, ndarray.NDArrayType) and
+            arr.block is not None):
             if arr.block in self.blocks:
                 return arr.block
             else:
@@ -764,10 +757,6 @@ class BlockManager(object):
         if block is not None:
             return block
         block = Block(base)
-
-        if self._should_inline(arr):
-            block._array_storage = 'inline'
-
         self.add(block)
         self._handle_global_block_settings(ctx, block)
         return block

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -30,8 +30,8 @@ class BlockManager(object):
     """
     Manages the `Block`s associated with a ASDF file.
     """
-    def __init__(self, asdffile, copy_arrays=False, inline_threshold=None,
-                 lazy_load=True, readonly=False):
+    def __init__(self, asdffile, copy_arrays=False, lazy_load=True,
+                 readonly=False):
         self._asdffile = weakref.ref(asdffile)
 
         self._internal_blocks = []

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -180,9 +180,6 @@ def _assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
 
     fname = str(tmpdir.join('test.asdf'))
 
-    # Most tests assume that all blocks will be stored internally
-    init_options.setdefault('inline_threshold', 0)
-
     # First, test writing/reading a BytesIO buffer
     buff = io.BytesIO()
     AsdfFile(tree, extensions=extensions, **init_options).write_to(buff, **write_options)

--- a/asdf/tests/test_low_level.py
+++ b/asdf/tests/test_low_level.py
@@ -1216,6 +1216,7 @@ def test_context_handler_resolve_and_inline(tmpdir):
         newf.tree['random'][0]
 
 
+@pytest.mark.skip(reason='Until inline_threshold is added as a write option')
 def test_inline_threshold(tmpdir):
 
     tree = {
@@ -1240,6 +1241,7 @@ def test_inline_threshold(tmpdir):
         assert len(list(af.blocks.internal_blocks)) == 0
 
 
+@pytest.mark.skip(reason='Until inline_threshold is added as a write option')
 def test_inline_threshold_masked(tmpdir):
 
     mask = np.random.randint(0, 1+1, 20)
@@ -1265,6 +1267,7 @@ def test_inline_threshold_masked(tmpdir):
         assert len(list(af.blocks.internal_blocks)) == 2
 
 
+@pytest.mark.skip(reason='Until inline_threshold is added as a write option')
 def test_inline_threshold_override(tmpdir):
 
     tmpfile = str(tmpdir.join('inline.asdf'))

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -56,37 +56,11 @@ data being saved.
 Saving inline arrays
 --------------------
 
-As of `asdf-2.2.0`, small numerical arrays are automatically stored inline. The
-default threshold size for inline versus internal arrays can be found with the
-following:
-
-.. code::
-
-   >>> from asdf.block import _DEFAULT_INLINE_THRESHOLD_SIZE
-   >>> print(_DEFAULT_INLINE_THRESHOLD_SIZE)
-   50
-
-The default threshold can be overridden passing the `inline_threshold` argument
-to the `asdf.AsdfFile` constructor. Setting `inline_threshold=0` has the effect
-of making all small arrays be stored in internal blocks:
-
-.. runcode::
-
-   from asdf import AsdfFile
-   import numpy as np
-
-   # Ordinarilly an array this size would be automatically inlined
-   my_array = np.ones(10)
-   tree = {'my_array': my_array}
-   # Set the inline threshold to 0 to force internal storage
-   with AsdfFile(tree, inline_threshold=0) as ff:
-      ff.write_to("test.asdf")
-
-.. asdf:: test.asdf
-
-The `~asdf.AsdfFile.set_array_storage` method can be used to set or override
-the default storage type of a particular data array. The allowed values are
-``internal``, ``external``, and ``inline``.
+For small arrays, you may not care about the efficiency of a binary
+representation and just want to save the array contents directly in the YAML
+tree.  The `~asdf.AsdfFile.set_array_storage` method can be used to set the
+storage type of the associated data. The allowed values are ``internal``,
+``external``, and ``inline``.
 
 - ``internal``: The default.  The array data will be
   stored in a binary block in the same ASDF file.


### PR DESCRIPTION
This feature has proved to be too problematic to be supported in an official release. The semantics are unfortunately rather complicated due to the fact that the same `AsdfFile` object can be used both for reading and for writing. It also turns out that there already exists an option to `write_to` called `auto_inline` that serves a similar purpose, although I believe it may not be working properly in all cases (see #599).

Also, to complicate matters further, neither `inline_threshold` nor `auto_inline` are idempotent, meaning that both modify the underlying `AsdfFile` object in undesirable ways. This has exposed some significant design warts in the `asdf` API and implementation that need to be addressed, although that will be difficult and will probably lead to significant user-facing changes.

I hope to revisit this and address the issues in an upcoming PR, but I have begun to consider whether we need to make some significant design changes for 3.0.

cc @jdavies-st 