### PR TITLE
Use astropy display plugin for pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,16 +1,28 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 import os
+from collections import OrderedDict
+
 import pytest
 from _pytest.doctest import DoctestItem
 
 from astropy.tests.helper import enable_deprecations_as_exceptions
+from astropy.tests.plugins import display
 
-enable_deprecations_as_exceptions()
+
+display.PYTEST_HEADER_MODULES = OrderedDict([
+                                    ('asdf', 'asdf'),
+                                    ('numpy', 'numpy'),
+                                    ('jsonschema', 'jsonschema'),
+                                    ('pyyaml', 'pyyaml'),
+                                    ('astropy', 'astropy')])
 
 pytest_plugins = [
-    'asdf.tests.schema_tester'
+    'asdf.tests.schema_tester',
+    'astropy.tests.plugins.display'
 ]
+
+enable_deprecations_as_exceptions()
 
 
 @pytest.fixture(autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,13 @@ display.PYTEST_HEADER_MODULES = OrderedDict([
                                     ('pyyaml', 'pyyaml'),
                                     ('astropy', 'astropy')])
 
+try:
+    import gwcs
+    display.PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
+except ImportError:
+    pass
+
+
 pytest_plugins = [
     'asdf.tests.schema_tester',
     'astropy.tests.plugins.display'


### PR DESCRIPTION
We already have a test dependency on Astropy, so this is not a problem.