### PR TITLE
Pin version of gwcs to ~=0.9.1 for older versions of Astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
         - env: TOXENV='py36-numpy12'
 
         # also test against development versions of Astropy and GWCS
-        - env: TOXENV='py36-astropydev-gwcsdev'
+        - env: TOXENV='py37-astrodev'
 
         # Test against development version of numpy (this job can fail)
         - env: TOXENV='py37-numpydev'

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,28 @@
 [tox]
 envlist =
-    {py36,py37}-{stable,gwcsdev},py37-astropydev
+    {py36,py37}-{stable,gwcsdev},py37-astrodev
 
 [testenv]
 deps=
     pytest-sugar
     pytest-faulthandler
-    !astropydev: gwcs
+    astrodev: git+git://github.com/astropy/astropy
     py35,py36: importlib_resources
+    py35-!astrodev,py36-!astrodev: gwcs~=0.9.1
+    py37-!astrodev: gwcs
     numpydev: git+git://github.com/numpy/numpy
-    gwcsdev,astropydev: git+git://github.com/astropy/astropy
 conda_deps=
     pytest
     pytest-astropy
-    !astropydev: astropy
+    !astrodev: astropy
     numpy11: numpy=1.11
     numpy12: numpy=1.12
     !numpydev: numpy
-    numpydev,astropydev: cython
+    numpydev,astrodev: cython
 conda_channels=
     conda-forge
 commands=
-    gwcsdev: pip install --no-deps git+git://github.com/spacetelescope/gwcs
+    astrodev: pip install --no-deps git+git://github.com/spacetelescope/gwcs
     pytest {posargs}
 
 [testenv:egg_info]


### PR DESCRIPTION
This should fix the recent cron failures on travis.