### PR TITLE
Install pytest-astropy from pip instead of from conda

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps=
     pytest-sugar
     pytest-faulthandler
     pytest-astropy
+    pytest-openfiles>=0.3.2
     astrodev: git+git://github.com/astropy/astropy
     py35,py36: importlib_resources
     py35-!astrodev,py36-!astrodev: gwcs~=0.9.1
@@ -68,6 +69,7 @@ basepython= python3.7
 deps=
     gwcs
     pytest-astropy
+    pytest-openfiles>=0.3.2
 conda_deps=
     pytest
     astropy

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 deps=
     pytest-sugar
     pytest-faulthandler
+    pytest-astropy
     astrodev: git+git://github.com/astropy/astropy
     py35,py36: importlib_resources
     py35-!astrodev,py36-!astrodev: gwcs~=0.9.1
@@ -13,7 +14,6 @@ deps=
     numpydev: git+git://github.com/numpy/numpy
 conda_deps=
     pytest
-    pytest-astropy
     !astrodev: astropy
     numpy11: numpy=1.11
     numpy12: numpy=1.12
@@ -67,9 +67,9 @@ commands=
 basepython= python3.7
 deps=
     gwcs
+    pytest-astropy
 conda_deps=
     pytest
-    pytest-astropy
     astropy
     coverage
     coveralls


### PR DESCRIPTION
This should ensure that we always get the latest versions of `pytest-astropy` and its dependencies, even if the `conda` recipes are not yet up-to-date.

As a philosophical issue, there's really no reason we shouldn't prefer getting most dependencies from `pypi` instead of `conda` anyway.