### PR TITLE
Fix fake URLs to point to non-existent site...

### DIFF
--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -46,7 +46,7 @@ def test_history():
     assert 'history' not in ff.tree
     ff.add_history_entry('This happened',
                          {'name': 'my_tool',
-                          'homepage': 'http://nowhere.com',
+                          'homepage': 'http://nowhere.org',
                           'author': 'John Doe',
                           'version': '2.0'})
     assert len(ff.tree['history']['entries']) == 1
@@ -69,7 +69,7 @@ def test_history_to_file(tmpdir):
     with asdf.AsdfFile() as ff:
         ff.add_history_entry('This happened',
                              {'name': 'my_tool',
-                              'homepage': 'http://nowhere.com',
+                              'homepage': 'http://nowhere.org',
                               'author': 'John Doe',
                               'version': '2.0'})
         ff.write_to(tmpfile)

--- a/asdf/tests/test_reference.py
+++ b/asdf/tests/test_reference.py
@@ -156,7 +156,7 @@ def test_external_reference_invalid(tmpdir):
     with pytest.raises(ValueError):
         ff.resolve_references()
 
-    ff = asdf.AsdfFile(tree, uri="http://nowhere.com/")
+    ff = asdf.AsdfFile(tree, uri="http://httpstat.us/404")
     with pytest.raises(IOError):
         ff.resolve_references()
 


### PR DESCRIPTION
This is kind of funny, but apparently someone bought the domain that we were using to test fake URLs, which caused test failures. So updating for now.