### PR TITLE
Pass ignore_unrecognized_tag option to ASDF-in-FITS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - Define the ``in`` operator for top-level ``AsdfFile`` objects. [#623]
 
+2.3.3 (unreleased)
+------------------
+
+- Pass ``ignore_unrecognized_tag`` setting through to ASDF-in-FITS. [#650]
+
 2.3.2 (2019-02-19)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -693,6 +693,7 @@ class AsdfFile(versioning.VersionedMixin):
                             extensions=self._extensions,
                             strict_extension_check=strict_extension_check,
                             ignore_missing_extensions=ignore_missing_extensions,
+                            ignore_unrecognized_tag=self._ignore_unrecognized_tag,
                             _extension_metadata=self._extension_metadata)
             except ValueError:
                 raise ValueError(


### PR DESCRIPTION
Previously this option was not being passed through when opening an ASDF-in-FITS file using the top-level API.