### PR TITLE
Mark external_reference_invalid test with remote_data

### DIFF
--- a/asdf/tests/test_reference.py
+++ b/asdf/tests/test_reference.py
@@ -145,6 +145,7 @@ def test_external_reference(tmpdir):
         assert_array_equal(ff.tree['internal'], exttree['cool_stuff']['a'])
 
 
+@pytest.mark.remote_data
 def test_external_reference_invalid(tmpdir):
     tree = {
         'foo': {


### PR DESCRIPTION
Came up in https://github.com/astropy/astropy/issues/8464.

cc @olebole 