### PR TITLE
Use $schema keyword to determine metaschema to use for schema tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 
 - Pass ``ignore_unrecognized_tag`` setting through to ASDF-in-FITS. [#650]
 
+- Use ``$schema`` keyword if available to determine meta-schema to use when
+  testing whether schemas themselves are valid. [#654]
+
 2.3.2 (2019-02-19)
 ------------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -582,7 +582,8 @@ def check_schema(schema):
         'default': validate_default
     })
 
-    meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID, mresolver.default_resolver)
+    meta_schema_id = schema.get('$schema', YAML_SCHEMA_METASCHEMA_ID)
+    meta_schema = load_schema(meta_schema_id, mresolver.default_resolver)
 
     resolver = _make_resolver(mresolver.default_resolver)
 


### PR DESCRIPTION
Prior to this change the YAML meta-schema ID was hard-coded into the `check_schema` routine which is used by the schema tester. This ID is still used as a fallback if the `$schema` keyword is not present, however.