### PR TITLE
Make schema validation resolver use installed extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@
 - Use ``$schema`` keyword if available to determine meta-schema to use when
   testing whether schemas themselves are valid. [#654]
 
+- Take into account resolvers from installed extensions when loading schemas
+  for validation. [#655]
+
 2.3.2 (2019-02-19)
 ------------------
 


### PR DESCRIPTION
This is a follow-on to #654. Now that we are properly performing meta-schema validation, it is important to use all available resolvers when loading schemas. Previously, only schemas from the ASDF Standard were resolvable in this way.