### PR TITLE
Allow use of pathlib.Path objects for custom_schema option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@
 
 - Fix compatibility issue with new release of ``pyyaml`` (version 5.1). [#662]
 
+- Allow use of ``pathlib.Path`` objects for ``custom_schema`` option. [#663]
+
 2.3.2 (2019-02-19)
 ------------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -286,7 +286,7 @@ def _load_schema(url):
 
 def _make_schema_loader(resolver):
     def load_schema(url):
-        url = resolver(url)
+        url = resolver(str(url))
         return _load_schema(url)
     return load_schema
 

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -706,6 +706,30 @@ def test_custom_validation_good(tmpdir):
         pass
 
 
+def test_custom_validation_pathlib(tmpdir):
+    """
+    Make sure custom schema paths can be pathlib.Path objects
+
+    See https://github.com/spacetelescope/asdf/issues/653 for discussion.
+    """
+    from pathlib import Path
+
+    custom_schema_path = Path(helpers.get_test_data_path('custom_schema.yaml'))
+    asdf_file = os.path.join(str(tmpdir), 'out.asdf')
+
+    # This tree conforms to the custom schema
+    tree = {
+        'foo': {'x': 42, 'y': 10},
+        'bar': {'a': 'hello', 'b': 'banjo'}
+    }
+
+    with asdf.AsdfFile(tree, custom_schema=custom_schema_path) as ff:
+        ff.write_to(asdf_file)
+
+    with asdf.open(asdf_file, custom_schema=custom_schema_path) as ff:
+        pass
+
+
 def test_custom_validation_with_definitions_good(tmpdir):
     custom_schema_path = helpers.get_test_data_path('custom_schema_definitions.yaml')
     asdf_file = os.path.join(str(tmpdir), 'out.asdf')


### PR DESCRIPTION
This fixes #653.