### PR TITLE
Set tox version to avoid buggy release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
     - conda install openssl
-    - pip install tox tox-conda
+    - pip install "tox~=3.7.0" tox-conda
 
 script:
    - $TOX_CMD $TOX_ARGS


### PR DESCRIPTION
There appears to be an incompatibility between `tox-conda` and the latest release of `tox` which is causing the CI failures. See https://github.com/tox-dev/tox-conda/issues/15 for discussion.