### PR TITLE
Update to reflect release of new tox-conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
     - conda install openssl
-    - pip install "tox~=3.7.0" tox-conda
+    - pip install tox tox-conda>=0.2
 
 script:
    - $TOX_CMD $TOX_ARGS

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands=
 [testenv:docbuild]
 basepython= python3.6
 conda_deps=
-    sphinx
+    sphinx<2.0
     graphviz
     matplotlib
     astropy


### PR DESCRIPTION
This is a follow-on to #665. Now that a new version of `tox-conda` has been released, we should depend on that instead of fixing the version of `tox` itself.