### PR TITLE
Use yaml.safe_load in test cases

### DIFF
--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -169,7 +169,7 @@ def test_table_inline(tmpdir):
     tree = {'table_data': table}
 
     def check_raw_yaml(content):
-        tree = yaml.load(
+        tree = yaml.safe_load(
             re.sub(br'!core/\S+', b'', content))
 
         assert tree['table_data'] == {
@@ -225,7 +225,7 @@ def test_table(tmpdir):
     tree = {'table_data': table}
 
     def check_raw_yaml(content):
-        tree = yaml.load(
+        tree = yaml.safe_load(
             re.sub(br'!core/\S+', b'', content))
 
         assert tree['table_data'] == {
@@ -251,7 +251,7 @@ def test_table_nested_fields(tmpdir):
     tree = {'table_data': table}
 
     def check_raw_yaml(content):
-        tree = yaml.load(
+        tree = yaml.safe_load(
             re.sub(br'!core/\S+', b'', content))
 
         assert tree['table_data'] == {

--- a/asdf/tests/schema_tester.py
+++ b/asdf/tests/schema_tester.py
@@ -81,7 +81,7 @@ class AsdfSchemaFile(pytest.File):
     def find_examples_in_schema(self):
         """Returns generator for all examples in schema at given path"""
         with open(str(self.fspath), 'rb') as fd:
-            schema_tree = yaml.load(fd)
+            schema_tree = yaml.safe_load(fd)
 
         for node in treeutil.iter_tree(schema_tree):
             if (isinstance(node, dict) and

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ norecursedirs = build docs/_build
 doctest_plus = enabled
 remote_data_strict = True
 open_files_ignore = test.fits asdf.fits
+# Configuration for pytest-doctestplus
+text_file_format = rst
 # Account for both the astropy test runner case and the native pytest case
 asdf_schema_root = asdf-standard/schemas asdf/schemas
 asdf_schema_skip_names = asdf-schema-1.0.0 draft-01


### PR DESCRIPTION
This eliminates a few overlooked cases in tests where `yaml.load` was being used instead of `yaml.safe_load`.  There are still a few other instances of `yaml.load` in various places, but these all explicitly pass a safe loader in as an argument.