### PR TITLE
Don't use conda to install tox deps. Update documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,12 +263,12 @@ To install:
 ::
 
     $ cd asdf
-    $ python3 setup.py install
+    $ pip install .
 
 To install in `development
 mode <https://packaging.python.org/tutorials/distributing-packages/#working-in-development-mode>`__::
 
-    $ python3 setup.py develop
+    $ pip install -e .
 
 .. note::
 
@@ -287,11 +287,17 @@ Testing
 
 .. _begin-testing-text
 
+To install the test dependencies from a source checkout of the repository:
+
+::
+
+   $ pip install -e .[tests]
+
 To run the unit tests from a source checkout of the repository:
 
 ::
 
-    $ python3 setup.py test
+    $ pytest
 
 It is also possible to run the test suite from an installed version of
 the package. In a Python interpreter:
@@ -303,6 +309,27 @@ the package. In a Python interpreter:
 
 Please note that the `astropy <https://github.com/astropy/astropy>`__
 package must be installed to run the tests.
+
+It is also possible to run the tests using `tox
+<https://tox.readthedocs.io/en/latest/>`__. It is first necessary to install
+``tox`` and `tox-conda <https://github.com/tox-dev/tox-conda>`__:
+
+::
+
+   $ pip install tox tox-conda
+
+To list all available environments:
+
+::
+
+   $ tox -va
+
+To run a specific environment:
+
+::
+
+   $ tox -e <envname>
+
 
 .. _end-testing-text
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,9 @@ deps=
     legacy: pyyaml==3.10
     legacy: jsonschema==2.3
     legacy: numpy~=1.10.0
-    legacy: astropy~=3.0.0
-conda_deps=
-    numpy11: numpy=1.11
-    numpy12: numpy=1.12
+    numpy11,numpy12,legacy: astropy~=3.0.0
+    numpy11: numpy==1.11
+    numpy12: numpy==1.12
     numpydev,astrodev: cython
 conda_channels=
     conda-forge
@@ -62,7 +61,7 @@ commands=
 
 [testenv:style]
 basepython= python3.6
-conda_deps=
+deps=
     flake8
 commands=
     flake8 asdf --count
@@ -74,9 +73,6 @@ deps=
     pytest-astropy
     pytest-openfiles>=0.3.2
     codecov
-conda_deps=
-    pytest
-    astropy
     coverage
 commands=
     coverage run --source=asdf --rcfile={toxinidir}/asdf/tests/coveragerc \


### PR DESCRIPTION
Trying to wean ourselves off of `conda` a little bit here. It's not necessary to use it to install dependencies, even if we're still using `tox-conda` for environment management. The current advantage of that is it allows us to run Py35 tests on Travis even though the Travis image doesn't have Python 3.5 installed.