### PR TITLE
add .eggs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ docs/_build
 dist
 build
 eggs
+.eggs
 parts
 bin
 var


### PR DESCRIPTION
Does just what it says.  It *may* have been that actually `eggs` was a typo and it was supposed to be `.eggs`?  But just in case I figured I'd make it a separate entry...

(Encountered when doing `python setup.py build`)