### PR TITLE
Fix load_schema memory issue and add convenience function for fetching the default resolver.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 ------------------
 
 - Added asdf-standard 1.4.0 to the list of supported versions. [#704]
+- Fix load_schema LRU cache memory usage issue [#682]
+- Add convenience method for fetching the default resolver [#682]
 
 - ``SpecItem`` and ``Spec`` were depreicated  in ``semantic_version``
   and were replaced with ``SimpleSpec``. [#715]

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -313,8 +313,9 @@ class AsdfFile(versioning.VersionedMixin):
     def url_mapping(self):
         return self._extensions.url_mapping
 
-    def resolver(self, uri):
-        return self.url_mapping(self.tag_mapping(uri))
+    @property
+    def resolver(self):
+        return self._extensions.resolver
 
     @property
     def type_index(self):

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -137,6 +137,7 @@ class AsdfExtensionList:
                     validators.update(sibling.validators)
         self._tag_mapping = resolver.Resolver(tag_mapping, 'tag')
         self._url_mapping = resolver.Resolver(url_mapping, 'url')
+        self._resolver = resolver.ResolverChain(self._tag_mapping, self._url_mapping)
         self._validators = validators
 
     @property
@@ -155,6 +156,10 @@ class AsdfExtensionList:
     @property
     def url_mapping(self):
         return self._url_mapping
+
+    @property
+    def resolver(self):
+        return self._resolver
 
     @property
     def type_index(self):
@@ -244,10 +249,17 @@ class _DefaultExtensions:
         self._extension_list = None
         self._package_metadata = {}
 
-    def resolver(self, uri):
-        tag_mapping = self.extension_list.tag_mapping
-        url_mapping = self.extension_list.url_mapping
-        return url_mapping(tag_mapping(uri))
+    @property
+    def resolver(self):
+        return self.extension_list.resolver
 
 
 default_extensions = _DefaultExtensions()
+
+
+def get_default_resolver():
+    """
+    Get the resolver that includes mappings from all installed extensions.
+    """
+    return default_extensions.resolver
+

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -262,4 +262,3 @@ def get_default_resolver():
     Get the resolver that includes mappings from all installed extensions.
     """
     return default_extensions.resolver
-

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -176,4 +176,4 @@ def default_resolver(uri):
         "'asdf.extension.get_default_resolver()(...)' instead.",
         AsdfDeprecationWarning)
     return default_resolver._resolver(uri)
-default_resolver._resolver = ResolverChain(default_tag_to_url_mapping, default_url_mapping)
+default_resolver._resolver = ResolverChain(default_tag_to_url_mapping._resolver, default_url_mapping._resolver)

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -23,6 +23,7 @@ from . import treeutil
 from . import util
 from .extension import default_extensions
 from .compat.jsonschemacompat import JSONSCHEMA_LT_3
+from . import extension
 from .exceptions import AsdfDeprecationWarning
 
 
@@ -48,7 +49,7 @@ def default_ext_resolver(uri):
             "The 'default_ext_resolver(...)' function is deprecated. Use "
             "'asdf.extension.get_default_resolver()(...)' instead.",
             AsdfDeprecationWarning)
-    return default_extensions.extension_list.resolver(uri)
+    return extension.get_default_resolver()(uri)
 
 
 PYTHON_TYPE_TO_YAML_TAG = {
@@ -206,7 +207,7 @@ REMOVE_DEFAULTS['properties'] = validate_remove_default
 
 @lru_cache()
 def _create_validator(validators=YAML_VALIDATORS):
-    meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID, default_extensions.extension_list.resolver)
+    meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID, extension.get_default_resolver())
 
     if JSONSCHEMA_LT_3:
         base_cls = mvalidators.create(meta_schema=meta_schema, validators=validators)
@@ -390,8 +391,8 @@ def load_schema(url, resolver=None, resolve_references=False,
     """
     if resolver is None:
         # We can't just set this as the default in load_schema's definition
-        # because accessing extension_list at import time leads to a circular import.
-        resolver = default_extensions.extension_list.resolver
+        # because invoking get_default_resolver at import time leads to a circular import.
+        resolver = extension.get_default_resolver()
 
     loader = _make_schema_loader(resolver)
     if url in HARDCODED_SCHEMA:
@@ -616,9 +617,9 @@ def check_schema(schema):
     })
 
     meta_schema_id = schema.get('$schema', YAML_SCHEMA_METASCHEMA_ID)
-    meta_schema = load_schema(meta_schema_id, default_extensions.extension_list.resolver)
+    meta_schema = load_schema(meta_schema_id, extension.get_default_resolver())
 
-    resolver = _make_resolver(default_extensions.extension_list.resolver)
+    resolver = _make_resolver(extension.get_default_resolver())
 
     cls = mvalidators.create(meta_schema=meta_schema,
                              validators=VALIDATORS)

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -23,6 +23,7 @@ from . import treeutil
 from . import util
 from .extension import default_extensions
 from .compat.jsonschemacompat import JSONSCHEMA_LT_3
+from .exceptions import AsdfDeprecationWarning
 
 
 YAML_SCHEMA_METASCHEMA_ID = 'http://stsci.edu/schemas/yaml-schema/draft-01'
@@ -41,9 +42,13 @@ def default_ext_resolver(uri):
     """
     Resolver that uses tag/url mappings from all installed extensions
     """
-    tag_mapping = default_extensions.extension_list.tag_mapping
-    url_mapping = default_extensions.extension_list.url_mapping
-    return url_mapping(tag_mapping(uri))
+    # Deprecating this because it doesn't play nicely with the caching on
+    # load_schema(...).
+    warnings.warn(
+            "The 'default_ext_resolver(...)' function is deprecated. Use "
+            "'asdf.extension.get_default_resolver()(...)' instead.",
+            AsdfDeprecationWarning)
+    return default_extensions.extension_list.resolver(uri)
 
 
 PYTHON_TYPE_TO_YAML_TAG = {
@@ -199,10 +204,9 @@ for key in ('allOf', 'anyOf', 'oneOf', 'items'):
 REMOVE_DEFAULTS['properties'] = validate_remove_default
 
 
-
 @lru_cache()
 def _create_validator(validators=YAML_VALIDATORS):
-    meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID, default_ext_resolver)
+    meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID, default_extensions.extension_list.resolver)
 
     if JSONSCHEMA_LT_3:
         base_cls = mvalidators.create(meta_schema=meta_schema, validators=validators)
@@ -385,7 +389,10 @@ def load_schema(url, resolver=None, resolve_references=False,
         control local reference resolution separately.
     """
     if resolver is None:
-        resolver = default_ext_resolver
+        # We can't just set this as the default in load_schema's definition
+        # because accessing extension_list at import time leads to a circular import.
+        resolver = default_extensions.extension_list.resolver
+
     loader = _make_schema_loader(resolver)
     if url in HARDCODED_SCHEMA:
         schema = HARDCODED_SCHEMA[url]()
@@ -609,9 +616,9 @@ def check_schema(schema):
     })
 
     meta_schema_id = schema.get('$schema', YAML_SCHEMA_METASCHEMA_ID)
-    meta_schema = load_schema(meta_schema_id, default_ext_resolver)
+    meta_schema = load_schema(meta_schema_id, default_extensions.extension_list.resolver)
 
-    resolver = _make_resolver(default_ext_resolver)
+    resolver = _make_resolver(default_extensions.extension_list.resolver)
 
     cls = mvalidators.create(meta_schema=meta_schema,
                              validators=VALIDATORS)

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -13,6 +13,8 @@ import pytest
 import asdf
 from asdf import treeutil
 from asdf import extension
+from asdf import resolver
+from asdf import schema
 from asdf import versioning
 from asdf.exceptions import AsdfDeprecationWarning
 from .helpers import assert_tree_match, assert_roundtrip_tree, display_warnings
@@ -408,3 +410,22 @@ def test_inline_threshold_override(tmpdir):
         af.write_to(tmpfile, all_array_storage='inline')
         assert len(list(af.blocks.inline_blocks)) == 2
         assert len(list(af.blocks.internal_blocks)) == 0
+
+
+def test_resolver_deprecations():
+    for resolver_method in [
+        resolver.default_resolver,
+        resolver.default_tag_to_url_mapping,
+        resolver.default_url_mapping,
+        schema.default_ext_resolver
+    ]:
+        with pytest.warns(AsdfDeprecationWarning):
+            resolver_method("foo")
+
+
+def test_get_default_resolver():
+    resolver = extension.get_default_resolver()
+
+    result = resolver('tag:stsci.edu:asdf/core/ndarray-1.0.0')
+
+    assert result.endswith("asdf-standard/schemas/stsci.edu/asdf/core/ndarray-1.0.0.yaml")

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -302,7 +302,7 @@ def test_http_connection_range(tree, rhttpserver):
         if len(tree) == 4:
             assert connection[0]._nreads == 0
         else:
-            assert connection[0]._nreads == 6
+            assert connection[0]._nreads == 5
 
         assert len(list(ff.blocks.internal_blocks)) == 2
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -302,7 +302,7 @@ def test_http_connection_range(tree, rhttpserver):
         if len(tree) == 4:
             assert connection[0]._nreads == 0
         else:
-            assert connection[0]._nreads == 5
+            assert connection[0]._nreads == 6
 
         assert len(list(ff.blocks.internal_blocks)) == 2
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)

--- a/asdf/tests/test_resolver.py
+++ b/asdf/tests/test_resolver.py
@@ -10,9 +10,9 @@ def test_resolver_no_mappings():
     r = Resolver([], "test")
     assert r("united_states:maryland:baltimore") == "united_states:maryland:baltimore"
 
-    
+
 def test_resolver_tuple_mapping():
-    r = Resolver([("united_states:", "earth:{test}")], "test")    
+    r = Resolver([("united_states:", "earth:{test}")], "test")
     assert r("united_states:maryland:baltimore") == "earth:united_states:maryland:baltimore"
 
     r = Resolver([("united_states:", "{test_prefix}texas:houston")], "test")
@@ -63,7 +63,7 @@ def test_resolver_invalid_mapping():
 
     with pytest.raises(ValueError):
         Resolver([12], "test")
-        
+
 
 def test_resolver_hash_and_equals():
     r1 = Resolver([("united_states:", "earth:{test}")], "test")
@@ -74,7 +74,7 @@ def test_resolver_hash_and_equals():
     assert r1 == r2
 
     assert hash(r1) != hash(r3)
-    assert r1 != r3        
+    assert r1 != r3
 
 
 def test_resolver_add_mapping_deprecated():
@@ -82,7 +82,7 @@ def test_resolver_add_mapping_deprecated():
     with pytest.warns(AsdfDeprecationWarning):
         r.add_mapping([("united_states:", "earth:{test}")], "test")
 
-        
+
 def test_resolver_chain():
     r1 = Resolver([("maryland:", "united_states:{test}")], "test")
     r2 = Resolver([("united_states:", "earth:{test}")], "test")
@@ -90,8 +90,8 @@ def test_resolver_chain():
     chain = ResolverChain(r1, r2)
 
     assert chain("maryland:baltimore") == "earth:united_states:maryland:baltimore"
-    
-    
+
+
 def test_resolver_chain_hash_and_equals():
     r1 = Resolver([("united_states:", "earth:{test}")], "test")
     r2 = Resolver([("united_states:", "earth:{test}")], "test")
@@ -106,8 +106,3 @@ def test_resolver_chain_hash_and_equals():
 
     assert hash(c1) != hash(c3)
     assert c1 != c3
-
-
-
-
-

--- a/asdf/tests/test_resolver.py
+++ b/asdf/tests/test_resolver.py
@@ -21,6 +21,7 @@ def test_resolver_tuple_mapping():
     r = Resolver([("united_states:", "{test_suffix}:hampden")], "test")
     assert r("united_states:maryland:baltimore") == "maryland:baltimore:hampden"
 
+
 def test_resolver_callable_mapping():
     r = Resolver([lambda inp: "nowhere"], "test")
     assert r("united_states:maryland:baltimore") == "nowhere"

--- a/asdf/tests/test_resolver.py
+++ b/asdf/tests/test_resolver.py
@@ -1,0 +1,113 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from asdf.resolver import Resolver, ResolverChain
+from asdf.exceptions import AsdfDeprecationWarning
+
+def test_resolver_no_mappings():
+    r = Resolver([], "test")
+    assert r("united_states:maryland:baltimore") == "united_states:maryland:baltimore"
+
+    
+def test_resolver_tuple_mapping():
+    r = Resolver([("united_states:", "earth:{test}")], "test")    
+    assert r("united_states:maryland:baltimore") == "earth:united_states:maryland:baltimore"
+
+    r = Resolver([("united_states:", "{test_prefix}texas:houston")], "test")
+    assert r("united_states:maryland:baltimore") == "united_states:texas:houston"
+
+    r = Resolver([("united_states:", "{test_suffix}:hampden")], "test")
+    assert r("united_states:maryland:baltimore") == "maryland:baltimore:hampden"
+
+def test_resolver_callable_mapping():
+    r = Resolver([lambda inp: "nowhere"], "test")
+    assert r("united_states:maryland:baltimore") == "nowhere"
+
+
+def test_resolver_multiple_mappings():
+    r = Resolver([
+        ("united_states:", "unknown_region:{test_suffix}"),
+        ("united_states:maryland:", "mid_atlantic:maryland:{test_suffix}")
+        ], "test")
+    # Should choose the mapping with the longest matched prefix:
+    assert r("united_states:maryland:baltimore") == "mid_atlantic:maryland:baltimore"
+
+    r = Resolver([
+        ("united_states:", "unknown_region:{test_suffix}"),
+        lambda inp: "nowhere",
+        ("united_states:maryland:", "mid_atlantic:maryland:{test_suffix}")
+        ], "test")
+    # Should prioritize the mapping offered by the callable:
+    assert r("united_states:maryland:baltimore") == "nowhere"
+
+    r = Resolver([
+        ("united_states:", "unknown_region:{test_suffix}"),
+        lambda inp: None,
+        ("united_states:maryland:", "mid_atlantic:maryland:{test_suffix}")
+        ], "test")
+    # None from the callable is a signal that it can't handle the input,
+    # so we should fall back to the longest matched prefix:
+    assert r("united_states:maryland:baltimore") == "mid_atlantic:maryland:baltimore"
+
+
+def test_resolver_non_prefix():
+    r = Resolver([("maryland:", "shouldn't happen")], "test")
+    assert r("united_states:maryland:baltimore") == "united_states:maryland:baltimore"
+
+
+def test_resolver_invalid_mapping():
+    with pytest.raises(ValueError):
+        Resolver([("foo",)], "test")
+
+    with pytest.raises(ValueError):
+        Resolver([12], "test")
+        
+
+def test_resolver_hash_and_equals():
+    r1 = Resolver([("united_states:", "earth:{test}")], "test")
+    r2 = Resolver([("united_states:", "earth:{test}")], "test")
+    r3 = Resolver([("united_states:", "{test}:hampden")], "test")
+
+    assert hash(r1) == hash(r2)
+    assert r1 == r2
+
+    assert hash(r1) != hash(r3)
+    assert r1 != r3        
+
+
+def test_resolver_add_mapping_deprecated():
+    r = Resolver([], "test")
+    with pytest.warns(AsdfDeprecationWarning):
+        r.add_mapping([("united_states:", "earth:{test}")], "test")
+
+        
+def test_resolver_chain():
+    r1 = Resolver([("maryland:", "united_states:{test}")], "test")
+    r2 = Resolver([("united_states:", "earth:{test}")], "test")
+
+    chain = ResolverChain(r1, r2)
+
+    assert chain("maryland:baltimore") == "earth:united_states:maryland:baltimore"
+    
+    
+def test_resolver_chain_hash_and_equals():
+    r1 = Resolver([("united_states:", "earth:{test}")], "test")
+    r2 = Resolver([("united_states:", "earth:{test}")], "test")
+    r3 = Resolver([("united_states:", "{test}:hampden")], "test")
+
+    c1 = ResolverChain(r1, r3)
+    c2 = ResolverChain(r2, r3)
+    c3 = ResolverChain(r1, r2)
+
+    assert hash(c1) == hash(c2)
+    assert c1 == c2
+
+    assert hash(c1) != hash(c3)
+    assert c1 != c3
+
+
+
+
+

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -171,38 +171,27 @@ required: [foobar]
 
 
 def test_schema_caching():
-    # Make sure that if we request the same URL, we get the *exact
-    # same* object, to ensure the cache is working.
+    # Make sure that if we request the same URL, we get a different object
+    # (despite the caching internal to load_schema).  Changes to a schema
+    # dict should not impact other uses of that schema.
+
     s1 = schema.load_schema(
         'http://stsci.edu/schemas/asdf/core/asdf-1.0.0')
     s2 = schema.load_schema(
         'http://stsci.edu/schemas/asdf/core/asdf-1.0.0')
-    assert s1 is s2
+    assert s1 is not s2
 
 
-def test_schema_caching_with_asdf_file():
+def test_asdf_file_resolver_hashing():
     # Confirm that resolvers from distinct AsdfFile instances
-    # hash to the same cache entry
-    schema.load_schema.cache_clear()
-
+    # hash to the same value (this allows schema caching to function).
     a1 = asdf.AsdfFile()
-    s1 = schema.load_schema(
-        'http://stsci.edu/schemas/asdf/core/asdf-1.0.0',
-        resolver=a1.resolver
-    )
-    info1 = schema.load_schema.cache_info()
-
     a2 = asdf.AsdfFile()
-    s2 = schema.load_schema(
-        'http://stsci.edu/schemas/asdf/core/asdf-1.0.0',
-        resolver=a2.resolver
-    )
-    info2 = schema.load_schema.cache_info()
 
-    assert s1 is s2
-    assert info1.misses == info2.misses
+    assert hash(a1.resolver) == hash(a2.resolver)
+    assert a1.resolver == a2.resolver
 
-
+    
 def test_flow_style():
     class CustomFlowStyleType(dict, types.CustomType):
         name = 'custom_flow'


### PR DESCRIPTION
This PR does the following:

- `AsdfFile.resolver` is now a property instead of a method, so caching it does not prevent the `AsdfFile` from being garbage collected.  The property returns an instance of `ResolverChain`, which is callable, so this change will hopefully be transparent to users.
- Fix Resolver's hash behavior
- Add `extension.get_default_resolver` for retrieving the default resolver without first instantiating an `AsdfFile`
- Deprecate `resolvers.default_url_mapping`, `resolvers.default_tag_to_url_mapping`, and `resolvers.default_resolver`, since none of these include mappings from loaded extensions
- Deprecate `extension.default_ext_resolver` because `load_schema` won't recognize it as identical to the default `ResolverChain`
- Deprecate `resolver.Resolver.add_mapping` because `Resolver` needs to be immutable to be used as a key in lru_cache's dictionary
- Add some `Resolver` tests

Fixes #681 
Fixes #672 