### PR TITLE
Upgrade jsonschema to 3.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@
 - Enable handling of subclasses of known custom types by using decorators for
   convenience. [#563]
 
+- Add support for jsonschema 3.x. [#684]
+
 2.3.4 (unreleased)
 ------------------
 

--- a/asdf/compat/jsonschemacompat.py
+++ b/asdf/compat/jsonschemacompat.py
@@ -1,0 +1,7 @@
+from ..util import minversion
+
+
+__all__ = ['JSONSCHEMA_LT_3']
+
+
+JSONSCHEMA_LT_3 = not minversion('jsonschema', '3.0.0')

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -203,7 +203,7 @@ REMOVE_DEFAULTS['properties'] = validate_remove_default
 @lru_cache()
 def _create_validator(validators=YAML_VALIDATORS):
     meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID, default_ext_resolver)
-    
+
     if JSONSCHEMA_LT_3:
         base_cls = mvalidators.create(meta_schema=meta_schema, validators=validators)
     else:
@@ -223,7 +223,7 @@ def _create_validator(validators=YAML_VALIDATORS):
         if JSONSCHEMA_LT_3:
             DEFAULT_TYPES = base_cls.DEFAULT_TYPES.copy()
             DEFAULT_TYPES['array'] = (list, tuple)
-            
+
         def iter_errors(self, instance, _schema=None, _seen=set()):
             # We can't validate anything that looks like an external reference,
             # since we don't have the actual content, so we just have to defer

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -22,6 +22,7 @@ from . import reference
 from . import treeutil
 from . import util
 from .extension import default_extensions
+from .compat.jsonschemacompat import JSONSCHEMA_LT_3
 
 
 YAML_SCHEMA_METASCHEMA_ID = 'http://stsci.edu/schemas/yaml-schema/draft-01'
@@ -202,19 +203,27 @@ REMOVE_DEFAULTS['properties'] = validate_remove_default
 @lru_cache()
 def _create_validator(validators=YAML_VALIDATORS):
     meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID, default_ext_resolver)
-    type_checker = mvalidators.Draft4Validator.TYPE_CHECKER.redefine(
-        'array',
-        lambda checker, instance: isinstance(instance, list) or isinstance(instance, tuple)
-    )
-    id_of = mvalidators.Draft4Validator.ID_OF
-    base_cls = mvalidators.create(
-        meta_schema=meta_schema,
-        validators=validators,
-        type_checker=type_checker,
-        id_of=id_of
-    )
+    
+    if JSONSCHEMA_LT_3:
+        base_cls = mvalidators.create(meta_schema=meta_schema, validators=validators)
+    else:
+        type_checker = mvalidators.Draft4Validator.TYPE_CHECKER.redefine(
+            'array',
+            lambda checker, instance: isinstance(instance, list) or isinstance(instance, tuple)
+        )
+        id_of = mvalidators.Draft4Validator.ID_OF
+        base_cls = mvalidators.create(
+            meta_schema=meta_schema,
+            validators=validators,
+            type_checker=type_checker,
+            id_of=id_of
+        )
 
     class ASDFValidator(base_cls):
+        if JSONSCHEMA_LT_3:
+            DEFAULT_TYPES = base_cls.DEFAULT_TYPES.copy()
+            DEFAULT_TYPES['array'] = (list, tuple)
+            
         def iter_errors(self, instance, _schema=None, _seen=set()):
             # We can't validate anything that looks like an external reference,
             # since we don't have the actual content, so we just have to defer

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 install_requires =
     semantic_version>=2.3.1
     pyyaml>=3.10
-    jsonschema>=2.3,<=2.6
+    jsonschema>=3.0.1,<4
     six>=1.9.0
     numpy>=1.8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 install_requires =
     semantic_version>=2.3.1
     pyyaml>=3.10
-    jsonschema>=3.0.1,<4
+    jsonschema>=2.3,<4
     six>=1.9.0
     numpy>=1.8
 


### PR DESCRIPTION
Addresses #530 

In its current state, this PR isn't compatible with jsonschema < 3, due to some (relatively minor) changes to `validators.create(...)`.  It would be straightforward to support both, but I thought I'd keep it clean unless I hear otherwise.

I installed this and ran the unit tests on jwst, gwcs, and astropy.  With the changes in https://github.com/spacetelescope/jwst/pull/3705, they all pass.