### PR TITLE
Use collections.abc.Sequence instead of collections.Sequence

### DIFF
--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -8,7 +8,7 @@ and `JSON Pointer standard <http://tools.ietf.org/html/rfc6901>`__.
 """
 
 
-from collections import Sequence
+from collections.abc import Sequence
 import weakref
 
 import numpy as np


### PR DESCRIPTION
The `collections.Sequence` is just a deprecated alias and will be removed in Python 3.8.  It's been available since Python 3.3, so I don't think this changes anything about asdf's support for Python versions.