### PR TITLE
Update install docs to include submodule initialization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,6 +263,7 @@ To install:
 ::
 
     $ cd asdf
+    $ git submodule update --init
     $ pip install .
 
 To install in `development


### PR DESCRIPTION
Following the install docs for the dev version fails with "error: package directory 'asdf-standard/schemas' does not exist" because the `asdf_standard` subpackage does not get downloaded with `git clone https://github.com/spacetelescope/asdf`.

I added a separate command to do this (`git submodule update --init`), but one could alternatively
add a flag in `git clone`, i.e.:

`git clone --recurse-submodules https://github.com/spacetelescope/asdf`

