### PR TITLE
Fix test warnings; remove cruft

### DIFF
--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -43,16 +43,16 @@ class TagReferenceType(types.CustomType):
         return node
 
 
-@pytest.mark.importorskip('astropy')
 def test_tagging_scalars():
+    astropy = pytest.importorskip('astropy', '3.0.0')
+    from astropy import units as u
+
     yaml = """
 unit: !unit/unit-1.0.0
   m
 not_unit:
   m
     """
-    from astropy import units as u
-
     buff = helpers.yaml_to_asdf(yaml)
     with asdf.open(buff) as ff:
         assert isinstance(ff.tree['unit'], u.UnitBase)
@@ -590,8 +590,8 @@ properties:
             schema.validate(b, schema=schema_tree)
 
 
-@pytest.mark.importorskip('astropy')
 def test_type_missing_dependencies():
+    astropy = pytest.importorskip('astropy', '3.0.0')
 
     class MissingType(types.CustomType):
         name = 'missing'

--- a/conftest.py
+++ b/conftest.py
@@ -1,34 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 import os
-from collections import OrderedDict
 
 import pytest
 from _pytest.doctest import DoctestItem
-
-from astropy.tests.helper import enable_deprecations_as_exceptions
-from astropy.tests.plugins import display
-
-
-display.PYTEST_HEADER_MODULES = OrderedDict([
-                                    ('asdf', 'asdf'),
-                                    ('numpy', 'numpy'),
-                                    ('jsonschema', 'jsonschema'),
-                                    ('pyyaml', 'yaml'),
-                                    ('astropy', 'astropy')])
-
-try:
-    import gwcs
-    display.PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
-except ImportError:
-    pass
-
-
-pytest_plugins = [
-    'astropy.tests.plugins.display'
-]
-
-enable_deprecations_as_exceptions()
 
 
 @pytest.fixture(autouse=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,11 @@ docs =
 tests =
     pytest
     astropy
-    pytest-astropy
+    gwcs
+    pytest-doctestplus
+    pytest-remotedata
+    pytest-openfiles
+    psutil
 
 [options.package_data]
 data = tests/**


### PR DESCRIPTION
Fixes the following warning
```
./site-packages/_pytest/mark/structures.py:332
  ./site-packages/_pytest/mark/structures.py:332: PytestUnknownMarkWarning: Unknown pytest.mark.importorskip - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,
```
Plus some updates to testing infrastructure.