### PR TITLE
Fix failing tests due to pytest 5.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 
 [testenv]
 deps=
+    pytest<5.1
     pytest-sugar
     pytest-faulthandler
     pytest-openfiles>=0.3.2
@@ -70,6 +71,7 @@ commands=
 basepython= python3.7
 deps=
     gwcs
+    pytest<5.1
     pytest-astropy
     pytest-openfiles>=0.3.2
     codecov


### PR DESCRIPTION
The Travis tests are failing because `pytest 5.1` removed `getfuncargvalue`.  This has been fixed upstream in `pytest-doctestplus` (https://github.com/astropy/pytest-doctestplus/pull/63).  This is a workaround to limit `pytest <5.1` until a new version of `pytest-doctestplus` is released.

(I'm repeatedly getting emails for the failing Travis cron jobs because I was the last committer).