### PR TITLE
Skip schema test of ortho_polynomial-1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ open_files_ignore = test.fits asdf.fits
 text_file_format = rst
 # Account for both the astropy test runner case and the native pytest case
 asdf_schema_root = asdf-standard/schemas asdf/schemas
-asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
+asdf_schema_skip_names = asdf-schema-1.0.0 draft-01 ortho_polynomial-1.0.0
 asdf_schema_skip_examples = domain-1.0.0 frame-1.0.0 frame-1.1.0
 # Enable the schema tests by default
 asdf_schema_tests_enabled = true


### PR DESCRIPTION
Since `ortho_polynomial-1.0.0` tag is defined in dev version of `astropy`, it is currently failing schema checks when run against the current release version of `astropy`.  This PR disables testing of the schema.

Once `astropy 4.0.0` is out, then the test can be re-enabled.

If any changes are made to this schema in the meantime, be sure to back out this change and make sure it gets tested against the appropriate dev version of `astropy`.