### PR TITLE
Make AsdfDeprecationWarning a subclass of DeprecationWarning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Add ``package`` property to extension metadata, and deprecate
   use of ``software``. [#728]
 
+- AsdfDeprecationWarning now subclasses DeprecationWarning. [#710]
+
 2.5.0 (2019-12-23)
 ------------------
 

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -7,7 +7,7 @@ class AsdfWarning(Warning):
     The base warning class from which all ASDF warnings should inherit.
     """
 
-class AsdfDeprecationWarning(AsdfWarning):
+class AsdfDeprecationWarning(AsdfWarning, DeprecationWarning):
     """
     A warning class to indicate a deprecated feature.
     """


### PR DESCRIPTION
Currently, if `AsdfDeprecationWarning` appears, it doesn't show up if one is trying to filter `DeprecationWarning`. If I turn `DeprecationWarning` into exceptions:
```
pytest -W "error::DeprecationWarning"
```
it does not catch `AsdfDeprecationWarning` as it should.

This PR properly subclasses it so it will.