### PR TITLE
replace SpecItem with SimpleSpec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - Added asdf-standard 1.4.0 to the list of supported versions. [#704]
 
+- ``SpecItem`` and ``Spec`` were depreicated  in ``semantic_version``
+  and were replaced with ``SimpleSpec``. [#715]
+
+- Pinned the minimum required ``semantic_version`` to 2.8. [#715]
+
 2.4.2 (2019-08-29)
 ------------------
 

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -5,6 +5,7 @@
 This module deals with things that change between different versions
 of the ASDF spec.
 """
+
 from functools import total_ordering
 
 import yaml
@@ -14,7 +15,7 @@ if getattr(yaml, '__with_libyaml__', None):  # pragma: no cover
 else:  # pragma: no cover
     _yaml_base_loader = yaml.SafeLoader
 
-from semantic_version import Version, SpecItem, Spec
+from semantic_version import Version, SimpleSpec
 
 from . import generic_io
 from . import resolver
@@ -83,7 +84,7 @@ class AsdfVersionMixin:
 
     def __eq__(self, other):
         # Seems like a bit of a hack...
-        if isinstance(other, SpecItem):
+        if isinstance(other, SimpleSpec):
             return other == self
         if isinstance(other, (str, tuple, list)):
             other = AsdfVersion(other)
@@ -123,7 +124,7 @@ class AsdfVersion(AsdfVersionMixin, Version):
         super(AsdfVersion, self).__init__(version)
 
 
-class AsdfSpec(SpecItem, Spec):
+class AsdfSpec(SimpleSpec):
 
     def __init__(self, *args, **kwargs):
         super(AsdfSpec, self).__init__(*args, **kwargs)
@@ -147,7 +148,7 @@ class AsdfSpec(SpecItem, Spec):
 
     def __eq__(self, other):
         """Equality between Spec and Version, string, or tuple, means match"""
-        if isinstance(other, SpecItem):
+        if isinstance(other, SimpleSpec):
             return super(AsdfSpec, self).__eq__(other)
         return self.match(other)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
     asdf.reference_files = asdf-standard/reference_files
 include_package_data = True
 install_requires =
-    semantic_version>=2.3.1,<=2.6.0
+    semantic_version>=2.8
     pyyaml>=3.10
     jsonschema>=2.3,<4
     six>=1.9.0


### PR DESCRIPTION
Fixes #702

This PR replaces `SpecItem` with `SimpleSpec` (both from `semantic_version`).
It also fixes the semantic_version to >= 2.8 . This is a backwards incompatible change in `semantic_version` so if we need to support earlier versions more changes will be needed.
@olebole Do you think support for earlier versions is needed?
