### PR TITLE
Refresh NDArrayType when underlying mmap is closed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 
 - Pinned the minimum required ``semantic_version`` to 2.8. [#715]
 
+- Fix bug causing segfault after update of a memory-mapped file. [#716]
+
 2.4.2 (2019-08-29)
 ------------------
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -876,7 +876,7 @@ def test_block_data_change(tmpdir):
     tmpfile = str(tmpdir.join("data.asdf"))
     tree = {"data": np.ndarray(10)}
     with asdf.AsdfFile(tree) as af:
-       af.write_to(tmpfile)
+        af.write_to(tmpfile)
 
     with asdf.open(tmpfile, mode="rw") as af:
         array_before = af.tree["data"].__array__()

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -858,7 +858,6 @@ def test_readonly(tmpdir):
 
 
 def test_readonly_inline(tmpdir):
-
     tmpfile = str(tmpdir.join('data.asdf'))
     tree = dict(data=np.ndarray((100)))
 
@@ -869,3 +868,18 @@ def test_readonly_inline(tmpdir):
     with asdf.open(tmpfile, mode='r') as af:
         assert af['data'].flags.writeable == True
         af['data'][0] = 42
+
+
+# Confirm that NDArrayType's internal array is regenerated
+# following an update.
+def test_block_data_change(tmpdir):
+    tmpfile = str(tmpdir.join("data.asdf"))
+    tree = {"data": np.ndarray(10)}
+    with asdf.AsdfFile(tree) as af:
+       af.write_to(tmpfile)
+
+    with asdf.open(tmpfile, mode="rw") as af:
+        array_before = af.tree["data"].__array__()
+        af.update()
+        array_after = af.tree["data"].__array__()
+        assert array_before is not array_after


### PR DESCRIPTION
This is the start of a fix for https://github.com/spacetelescope/asdf/issues/711.

When an asdf file is updated, we call [calculate_updated_layout](https://github.com/spacetelescope/asdf/blob/cfa6a039d2e8c5dc93f2fd52e7d0faa9c7b16d51/asdf/block.py#L1253), which shuffles blocks around the file as needed to make room for the expansion of the tree and changes to the other blocks.  When a block gets moved, its underlying memory map is closed and then reopened in the new location.

This is a problem for NDArrayType, which keeps a [memoized copy](https://github.com/spacetelescope/asdf/blob/d8d8b3b62b7a3a6e0ce06dc83708b4c4fb807935/asdf/tags/core/ndarray.py#L251) of an ndarray that is built on top of that mmap.  The segfault occurs when the tree calls `__repr__` on the ndarray.

This PR gives NDArrayType the ability to detect that the block has been moved, and rebuild the ndarray in that case.  It does fix the issue as reported but it might be worth revisiting whether the optimizations that cause this problem are even necessary?  Maybe we don't need to memoize the ndarray at all, or maybe it's not really necessary to be able to update a small part of the asdf file without rewriting the entire thing.