### PR TITLE
Ignore failing schema tests on astropy < 4.0

### DIFF
--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -191,7 +191,7 @@ def test_asdf_file_resolver_hashing():
     assert hash(a1.resolver) == hash(a2.resolver)
     assert a1.resolver == a2.resolver
 
-    
+
 def test_flow_style():
     class CustomFlowStyleType(dict, types.CustomType):
         name = 'custom_flow'

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -71,18 +71,32 @@ class AsdfSchemaItem(pytest.Item):
         schema.check_schema(schema_tree)
 
 
+ASTROPY_4_0_TAGS = {
+    'tag:stsci.edu:asdf/transform/rotate_sequence_3d',
+    'tag:stsci.edu:asdf/transform/ortho_polynomial',
+    'tag:stsci.edu:asdf/transform/fix_inputs',
+    'tag:stsci.edu:asdf/transform/math_functions',
+    'tag:stsci.edu:asdf/time/time',
+}
+
+
 def should_skip(name, version):
-
     if name == 'tag:stsci.edu:asdf/transform/multiplyscale':
-        astropy = find_spec('astropy')
-        if astropy is None:
-            return True
-
-        import astropy
-        if parse_version(astropy.version.version) < parse_version('3.1.dev0'):
-            return True
+        return not is_min_astropy_version('3.1.dev0')
+    elif name in ASTROPY_4_0_TAGS:
+	return not is_min_astropy_version('4.0')
 
     return False
+
+
+def is_min_astropy_version(min_version):
+    astropy = find_spec('astropy')
+    if astropy is None:
+        return False
+
+    import astropy
+    return parse_version(astropy.version.version) >= parse_version(min_version)
+
 
 def parse_schema_filename(filename):
     from asdf import versioning

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -84,7 +84,7 @@ def should_skip(name, version):
     if name == 'tag:stsci.edu:asdf/transform/multiplyscale':
         return not is_min_astropy_version('3.1.dev0')
     elif name in ASTROPY_4_0_TAGS:
-	return not is_min_astropy_version('4.0')
+        return not is_min_astropy_version('4.0')
 
     return False
 


### PR DESCRIPTION
It turns out there's already an example in pytest_asdf of ignoring a schema test for older versions of astropy.