### PR TITLE
Add tox environment that runs tests against an installed asdf package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,9 @@ matrix:
         # Test against prerelease versions of all dependencies
         - env: TOXENV='prerelease'
 
+        # Test against an installed asdf package
+        - env: TOXENV='packaged'
+
         # Try a run on OSX
         - os: osx
           env: TOXENV='py37-stable'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@
 
 - AsdfDeprecationWarning now subclasses DeprecationWarning. [#710]
 
+2.5.1 (unreleased)
+------------------
+
+- Fix bug in test causing failure when test suite is run against
+  an installed asdf package. [#732]
+
 2.5.0 (2019-12-23)
 ------------------
 

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -428,4 +428,4 @@ def test_get_default_resolver():
 
     result = resolver('tag:stsci.edu:asdf/core/ndarray-1.0.0')
 
-    assert result.endswith("asdf-standard/schemas/stsci.edu/asdf/core/ndarray-1.0.0.yaml")
+    assert result.endswith("/schemas/stsci.edu/asdf/core/ndarray-1.0.0.yaml")

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,17 @@ commands=
 basepython= python3.7
 pip_pre= true
 
+[testenv:packaged]
+basepython= python3.7
+# The default tox working directory is in .tox in the source directory.  If we
+# execute pytest from there, it will discover tox.ini in the source directory
+# and load the asdf module from the unpackaged sourcee, which is not what we
+# want.  The home directory does not have a tox.ini in any of its ancestors,
+# so this will allow us to test the installed package.
+changedir= {homedir}
+commands=
+    pytest --pyargs asdf
+
 [testenv:egg_info]
 deps=
 conda_deps=


### PR DESCRIPTION
This adds a job to the Travis build that runs the tests against an installed asdf package, which should help us catch issues like https://github.com/spacetelescope/asdf/issues/731.

I'll also fix that failing test, but I want to see it fail on Travis first, so I'm opening the PR early.