### PR TITLE
Add asdf.info and AsdfFile.search prototypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@
 - Resolve external references in custom schemas, and deprecate
   asdf.schema.load_custom_schema.  [#738]
 
+- Add ``asdf.info`` for displaying a summary of a tree, and
+  ``AsdfFile.search`` for searching a tree. [#736]
+
 2.5.1 (2020-01-07)
 ------------------
 

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -15,7 +15,7 @@ from ._internal_init import *
 
 __all__ = [
     'AsdfFile', 'CustomType', 'AsdfExtension', 'Stream', 'open', 'test',
-    'commands', 'IntegerType', 'ExternalArrayReference'
+    'commands', 'IntegerType', 'ExternalArrayReference', 'info'
 ]
 
 try:
@@ -40,6 +40,7 @@ from .stream import Stream
 from . import commands
 from .tags.core import IntegerType
 from .tags.core.external_reference import ExternalArrayReference
+from ._convenience import info
 
 from jsonschema import ValidationError
 

--- a/asdf/_convenience.py
+++ b/asdf/_convenience.py
@@ -1,0 +1,58 @@
+"""
+Implementation of the asdf.info(...) function.  This is just a thin wrapper
+around _display module code.
+"""
+import pathlib
+from contextlib import contextmanager
+
+from .asdf import open_asdf, AsdfFile
+from ._display import render_tree, DEFAULT_MAX_ROWS, DEFAULT_MAX_COLS, DEFAULT_SHOW_VALUES
+
+
+__all__ = ["info"]
+
+
+def info(node_or_path, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, show_values=DEFAULT_SHOW_VALUES):
+    """
+    Print a rendering of an ASDF tree or sub-tree to stdout.
+
+    Parameters
+    ----------
+    node_or_path : str, pathlib.Path, asdf.asdf.AsdfFile, or any \
+                   ASDF tree node
+        The tree or sub-tree to render.  Strings and Path objects
+        will first be passed to asdf.open(...).
+
+    max_rows : int, tuple, or None, optional
+        Maximum number of lines to print.  Nodes that cannot be
+        displayed will be elided with a message.
+        If int, constrain total number of displayed lines.
+        If tuple, constrain lines per node at the depth corresponding \
+            to the tuple index.
+        If None, display all lines.
+
+    max_cols : int or None, optional
+        Maximum length of line to print.  Nodes that cannot
+        be fully displayed will be truncated with a message.
+        If int, constrain length of displayed lines.
+        If None, line length is unconstrained.
+
+    show_values : bool, optional
+        Set to False to disable display of primitive values in
+        the rendered tree.
+    """
+    with _manage_node(node_or_path) as (identifier, node):
+        lines = render_tree(node, max_rows=max_rows, max_cols=max_cols, show_values=show_values, identifier=identifier)
+        print("\n".join(lines))
+
+
+@contextmanager
+def _manage_node(node_or_path):
+    if isinstance(node_or_path, str) or isinstance(node_or_path, pathlib.Path):
+        with open_asdf(node_or_path) as af:
+            yield "root.tree", af.tree
+    else:
+        if isinstance(node_or_path, AsdfFile):
+            yield "root.tree", node_or_path.tree
+        else:
+            yield "root", node_or_path

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -1,0 +1,331 @@
+"""
+Utilities for displaying the content of an ASDF tree.
+"""
+import numpy as np
+
+from .util import is_primitive
+from .treeutil import get_children
+from .tags.core.ndarray import NDArrayType
+
+
+__all__ = [
+    "DEFAULT_MAX_ROWS",
+    "DEFAULT_MAX_COLS",
+    "DEFAULT_SHOW_VALUES",
+    "render_tree",
+    "format_bold",
+    "format_faint",
+    "format_italic",
+]
+
+
+DEFAULT_MAX_ROWS = 24
+DEFAULT_MAX_COLS = 120
+DEFAULT_SHOW_VALUES = True
+
+
+def render_tree(node, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, show_values=DEFAULT_SHOW_VALUES, filters=[], identifier="root"):
+    """
+    Render a tree as text with indents showing depth.
+    """
+    info = _NodeInfo.from_root_node(identifier, node)
+
+    if len(filters) > 0:
+        if not _filter_tree(info, filters):
+            return []
+
+    renderer = _TreeRenderer(max_rows, max_cols, show_values)
+    return renderer.render(info)
+
+
+def format_bold(value):
+    """
+    Wrap the input value in the ANSI escape sequence for increased intensity.
+    """
+    return _format_code(value, 1)
+
+
+def format_faint(value):
+    """
+    Wrap the input value in the ANSI escape sequence for decreased intensity.
+    """
+    return _format_code(value, 2)
+
+
+def format_italic(value):
+    """
+    Wrap the input value in the ANSI escape sequence for italic.
+    """
+    return _format_code(value, 3)
+
+
+def _format_code(value, code):
+    return "\x1B[{}m{}\x1B[0m".format(code, value)
+
+
+class _NodeInfo:
+    """
+    Container for a node, its state of visibility, and values used to display it.
+    """
+    @classmethod
+    def from_root_node(cls, root_identifier, root_node):
+        """
+        Build a _NodeInfo tree from the given ASDF root node.
+        Intentionally processes the tree in breadth-first order so that recursively
+        referenced nodes are displayed at their shallowest reference point.
+        """
+        current_nodes = [(None, root_identifier, root_node)]
+        seen = set()
+        root_info = None
+        current_depth = 0
+        while True:
+            next_nodes = []
+
+            for parent, identifier, node in current_nodes:
+                if (isinstance(node, dict) or isinstance(node, list) or isinstance(node, tuple)) and id(node) in seen:
+                    info = _NodeInfo(parent, identifier, node, current_depth, recursive=True)
+                    parent.children.append(info)
+                else:
+                    info = _NodeInfo(parent, identifier, node, current_depth)
+                    if root_info is None:
+                        root_info = info
+                    if parent is not None:
+                        parent.children.append(info)
+                    seen.add(id(node))
+
+                    for child_identifier, child_node in get_children(node):
+                        next_nodes.append((info, child_identifier, child_node))
+
+            if len(next_nodes) == 0:
+                break
+
+            current_nodes = next_nodes
+            current_depth += 1
+
+        return root_info
+
+    def __init__(
+        self, parent, identifier, node, depth, recursive=False, visible=True
+    ):
+        self.parent = parent
+        self.identifier = identifier
+        self.node = node
+        self.depth = depth
+        self.recursive = recursive
+        self.visible = visible
+        self.children = []
+
+    @property
+    def visible_children(self):
+        return [c for c in self.children if c.visible]
+
+    @property
+    def parent_node(self):
+        if self.parent is None:
+            return None
+        else:
+            return self.parent.node
+
+
+def _filter_tree(info, filters):
+    """
+    Remove nodes from the tree that get caught in the filters.
+    Mutates the tree.
+    """
+    filtered_children = []
+    for child in info.children:
+        if _filter_tree(child, filters):
+            filtered_children.append(child)
+    info.children = filtered_children
+
+    return len(info.children) > 0 or all(f(info.node, info.identifier) for f in filters)
+
+
+class _TreeRenderer:
+    """
+    Render a _NodeInfo tree with indent showing depth.
+    """
+    def __init__(self, max_rows, max_cols, show_values):
+        self._max_rows = max_rows
+        self._max_cols = max_cols
+        self._show_values = show_values
+
+    def render(self, info):
+        self._mark_visible(info)
+
+        lines, elided = self._render(info, set(), True)
+
+        if elided:
+            lines.append(format_faint(format_italic("Some nodes not shown.")))
+
+        return lines
+
+    def _mark_visible(self, root_info):
+        """
+        Select nodes to display, respecting max_rows.  Nodes at lower
+        depths will be prioritized.
+        """
+        if isinstance(self._max_rows, tuple):
+            self._mark_visible_tuple(root_info)
+        else:
+            self._mark_visible_int(root_info)
+
+    def _mark_visible_int(self, root_info):
+        """
+        Select nodes to display, obeying max_rows as an overall limit on
+        the number of lines returned.
+        """
+        if self._max_rows is None:
+            return
+
+        if self._max_rows < 2:
+            root_info.visible = False
+            return
+
+        current_infos = [root_info]
+        # Reserve one row for the root node, and another for the
+        # "Some nodes not shown." message.
+        rows_left = self._max_rows - 2
+        while True:
+            next_infos = []
+
+            for info in current_infos:
+                if rows_left >= len(info.children):
+                    rows_left -= len(info.children)
+                    next_infos.extend(info.children)
+                elif rows_left > 1:
+                    for child in info.children[rows_left-1:]:
+                        child.visible = False
+                    next_infos.extend(info.children[0:rows_left-1])
+                    rows_left = 0
+                else:
+                    for child in info.children:
+                        child.visible = False
+
+            if len(next_infos) == 0:
+                break
+
+            current_infos = next_infos
+
+    def _mark_visible_tuple(self, root_info):
+        """
+        Select nodes to display, obeying the per-node max_rows value for
+        each tree depth.
+        """
+        max_rows = (None,) + self._max_rows
+
+        current_infos = [root_info]
+        while True:
+            next_infos = []
+
+            for info in current_infos:
+                if info.depth + 1 < len(max_rows):
+                    rows_left = max_rows[info.depth + 1]
+                    if rows_left is None or rows_left >= len(info.children):
+                        next_infos.extend(info.children)
+                    elif rows_left > 1:
+                        for child in info.children[rows_left-1:]:
+                            child.visible = False
+                        next_infos.extend(info.children[0:rows_left-1])
+                    else:
+                        for child in info.children:
+                            child.visible = False
+                else:
+                    for child in info.children:
+                        child.visible = False
+
+            if len(next_infos) == 0:
+                break
+
+            current_infos = next_infos
+
+    def _render(self, info, active_depths, is_tail):
+        """
+        Render the tree.  Called recursively on child nodes.
+        """
+        lines = []
+
+        if info.visible == False:
+            return lines, True
+
+        lines.append(self._render_node(info, active_depths, is_tail))
+
+        elided = len(info.visible_children) < len(info.children)
+
+        for i, child in enumerate(info.visible_children):
+            if i == len(info.children) - 1:
+                child_is_tail = True
+                child_active_depths = active_depths
+            else:
+                child_is_tail = False
+                child_active_depths = active_depths.union({info.depth})
+
+            child_list, child_elided = self._render(child, child_active_depths, child_is_tail)
+            lines.extend(child_list)
+            elided = elided or child_elided
+
+        num_visible_children = len(info.visible_children)
+        if num_visible_children > 0 and num_visible_children != len(info.children):
+            hidden_count = len(info.children) - num_visible_children
+            prefix = self._make_prefix(info.depth + 1, active_depths, True)
+            message = format_faint(format_italic(str(hidden_count) + ' not shown'))
+            lines.append(
+                "{}{}".format(prefix, message)
+            )
+
+        return lines, elided
+
+    def _render_node(self, info, active_depths, is_tail):
+        prefix = self._make_prefix(info.depth, active_depths, is_tail)
+        value = self._render_node_value(info)
+
+        if isinstance(info.parent_node, list) or isinstance(info.parent_node, tuple):
+            line = "{}[{}] {}".format(prefix, format_bold(info.identifier), value)
+        else:
+            line = "{}{} {}".format(prefix, format_bold(info.identifier), value)
+
+        visible_children = info.visible_children
+        if len(visible_children) == 0 and len(info.children) > 0:
+            line = line + format_italic(" ...")
+
+        if info.recursive:
+            line = line + " " + format_faint(format_italic("(recursive reference)"))
+
+        if self._max_cols is not None and len(line) > self._max_cols:
+            message = " (truncated)"
+            line = line[0 : (self._max_cols - len(message))] + format_faint(format_italic(message))
+
+        return line
+
+    def _render_node_value(self, info):
+        rendered_type = type(info.node).__name__
+        if is_primitive(info.node) and self._show_values:
+            return "({}): {}".format(rendered_type, info.node)
+        elif isinstance(info.node, NDArrayType) or isinstance(info.node, np.ndarray):
+            return "({}): shape={}, dtype={}".format(rendered_type, info.node.shape, info.node.dtype.name)
+        else:
+            return "({})".format(rendered_type)
+
+    def _make_prefix(self, depth, active_depths, is_tail):
+        """
+        Create a prefix for a displayed node, accounting for depth
+        and including lines that show connections to other nodes.
+        """
+        prefix = ""
+
+        if depth < 1:
+            return prefix
+
+        if depth >= 2:
+            for n in range(0, depth - 1):
+                if n in active_depths:
+                    prefix = prefix + "│ "
+                else:
+                    prefix = prefix + "  "
+
+        if is_tail:
+            prefix = prefix + "└─"
+        else:
+            prefix = prefix + "├─"
+
+        return format_faint(prefix)

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -25,8 +25,11 @@ from . import util
 from . import version
 from . import versioning
 from . import yamlutil
+from . import _display as display
 from .exceptions import AsdfDeprecationWarning
 from .extension import AsdfExtensionList, default_extensions
+from .util import NotSet
+from .search import AsdfSearchResult
 
 from .tags.core import AsdfObject, Software, HistoryEntry, ExtensionMetadata
 
@@ -1225,6 +1228,78 @@ class AsdfFile(versioning.VersionedMixin):
             return self.tree['history']['entries']
 
         return []
+
+    def info(self, max_rows=display.DEFAULT_MAX_ROWS, max_cols=display.DEFAULT_MAX_COLS, show_values=display.DEFAULT_SHOW_VALUES):
+        """
+        Print a rendering of this file's tree to stdout.
+
+        Parameters
+        ----------
+        max_rows : int, tuple, or None, optional
+            Maximum number of lines to print.  Nodes that cannot be
+            displayed will be elided with a message.
+            If int, constrain total number of displayed lines.
+            If tuple, constrain lines per node at the depth corresponding \
+                to the tuple index.
+            If None, display all lines.
+
+        max_cols : int or None, optional
+            Maximum length of line to print.  Nodes that cannot
+            be fully displayed will be truncated with a message.
+            If int, constrain length of displayed lines.
+            If None, line length is unconstrained.
+
+        show_values : bool, optional
+            Set to False to disable display of primitive values in
+            the rendered tree.
+        """
+        lines = display.render_tree(self.tree, max_rows=max_rows, max_cols=max_cols, show_values=show_values, identifier="root.tree")
+        print("\n".join(lines))
+
+    def search(self, key=NotSet, type=NotSet, value=NotSet, filter=None):
+        """
+        Search this file's tree.
+
+        Parameters
+        ----------
+        key : NotSet, str, or any other object
+            Search query that selects nodes by dict key or list index.
+            If NotSet, the node key is unconstrained.
+            If str, the input is searched among keys/indexes as a regular
+            expression pattern.
+            If any other object, node's key or index must equal the queried key.
+
+        type : NotSet, str, or builtins.type
+            Search query that selects nodes by type.
+            If NotSet, the node type is unconstrained.
+            If str, the input is searched among (fully qualified) node type
+            names as a regular expression pattern.
+            If builtins.type, the node must be an instance of the input.
+
+        value : NotSet, str, or any other object
+            Search query that selects nodes by value.
+            If NotSet, the node value is unconstrained.
+            If str, the input is searched among values as a regular
+            expression pattern.
+            If any other object, node's value must equal the queried value.
+
+        filter : callable
+            Callable that filters nodes by arbitrary criteria.
+            The callable accepts one or two arguments:
+
+            - the node
+            - the node's list index or dict key (optional)
+
+            and returns True to retain the node, or False to remove it from
+            the search results.
+
+        Returns
+        -------
+        asdf.search.AsdfSearchResult
+            the result of the search
+        """
+        result = AsdfSearchResult(["root.tree"], self.tree)
+        return result.search(key=key, type=type, value=value, filter=filter)
 
 
 # Inherit docstring from dictionary

--- a/asdf/commands/__init__.py
+++ b/asdf/commands/__init__.py
@@ -9,6 +9,7 @@ from .defragment import *
 from .diff import *
 from .tags import *
 from .extension import *
+from .info import *
 
 # Extracting ASDF-in-FITS files requires Astropy
 if importlib.util.find_spec('astropy'):

--- a/asdf/commands/info.py
+++ b/asdf/commands/info.py
@@ -1,0 +1,45 @@
+"""
+Commands for displaying summaries of ASDF trees
+"""
+
+from .main import Command
+from .. import _convenience as convenience
+
+
+__all__ = ["info"]
+
+
+class Info(Command):
+    @classmethod
+    def setup_arguments(cls, subparsers):
+        parser = subparsers.add_parser(
+            "info", help="Print a rendering of an ASDF tree.",
+            description="Print a rendering of an ASDF tree."
+        )
+
+        parser.add_argument("filename", help="ASDF file to render")
+        parser.add_argument(
+            "--max-rows",
+            type=int,
+            help="maximum number of lines"
+        )
+        parser.add_argument(
+            "--max-cols",
+            type=int,
+            help="maximum length of line")
+
+        parser.add_argument("--show-values", dest="show_values", action="store_true")
+        parser.add_argument("--no-show-values", dest="show_values", action="store_false")
+        parser.set_defaults(show_values=True)
+
+        parser.set_defaults(func=cls.run)
+
+        return parser
+
+    @classmethod
+    def run(cls, args):
+        info(args.filename, args.max_rows, args.max_cols, args.show_values)
+
+
+def info(filename, max_rows, max_cols, show_values):
+    convenience.info(filename, max_rows=max_rows, max_cols=max_cols, show_values=show_values)

--- a/asdf/commands/tests/test_info.py
+++ b/asdf/commands/tests/test_info.py
@@ -1,0 +1,26 @@
+from functools import partial
+
+from ...tests import helpers
+from . import data as test_data
+
+from .. import main
+
+
+get_test_data_path = partial(helpers.get_test_data_path, module=test_data)
+
+
+def test_info_command(capsys):
+    file_path = get_test_data_path("frames0.asdf")
+
+    assert main.main_from_args(["info", file_path]) == 0
+    captured = capsys.readouterr()
+    assert "root.tree" in captured.out
+    assert "frames" in captured.out
+    original_len = len(captured.out.split("\n"))
+
+    assert main.main_from_args(["info", "--max-rows", str(original_len - 5), file_path]) == 0
+    captured = capsys.readouterr()
+    assert "root.tree" in captured.out
+    assert "frames" in captured.out
+    new_len = len(captured.out.split("\n"))
+    assert new_len < original_len

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -1,0 +1,356 @@
+"""
+Utilities for searching ASDF trees.
+"""
+import inspect
+import re
+import typing
+import builtins
+
+from .util import NotSet
+from ._display import render_tree, DEFAULT_MAX_ROWS, DEFAULT_MAX_COLS, DEFAULT_SHOW_VALUES, format_italic, format_faint
+from .treeutil import get_children, is_container
+
+
+__all__ = ["AsdfSearchResult"]
+
+
+class AsdfSearchResult:
+    """
+    Result of a call to AsdfFile.search.
+    """
+    def __init__(self, identifiers, node, filters=[], parent_node=None, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, show_values=DEFAULT_SHOW_VALUES):
+        self._identifiers = identifiers
+        self._node = node
+        self._filters = filters
+        self._parent_node = parent_node
+        self._max_rows = max_rows
+        self._max_cols = max_cols
+        self._show_values = show_values
+
+    def format(self, max_rows=NotSet, max_cols=NotSet, show_values=NotSet):
+        """
+        Change formatting parameters of the rendered tree.
+
+        Parameters
+        ----------
+        max_rows : int, tuple, None, or NotSet, optional
+            Maximum number of lines to print.  Nodes that cannot be
+            displayed will be elided with a message.
+            If int, constrain total number of displayed lines.
+            If tuple, constrain lines per node at the depth corresponding \
+                to the tuple index.
+            If None, display all lines.
+            If NotSet, retain existing value.
+
+        max_cols : int, None or NotSet, optional
+            Maximum length of line to print.  Nodes that cannot
+            be fully displayed will be truncated with a message.
+            If int, constrain length of displayed lines.
+            If None, line length is unconstrained.
+            If NotSet, retain existing value.
+
+        show_values : bool or NotSet, optional
+            Set to False to disable display of primitive values in
+            the rendered tree.
+            Set to NotSet to retain existign value.
+
+        Returns
+        -------
+        AsdfSearchResult
+            the reformatted search result
+        """
+        if max_rows is NotSet:
+            max_rows = self._max_rows
+
+        if max_cols is NotSet:
+            max_cols = self._max_cols
+
+        if show_values is NotSet:
+            show_values = self._show_values
+
+        return AsdfSearchResult(
+            self._identifiers,
+            self._node,
+            filters=self._filters,
+            parent_node=self._parent_node,
+            max_rows=max_rows,
+            max_cols=max_cols,
+            show_values=show_values
+        )
+
+    def _maybe_compile_pattern(self, query):
+        if isinstance(query, str):
+            return re.compile(query)
+        else:
+            return query
+
+    def _safe_equals(self, a, b):
+        try:
+            result = (a == b)
+            if isinstance(result, bool):
+                return result
+            else:
+                return False
+        except Exception:
+            return False
+
+    def _get_fully_qualified_type(self, value):
+        value_type = type(value)
+        if value_type.__module__ == "builtins":
+            return value_type.__name__
+        else:
+            return ".".join([value_type.__module__, value_type.__name__])
+
+    def search(self, key=NotSet, type=NotSet, value=NotSet, filter=None):
+        """
+        Further narrow the search.
+
+        Parameters
+        ----------
+        key : NotSet, str, or any other object
+            Search query that selects nodes by dict key or list index.
+            If NotSet, the node key is unconstrained.
+            If str, the input is searched among keys/indexes as a regular
+            expression pattern.
+            If any other object, node's key or index must equal the queried key.
+
+        type : NotSet, str, or builtins.type
+            Search query that selects nodes by type.
+            If NotSet, the node type is unconstrained.
+            If str, the input is searched among (fully qualified) node type
+            names as a regular expression pattern.
+            If builtins.type, the node must be an instance of the input.
+
+        value : NotSet, str, or any other object
+            Search query that selects nodes by value.
+            If NotSet, the node value is unconstrained.
+            If str, the input is searched among values as a regular
+            expression pattern.
+            If any other object, node's value must equal the queried value.
+
+        filter : callable
+            Callable that filters nodes by arbitrary criteria.
+            The callable accepts one or two arguments:
+
+            - the node
+            - the node's list index or dict key (optional)
+
+            and returns True to retain the node, or False to remove it from
+            the search results.
+
+        Returns
+        -------
+        AsdfSearchResult
+            the subsequent search result
+        """
+        if not (type is NotSet or isinstance(type, str) or isinstance(type, typing.Pattern) or isinstance(type, builtins.type)):
+            raise TypeError("type must be NotSet, str, regular expression, or instance of builtins.type")
+
+        # value and key arguments can be anything, but pattern and str have special behavior
+
+        key = self._maybe_compile_pattern(key)
+        type = self._maybe_compile_pattern(type)
+        value = self._maybe_compile_pattern(value)
+
+        filter = _wrap_filter(filter)
+
+        def _filter(node, identifier):
+            if isinstance(key, typing.Pattern):
+                if key.search(str(identifier)) is None:
+                    return False
+            elif key is not NotSet:
+                if not self._safe_equals(identifier, key):
+                    return False
+
+            if isinstance(type, typing.Pattern):
+                fully_qualified_node_type = self._get_fully_qualified_type(node)
+                if type.search(fully_qualified_node_type) is None:
+                    return False
+            elif isinstance(type, builtins.type):
+                if not isinstance(node, type):
+                    return False
+
+            if isinstance(value, typing.Pattern):
+                if is_container(node):
+                    # The string representation of a container object tends to
+                    # include the child object values, but that's probably not
+                    # what searchers want.
+                    return False
+                elif value.search(str(node)) is None:
+                    return False
+            elif value is not NotSet:
+                if not self._safe_equals(node, value):
+                    return False
+
+            if filter is not None:
+                if not filter(node, identifier):
+                    return False
+
+            return True
+
+        return AsdfSearchResult(
+            self._identifiers,
+            self._node,
+            filters=self._filters + [_filter],
+            parent_node=self._parent_node,
+            max_rows=self._max_rows,
+            max_cols=self._max_cols,
+            show_values=self._show_values
+        )
+
+    @property
+    def node(self):
+        """
+        Retrieve the leaf node of a tree with one search result.
+
+        Returns
+        -------
+        object
+            the single node of the search result
+        """
+
+        results = self.nodes
+        if len(results) == 0:
+            return None
+        elif len(results) == 1:
+            return results[0]
+        else:
+            raise RuntimeError("More than one result")
+
+    @property
+    def path(self):
+        """
+        Retrieve the path to the leaf node of a tree with one search result.
+
+        Returns
+        -------
+        str
+            the path to the searched node
+        """
+        results = self.paths
+        if len(results) == 0:
+            return None
+        elif len(results) == 1:
+            return results[0]
+        else:
+            raise RuntimeError("More than one result")
+
+    @property
+    def nodes(self):
+        """
+        Retrieve all leaf nodes in the search results.
+
+        Returns
+        -------
+        list of object
+            every node in the search results (breadth-first order)
+        """
+        results = []
+
+        def _callback(identifiers, node, children):
+            if all(f(node, identifiers[-1]) for f in self._filters):
+                results.append(node)
+
+        _walk_tree_breadth_first(self._identifiers, self._node, _callback)
+        return results
+
+    @property
+    def paths(self):
+        """
+        Retrieve the paths to all leaf nodes in the search results.
+
+        Returns
+        -------
+        list of str
+            the path to every node in the search results
+        """
+        results = []
+
+        def _callback(identifiers, node, children):
+            if all(f(node, identifiers[-1]) for f in self._filters):
+                results.append(_build_path(identifiers))
+
+        _walk_tree_breadth_first(self._identifiers, self._node, _callback)
+        return results
+
+    def __repr__(self):
+        lines = render_tree(
+            self._node,
+            max_rows=self._max_rows,
+            max_cols=self._max_cols,
+            show_values=self._show_values,
+            filters=self._filters,
+            identifier=self._identifiers[-1]
+        )
+
+        if len(lines) == 0:
+            return format_faint(format_italic("No results found."))
+        else:
+            return "\n".join(lines)
+
+    def __getitem__(self, key):
+        if isinstance(self._node, dict) or isinstance(self._node, list) or isinstance(self._node, tuple):
+            child = self._node[key]
+        else:
+            raise TypeError("This node cannot be indexed")
+
+        return AsdfSearchResult(
+            self._identifiers + [key],
+            child,
+            filters=self._filters,
+            parent_node=self._node,
+            max_rows=self._max_rows,
+            max_cols=self._max_cols,
+            show_values=self._show_values,
+        )
+
+
+def _walk_tree_breadth_first(root_identifiers, root_node, callback):
+    """
+    Walk the tree in breadth-first order (useful for prioritizing
+    lower-depth nodes).
+    """
+    current_nodes = [(root_identifiers, root_node)]
+    seen = set()
+    while True:
+        next_nodes = []
+
+        for identifiers, node in current_nodes:
+            if (isinstance(node, dict) or isinstance(node, list) or isinstance(node, tuple)) and id(node) in seen:
+                continue
+
+            children = get_children(node)
+            callback(identifiers, node, [c for _, c in children])
+            next_nodes.extend([(identifiers + [i], c) for i, c in children])
+            seen.add(id(node))
+
+        if len(next_nodes) == 0:
+            break
+
+        current_nodes = next_nodes
+
+
+def _build_path(identifiers):
+    """
+    Generate the Python code needed to extract the identified node.
+    """
+    if len(identifiers) == 0:
+        return ""
+    else:
+        return identifiers[0] + "".join("[{}]".format(repr(i)) for i in identifiers[1:])
+
+
+def _wrap_filter(filter):
+    """
+    Ensure that filter callable accepts the expected number of arguments.
+    """
+    if filter is None:
+        return None
+    else:
+        arity = len(inspect.signature(filter).parameters)
+        if arity == 1:
+            return lambda n, i: filter(n)
+        elif arity == 2:
+            return filter
+        else:
+            raise ValueError("filter must accept 1 or 2 arguments")

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -429,3 +429,87 @@ def test_get_default_resolver():
     result = resolver('tag:stsci.edu:asdf/core/ndarray-1.0.0')
 
     assert result.endswith("/schemas/stsci.edu/asdf/core/ndarray-1.0.0.yaml")
+
+
+def test_info_module(capsys, tmpdir):
+    tree = dict(
+        foo=42, bar="hello", baz=np.arange(20),
+        nested={"woo": "hoo", "yee": "haw"},
+        long_line="a" * 100
+    )
+    af = asdf.AsdfFile(tree)
+
+    def _assert_correct_info(node_or_path):
+        asdf.info(node_or_path)
+        captured = capsys.readouterr()
+        assert "foo" in captured.out
+        assert "bar" in captured.out
+        assert "baz" in captured.out
+
+    _assert_correct_info(af)
+    _assert_correct_info(af.tree)
+
+    tmpfile = str(tmpdir.join("written.asdf"))
+    af.write_to(tmpfile)
+    af.close()
+
+    _assert_correct_info(tmpfile)
+    _assert_correct_info(pathlib.Path(tmpfile))
+
+    for i in range(1, 10):
+        asdf.info(af, max_rows=i)
+        lines = capsys.readouterr().out.strip().split("\n")
+        assert len(lines) <= i
+
+    asdf.info(af, max_cols=80)
+    assert "(truncated)" in capsys.readouterr().out
+    asdf.info(af, max_cols=None)
+    captured = capsys.readouterr().out
+    assert "(truncated)" not in captured
+    assert "a" * 100 in captured
+
+    asdf.info(af, show_values=True)
+    assert "hello" in capsys.readouterr().out
+    asdf.info(af, show_values=False)
+    assert "hello" not in capsys.readouterr().out
+
+    tree = {
+        "foo": ["alpha", "bravo", "charlie", "delta", "eagle"]
+    }
+    af = asdf.AsdfFile(tree)
+    asdf.info(af, max_rows=(None,))
+    assert "alpha" not in capsys.readouterr().out
+    for i in range(1, 5):
+        asdf.info(af, max_rows=(None, i))
+        captured = capsys.readouterr()
+        for val in tree["foo"][0:i-1]:
+            assert val in captured.out
+        for val in tree["foo"][i-1:]:
+            assert val not in captured.out
+
+def test_info_asdf_file(capsys, tmpdir):
+    tree = dict(
+        foo=42, bar="hello", baz=np.arange(20),
+        nested={"woo": "hoo", "yee": "haw"},
+        long_line="a" * 100
+    )
+    af = asdf.AsdfFile(tree)
+    af.info()
+    captured = capsys.readouterr()
+    assert "foo" in captured.out
+    assert "bar" in captured.out
+    assert "baz" in captured.out
+
+
+def test_search():
+    tree = dict(foo=42, bar="hello", baz=np.arange(20))
+    af = asdf.AsdfFile(tree)
+
+    result = af.search("foo")
+    assert result.node == 42
+
+    result = af.search(type="ndarray")
+    assert (result.node == tree["baz"]).all()
+
+    result = af.search(value="hello")
+    assert result.node == "hello"

--- a/asdf/tests/test_search.py
+++ b/asdf/tests/test_search.py
@@ -1,0 +1,173 @@
+import re
+
+import pytest
+import numpy as np
+
+from asdf import AsdfFile
+
+
+@pytest.fixture
+def asdf_file():
+    tree = {
+        "foo": 42,
+        "nested": {"foo": 24, "foible": "whoops", "folicle": "yup", "moo": 24},
+        "bar": "hello",
+        "list": [{"index": 0}, {"index": 1}, {"index": 2}]
+    }
+    return AsdfFile(tree)
+
+
+def test_no_arguments(asdf_file):
+    result = asdf_file.search()
+    assert len(result.paths) == 15
+    assert len(result.nodes) == 15
+
+
+def test_repr(asdf_file):
+    result = asdf_file.search()
+    assert "foo" in repr(result)
+    assert "nested" in repr(result)
+    assert "bar" in repr(result)
+    assert "list" in repr(result)
+
+
+def test_single_result(asdf_file):
+    result = asdf_file.search("bar")
+    assert len(result.paths) == 1
+    assert len(result.nodes) == 1
+    assert result.node == "hello"
+    assert result.path == "root.tree['bar']"
+
+
+def test_multiple_results(asdf_file):
+    result = asdf_file.search("foo")
+    assert len(result.paths) == 2
+    assert len(result.nodes) == 2
+    assert 42 in result.nodes
+    assert 24 in result.nodes
+    assert "root.tree['foo']" in result.paths
+    assert "root.tree['nested']['foo']" in result.paths
+
+    with pytest.raises(RuntimeError):
+        result.path
+
+    with pytest.raises(RuntimeError):
+        result.node
+
+
+def test_by_key(asdf_file):
+    result = asdf_file.search("bar")
+    assert result.node == "hello"
+
+    result = asdf_file.search("^b.r$")
+    assert result.node == "hello"
+
+    result = asdf_file.search(re.compile("fo[oi]"))
+    assert set(result.nodes) == {42, 24, "whoops"}
+
+    result = asdf_file.search(0)
+    assert result.node == {"index": 0}
+
+
+def test_by_type(asdf_file):
+    result = asdf_file.search(type=str)
+    assert sorted(result.nodes) == sorted(["hello", "whoops", "yup"])
+
+    result = asdf_file.search(type="int")
+    assert result.nodes == [42, 24, 24, 0, 1, 2]
+
+    result = asdf_file.search(type="dict|list")
+    assert len(result.nodes) == 5
+
+    result = asdf_file.search(type=re.compile("^i.t$"))
+    assert result.nodes == [42, 24, 24, 0, 1, 2]
+
+    with pytest.raises(TypeError):
+        asdf_file.search(type=4)
+
+
+def test_by_value(asdf_file):
+    result = asdf_file.search(value=42)
+    assert result.node == 42
+
+
+def test_by_value_with_ndarray():
+    """
+    Check some edge cases when comparing integers and booleans to numpy arrays.
+    """
+    tree = {
+        "foo": np.arange(10)
+    }
+    af = AsdfFile(tree)
+    result = af.search(value=True)
+    assert len(result.nodes) == 0
+    result = af.search(value=42)
+    assert len(result.nodes) == 0
+
+
+def test_by_filter(asdf_file):
+    with pytest.raises(ValueError):
+        asdf_file.search(filter=lambda: True)
+
+    result = asdf_file.search(filter=lambda n: isinstance(n, int) and n % 2 == 0)
+    assert result.nodes == [42, 24, 24, 0, 2]
+
+    result = asdf_file.search(filter=lambda n, k: k == "foo" and n > 30)
+    assert result.node == 42
+
+
+def test_multiple_conditions(asdf_file):
+    result = asdf_file.search("foo", value=24)
+    assert len(result.nodes) == 1
+    assert result.node == 24
+
+
+def test_chaining(asdf_file):
+    result = asdf_file.search("foo").search(value=24)
+    assert len(result.nodes) == 1
+    assert result.node == 24
+
+
+def test_index_operator(asdf_file):
+    result = asdf_file.search()["nested"].search("foo")
+    assert len(result.nodes) == 1
+    assert result.node == 24
+
+    with pytest.raises(TypeError):
+        asdf_file.search()["foo"][0]
+
+
+def test_format(asdf_file):
+    result = asdf_file.search()
+    original_len = len(repr(result).split("\n"))
+
+    result = result.format(max_rows=original_len - 5)
+    new_len = len(repr(result).split("\n"))
+    assert new_len < original_len
+
+    result = result.format(max_rows=(None, 5))
+    new_len = len(repr(result).split("\n"))
+    assert new_len < original_len
+
+    assert repr(result) == repr(result.format())
+
+
+def test_no_results(asdf_file):
+    result = asdf_file.search("missing")
+    assert len(result.nodes) == 0
+    assert "No results found." in repr(result)
+    assert result.node is None
+    assert result.path is None
+
+
+def test_recursive_tree():
+    tree = {"foo": {"bar": "baz"}}
+    af = AsdfFile(tree)
+    af.tree["foo"]["nested"] = af.tree["foo"]
+
+    result = af.search()
+    assert "(recursive reference)" in repr(result)
+
+    result = af.search("bar")
+    assert len(result.nodes) == 1
+    assert result.node == "baz"

--- a/asdf/tests/test_treeutil.py
+++ b/asdf/tests/test_treeutil.py
@@ -1,0 +1,26 @@
+from asdf import treeutil
+
+
+def test_get_children():
+    parent = ["foo", "bar"]
+    assert treeutil.get_children(parent) == [(0, "foo"), (1, "bar")]
+
+    parent = ("foo", "bar")
+    assert treeutil.get_children(parent) == [(0, "foo"), (1, "bar")]
+
+    parent = {"foo": "bar", "ding": "dong"}
+    assert sorted(treeutil.get_children(parent)) == sorted([("foo", "bar"), ("ding", "dong")])
+
+    parent = "foo"
+    assert treeutil.get_children(parent) == []
+
+    parent = None
+    assert treeutil.get_children(parent) == []
+
+
+def test_is_container():
+    for value in [[], {}, tuple()]:
+        assert treeutil.is_container(value) is True
+
+    for value in ["foo", 12, 13.9827]:
+        assert treeutil.is_container(value) is False

--- a/asdf/tests/test_util.py
+++ b/asdf/tests/test_util.py
@@ -1,0 +1,15 @@
+from asdf import util
+
+
+def test_is_primitive():
+    for value in [None, "foo", 1, 1.39, 1 + 1j, True]:
+        assert util.is_primitive(value) is True
+
+    for value in [[], tuple(), {}, set()]:
+        assert util.is_primitive(value) is False
+
+
+def test_not_set():
+    assert util.NotSet != None
+
+    assert repr(util.NotSet) == "NotSet"

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -10,6 +10,9 @@ import warnings
 from .tagged import tag_object
 
 
+__all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container"]
+
+
 def walk(top, callback):
     """
     Walking through a tree of objects, calling a given function at
@@ -204,3 +207,46 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False):
         return recurse_with_json_ids(top, None)
     else:
         return recurse(top)
+
+
+def get_children(node):
+    """
+    Retrieve the children (and their dict keys or list/tuple indices) of
+    an ASDF tree node.
+
+    Parameters
+    ----------
+    node : object
+        an ASDF tree node
+
+    Returns
+    -------
+    list of (object, object) tuples
+        list of (identifier, child node) tuples, or empty list if the
+        node has no children (either it is an empty container, or is
+        a non-container type)
+    """
+    if isinstance(node, dict):
+        return list(node.items())
+    elif isinstance(node, list) or isinstance(node, tuple):
+        return list(enumerate(node))
+    else:
+        return []
+
+
+def is_container(node):
+    """
+    Determine if an ASDF tree node is an instance of a "container" type
+    (i.e., value may contain child nodes).
+
+    Parameters
+    ----------
+    node : object
+        an ASDF tree node
+
+    Returns
+    -------
+    bool
+        True if node is a container, False otherwise
+    """
+    return isinstance(node, dict) or isinstance(node,list) or isinstance(node, tuple)

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -16,7 +16,8 @@ from .extern.decorators import add_common_docstring
 
 
 __all__ = ['human_list', 'get_array_base', 'get_base_uri', 'filepath_to_url',
-           'iter_subclasses', 'calculate_padding', 'resolve_name']
+           'iter_subclasses', 'calculate_padding', 'resolve_name', 'NotSet',
+           'is_primitive']
 
 
 def human_list(l, separator="and"):
@@ -395,3 +396,39 @@ class InheritDocstrings(type):
                         break
 
         super(InheritDocstrings, cls).__init__(name, bases, dct)
+
+
+class _NotSetType:
+    def __repr__(self):
+        return "NotSet"
+
+
+"""
+Special value indicating that a parameter is not set.  Distinct
+from None, which may for example be a value of interest in a search.
+"""
+NotSet = _NotSetType()
+
+
+def is_primitive(value):
+    """
+    Determine if a value is an instance of a "primitive" type.
+
+    Parameters
+    ----------
+    value : object
+        the value to test
+
+    Returns
+    -------
+    bool
+        True if the value is primitive, False otherwise
+    """
+    return (
+        value is None
+        or isinstance(value, bool)
+        or isinstance(value, int)
+        or isinstance(value, float)
+        or isinstance(value, complex)
+        or isinstance(value, str)
+    )

--- a/docs/asdf/asdf_tool.rst
+++ b/docs/asdf/asdf_tool.rst
@@ -17,6 +17,8 @@ useful operations:
   - ``remove-hdu``: Remove ASDF extension from ASDF-in-FITS file (requires
     `astropy`, see :ref:`asdf-in-fits`).
 
+  - ``info``: Print a rendering of an ASDF tree.
+
   - ``extensions``: Show information about installed extensions (see
     :ref:`other_packages`).
 

--- a/docs/asdf/user_api.rst
+++ b/docs/asdf/user_api.rst
@@ -1,7 +1,9 @@
 ********
-User API 
+User API
 ********
 
 .. automodapi:: asdf
     :include-all-objects:
     :inherited-members:
+
+.. automodapi:: asdf.search


### PR DESCRIPTION
This adds:

- `asdf.info(...)` for displaying a summary rendering of an ASDF tree in the console
- `asdftool info` subcommand that displays the same rendering from the commandline
- `AsdfFile.search(...)` for interactively searching an ASDF tree

Resolves #644 