### PR TITLE
Remove six dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 
 - AsdfDeprecationWarning now subclasses DeprecationWarning. [#710]
 
+- Remove unnecessary dependency on six. [#739]
+
 2.5.1 (2020-01-07)
 ------------------
 

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -6,7 +6,6 @@ import abc
 import warnings
 from pkg_resources import iter_entry_points
 
-import six
 import importlib
 
 from . import types
@@ -23,8 +22,7 @@ __all__ = ['AsdfExtension', 'AsdfExtensionList']
 ASDF_TEST_BUILD_ENV = 'ASDF_TEST_BUILD'
 
 
-@six.add_metaclass(abc.ABCMeta)
-class AsdfExtension:
+class AsdfExtension(metaclass=abc.ABCMeta):
     """
     Abstract base class defining an extension to ASDF.
     """

--- a/asdf/extern/atomicfile.py
+++ b/asdf/extern/atomicfile.py
@@ -1,5 +1,3 @@
-import six
-
 import os
 import tempfile
 import sys

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -25,8 +25,6 @@ import http.client
 from urllib import parse as urlparse
 from urllib.request import url2pathname
 
-import six
-
 import numpy as np
 
 from . import util
@@ -257,8 +255,7 @@ class _TruncatedReader:
         return content
 
 
-@six.add_metaclass(util.InheritDocstrings)
-class GenericFile:
+class GenericFile(metaclass=util.InheritDocstrings):
     """
     Base class for an abstraction layer around a number of different
     file-like types.  Each of its subclasses handles a particular kind
@@ -1096,7 +1093,7 @@ def get_uri(file_obj):
     ----------
     uri : object
     """
-    if isinstance(file_obj, six.string_types):
+    if isinstance(file_obj, str):
         return file_obj
     if isinstance(file_obj, GenericFile):
         return file_obj.uri

--- a/asdf/tests/coveragerc
+++ b/asdf/tests/coveragerc
@@ -28,7 +28,3 @@ exclude_lines =
 
    # Don't complain about script hooks
    def main\(.*\):
-
-   # Ignore branches that don't pertain to this version of Python
-   pragma: py{ignore_python_version}
-   six.PY{ignore_python_version}

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -7,7 +7,6 @@ import warnings
 import importlib
 from collections import defaultdict
 
-import six
 from copy import copy
 
 from . import tagged
@@ -489,16 +488,14 @@ class ExtensionType:
         return AsdfSubclassProperty(attribute)
 
 
-@six.add_metaclass(AsdfTypeMeta)
-class AsdfType(ExtensionType):
+class AsdfType(ExtensionType, metaclass=AsdfTypeMeta):
     """
     Base class for all built-in ASDF types. Types that inherit this class will
     be automatically added to the list of built-ins. This should *not* be used
     for user-defined extensions.
     """
 
-@six.add_metaclass(ExtensionTypeMeta)
-class CustomType(ExtensionType):
+class CustomType(ExtensionType, metaclass=ExtensionTypeMeta):
     """
     Base class for all user-defined types.
     """

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -366,9 +366,7 @@ class InheritDocstrings(type):
     For example::
 
         >>> from asdf.util import InheritDocstrings
-        >>> import six
-        >>> @six.add_metaclass(InheritDocstrings)
-        ... class A:
+        >>> class A(metaclass=InheritDocstrings):
         ...     def wiggle(self):
         ...         "Wiggle the thingamajig"
         ...         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
     semantic_version>=2.8
     pyyaml>=3.10
     jsonschema>=2.3,<4
-    six>=1.9.0
     numpy>=1.8
 
 [options.extras_require]


### PR DESCRIPTION
This removes our dependency on six, which shouldn't be necessary since we dropped Python 2 support.

Resolves https://github.com/spacetelescope/asdf/issues/724