### PR TITLE
Clean up tox and travis configs, add new builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,109 +1,108 @@
-# We set the language to c because python isn't supported on the MacOS X nodes
-# on Travis. However, the language ends up being irrelevant anyway, since we
-# install Python ourselves using conda.
-language: c
-
-os:
-    - linux
-
+os: linux
+language: python
+python: 3.8
 # Use Travis' container-based architecture
 sudo: false
 
-addons:
-  apt:
-    packages:
-    - graphviz
-    - texlive-latex-extra
-    - dvipng
-
-env:
-    global:
-        # The following versions are the 'default' for tests, unless
-        # overidden underneath. They are defined here in order to save having
-        # to repeat them for all configurations.
-        - TOX_CMD='tox --'
-        - TOX_ARGS='--remote-data'
-        # This is the Python version that will be used by the parent conda
-        # environment, but it will not be used in the test environments
-        # themselves.
-        - PYTHON_VERSION=3.6
-
-    matrix:
-        # Make sure that installation does not fail
-        - TOXENV='py36-stable' TOX_CMD='tox --notest' TOX_ARGS=''
-        # Make sure README will display properly on pypi
-        - TOXENV='checkdocs'
-        - TOXENV='py35-stable'
-        - TOXENV='py36-stable'
-        - TOXENV='py37-stable'
-
 matrix:
-    fast_finish: true
-    include:
+  include:
+    # Python 3.8, stable dependencies
+    - env: TOXENV=py38
 
-        # Do a coverage test
-        - env: TOXENV='coverage' TOX_ARGS=''
+    # Python 3.7, stable dependencies
+    - env: TOXENV=py37
+      python: 3.7
 
-        # Perform a sanity check of packaging using twine
-        - env: TOXENV='twine' TOX_ARGS=''
+    # Python 3.6, stable dependencies
+    - env: TOXENV=py36
+      python: 3.6
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
-        - env: TOXENV='docbuild' TOX_ARGS=''
+    # Python 3.5, stable dependencies
+    - env: TOXENV=py35
+      python: 3.5
 
-        # Do a code style check
-        - env: TOXENV='style' TOX_ARGS=''
+    # Do a coverage test
+    - env: TOXENV=coverage
 
-        # try older numpy versions
-        - env: TOXENV='py35-numpy11'
-        - env: TOXENV='py36-numpy12'
+    # Perform a sanity check of packaging using twine
+    - env: TOXENV=twine
 
-        # test against oldest compatible versions of all dependencies
-        - env: TOXENV='py35-legacy'
+    # Make sure README will display properly on pypi
+    - env: TOXENV=checkdocs
 
-        # also test against development versions of Astropy and GWCS
-        - env: TOXENV='py37-astrodev'
+    # Check for sphinx doc build warnings
+    - env: TOXENV=docbuild
+      addons:
+        apt:
+          packages:
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
 
-        # Test against development version of numpy (this job can fail)
-        - env: TOXENV='py37-numpydev'
+    # Do a code style check
+    - env: TOXENV=style
 
-        # Test against prerelease versions of all dependencies
-        - env: TOXENV='prerelease'
+    # Check older numpy versions
+    - env: TOXENV=py35-numpy11
+      python: 3.5
 
-        # Test against an installed asdf package
-        - env: TOXENV='packaged'
+    - env: TOXENV=py36-numpy12
+      python: 3.6
 
-        # Try a run on OSX
-        - os: osx
-          env: TOXENV='py37-stable'
+    # Test against oldest compatible versions of all dependencies
+    - env: TOXENV=py35-legacy
+      python: 3.5
 
-        - os: windows
-          env: TOXENV='py37-stable' TOX_ARGS='--remote-data'
+    # Test against development version of Astropy
+    - env: TOXENV=py38-astropydev
 
-        - os: windows
-          env: TOXENV='py35-stable'
+    # Test against development version of GWCS
+    - env: TOXENV=py38-gwcsdev
 
-        - os: windows
-          env: TOXENV='py36-stable' TOX_ARGS='--remote-data'
+    # Test against development version of numpy (allowed failure)
+    - env: TOXENV=py38-numpydev
 
-        # Windows test against development version of numpy (this job can fail)
-        - os: windows
-          env: TOXENV='py37-numpydev'
+    # Test against prerelease versions of all dependencies (allowed failure)
+    - env: TOXENV=prerelease
 
+    # Test against an installed asdf package
+    - env: TOXENV=packaged
 
-    allow_failures:
-        # There doesn't appear to be a stable version of numpy available for
-        # Py37 on Windows at the moment
-        - os: windows
-          env: TOXENV='py37-stable' TOX_ARGS='--remote-data'
-        - env: TOXENV='py37-numpydev'
-        - env: TOXENV='prerelease'
+    # Test on OS X
+    - env:
+        - TOXENV=py38
+        - PATH=/usr/local/opt/python@3.8/bin:$PATH
+        # As of 2020-01-24, homebrew on Travis requires an update
+        # to make Python 3.8 available.
+        # - HOMEBREW_NO_AUTO_UPDATE=1
+        - HOMEBREW_NO_INSTALL_CLEANUP=1
+      os: osx
+      language: shell
+      before_install:
+        - brew install python@3.8
 
-install:
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda.sh
-    - conda install openssl
-    - pip install tox tox-conda>=0.2
+    # Test on Windows
+    - env:
+        - TOXENV=py38
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+      os: windows
+      language: shell
+      before_install:
+        - choco install python --version=3.8
 
-script:
-   - $TOX_CMD $TOX_ARGS
+    # Test on big-endian platform.  Currently an allowed failure due to
+    # https://github.com/spacetelescope/asdf/issues/235
+    - env: TOXENV=s390x
+      arch: s390x
+
+  allow_failures:
+    - env: TOXENV=s390x
+      arch: s390x
+
+    - env: TOXENV=prerelease
+
+    - env: TOXENV=py38-numpydev
+
+install: pip install tox
+
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-envlist =
-    {py36,py37}-{stable,gwcsdev},py37-astrodev
-    py35-legacy
+envlist = py38,style
 
 [testenv]
 deps=
@@ -9,11 +7,14 @@ deps=
     pytest-sugar
     pytest-faulthandler
     pytest-openfiles>=0.3.2
-    astrodev: git+git://github.com/astropy/astropy
-    py35,py36: importlib_resources
-    py35-!astrodev,py36-!astrodev: gwcs~=0.9.1
-    py37-!astrodev: gwcs
+    astropydev: git+git://github.com/astropy/astropy
+    gwcsdev: git+git://github.com/spacetelescope/gwcs
     numpydev: git+git://github.com/numpy/numpy
+    py35,py36: importlib_resources
+    # Newer versions of gwcs require astropy 4.x, which
+    # isn't compatible with the older versions of numpy
+    # that we test with.
+    py35,py36: gwcs==0.9.1
     legacy: semantic_version==2.3.1
     legacy: pyyaml==3.10
     legacy: jsonschema==2.3
@@ -21,20 +22,23 @@ deps=
     numpy11,numpy12,legacy: astropy~=3.0.0
     numpy11: numpy==1.11
     numpy12: numpy==1.12
-    numpydev,astrodev: cython
-conda_channels=
-    conda-forge
+    numpydev,astrodev,s390x: cython
 extras= all,tests
 commands=
-    astrodev: pip install --no-deps git+git://github.com/spacetelescope/gwcs
-    pytest {posargs}
+    pytest --remote-data
+
+[testenv:s390x]
+# As of 2020-01-23, The s390x container on Travis has a bug where
+# /home/travis/.cache/pip/wheels is owned by root, which prevents
+# us from installing packages unless we disable caching.
+install_command= python -m pip install --no-cache-dir {opts} {packages}
 
 [testenv:prerelease]
-basepython= python3.7
+basepython= python3.8
 pip_pre= true
 
 [testenv:packaged]
-basepython= python3.7
+basepython= python3.8
 # The default tox working directory is in .tox in the source directory.  If we
 # execute pytest from there, it will discover tox.ini in the source directory
 # and load the asdf module from the unpackaged sourcee, which is not what we
@@ -42,29 +46,27 @@ basepython= python3.7
 # so this will allow us to test the installed package.
 changedir= {homedir}
 commands=
-    pytest --pyargs asdf
+    pytest --pyargs asdf --remote-data
 
 [testenv:egg_info]
 deps=
-conda_deps=
 commands=
     python setup.py egg_info
 
 [testenv:twine]
 deps=
     twine
-conda_deps=
 commands=
     twine check {distdir}/*
 
 [testenv:docbuild]
-basepython= python3.6
+basepython= python3.8
 extras= docs
 commands=
     sphinx-build -W docs build/docs
 
 [testenv:checkdocs]
-basepython= python3.6
+basepython= python3.8
 deps=
     collective.checkdocs
     pygments
@@ -72,14 +74,14 @@ commands=
     python setup.py checkdocs
 
 [testenv:style]
-basepython= python3.6
+basepython= python3.8
 deps=
     flake8
 commands=
     flake8 asdf --count
 
 [testenv:coverage]
-basepython= python3.7
+basepython= python3.8
 deps=
     gwcs
     pytest<5.1


### PR DESCRIPTION
Changes:

- Drop conda from the Travis environment.  It's not compatible with s390x, and anyway installing it slows the builds considerably.
- Add s390x to the included builds, to support troubleshooting #235 and prevent regressions in the future.
- Upgrade most builds to Python 3.8
- Move Windows out of allowed failures

I also confirmed that at least one build is running with Astropy 4.0 and numpy 1.18.x.

Resolves #717 