### PR TITLE
Update setup.cfg minimum Python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,15 +11,13 @@ github_project = spacetelescope/asdf
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Development Status :: 5 - Production/Stable
 
 [options]
-python_requires= >=3.3
+python_requires= >=3.5
 setup_requires = setuptools_scm
 packages =
     asdf


### PR DESCRIPTION
Looks like asdf doesn't even install on Python < 3.5, so setup.cfg should reflect that.