### PR TITLE
Fix tests on s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,15 +90,11 @@ matrix:
       before_install:
         - choco install python --version=3.8
 
-    # Test on big-endian platform.  Currently an allowed failure due to
-    # https://github.com/spacetelescope/asdf/issues/235
+    # Test on big-endian platform
     - env: TOXENV=s390x
       arch: s390x
 
   allow_failures:
-    - env: TOXENV=s390x
-      arch: s390x
-
     - env: TOXENV=prerelease
 
     - env: TOXENV=py38-numpydev

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -219,7 +219,7 @@ def test_table(tmpdir):
     table = np.array(
         [(0, 1, (2, 3)), (4, 5, (6, 7))],
         dtype=[(str('MINE'), np.int8),
-               (str(''), np.float64),
+               (str(''), '<f8'),
                (str('arr'), '>i4', (2,))])
 
     tree = {'table_data': table}
@@ -245,8 +245,8 @@ def test_table(tmpdir):
 def test_table_nested_fields(tmpdir):
     table = np.array(
         [(0, (1, 2)), (4, (5, 6)), (7, (8, 9))],
-        dtype=[(str('A'), np.int64),
-               (str('B'), [(str('C'), np.int64), (str('D'), np.int64)])])
+        dtype=[(str('A'), '<i8'),
+               (str('B'), [(str('C'), '<i8'), (str('D'), '<i8')])])
 
     tree = {'table_data': table}
 

--- a/asdf/tests/test_array_blocks.py
+++ b/asdf/tests/test_array_blocks.py
@@ -350,7 +350,7 @@ def test_update_add_array_at_end(tmpdir):
     original_size = os.stat(path).st_size
 
     with asdf.open(os.path.join(tmpdir, "test.asdf"), mode="rw") as ff:
-        ff.tree['arrays'].append(np.arange(2048))
+        ff.tree['arrays'].append(np.arange(65536, dtype='<i8'))
         ff.update()
         assert len(ff.blocks) == 4
 
@@ -360,7 +360,7 @@ def test_update_add_array_at_end(tmpdir):
         assert_array_equal(ff.tree['arrays'][0], tree['arrays'][0])
         assert_array_equal(ff.tree['arrays'][1], tree['arrays'][1])
         assert_array_equal(ff.tree['arrays'][2], tree['arrays'][2])
-        assert_array_equal(ff.tree['arrays'][3], np.arange(2048))
+        assert_array_equal(ff.tree['arrays'][3], np.arange(65536, dtype='<i8'))
 
 
 def test_update_replace_all_arrays(tmpdir):
@@ -460,7 +460,7 @@ def test_checksum(tmpdir):
     tmpdir = str(tmpdir)
     path = os.path.join(tmpdir, 'test.asdf')
 
-    my_array = np.arange(0, 64, dtype=np.int64).reshape((8, 8))
+    my_array = np.arange(0, 64, dtype='<i8').reshape((8, 8))
     tree = {'my_array': my_array}
     ff = asdf.AsdfFile(tree)
     ff.write_to(path)
@@ -475,7 +475,7 @@ def test_checksum_update(tmpdir):
     tmpdir = str(tmpdir)
     path = os.path.join(tmpdir, 'test.asdf')
 
-    my_array = np.arange(0, 64, dtype=np.int64).reshape((8, 8))
+    my_array = np.arange(0, 64, dtype='<i8').reshape((8, 8))
 
     tree = {'my_array': my_array}
     ff = asdf.AsdfFile(tree)


### PR DESCRIPTION
These were mostly failing because dtypes default to the endian-ness of the host platform, and we were making assertions in tests assuming little-endian.  Branched off of #740, so we should merge that one first.

Resolves #235 