### PR TITLE
Add versioning documentation and tests, fix versioning issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ----------------
 
 - Add a developer overview document to help understand how ASDF works
-  internally. Still a work in progress. [#730] 
+  internally. Still a work in progress. [#730]
 
 - Add ``package`` property to extension metadata, and deprecate
   use of ``software``. [#728]
@@ -16,6 +16,10 @@
 
 - Add ``asdf.info`` for displaying a summary of a tree, and
   ``AsdfFile.search`` for searching a tree. [#736]
+
+- Add developer documentation on schema versioning, additional
+  schema and extension-related tests, and fix a variety of
+  issues in ``AsdfType`` subclasses.
 
 2.5.1 (2020-01-07)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@
 
 - Add developer documentation on schema versioning, additional
   schema and extension-related tests, and fix a variety of
-  issues in ``AsdfType`` subclasses.
+  issues in ``AsdfType`` subclasses. [#750]
 
 2.5.1 (2020-01-07)
 ------------------

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -7,9 +7,23 @@ from ...yamlutil import custom_tree_to_tagged_tree
 from ...exceptions import AsdfDeprecationWarning
 
 
-class AsdfObject(dict, AsdfType):
+class AsdfObject(dict):
+    pass
+
+
+class AsdfObjectType(AsdfType):
     name = 'core/asdf'
     version = '1.1.0'
+    supported_versions = {'1.0.0', '1.1.0'}
+    types = [AsdfObject]
+
+    @classmethod
+    def from_tree(cls, node, ctx):
+        return AsdfObject(node)
+
+    @classmethod
+    def to_tree(cls, data, ctx):
+        return dict(data)
 
 
 class Software(dict, AsdfType):

--- a/asdf/tags/core/complex.py
+++ b/asdf/tags/core/complex.py
@@ -9,6 +9,7 @@ from ... import util
 
 class ComplexType(AsdfType):
     name = 'core/complex'
+    version = '1.0.0'
     types = list(util.iter_subclasses(np.complexfloating)) + [complex]
 
     @classmethod

--- a/asdf/tags/core/constant.py
+++ b/asdf/tags/core/constant.py
@@ -16,12 +16,13 @@ class Constant:
 
 class ConstantType(AsdfType):
     name = 'core/constant'
+    version = '1.0.0'
     types = [Constant]
 
     @classmethod
-    def from_tree(self, node, ctx):
+    def from_tree(cls, node, ctx):
         return Constant(node)
 
     @classmethod
-    def to_tree(self, data, ctx):
+    def to_tree(cls, data, ctx):
         return data.value

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -215,6 +215,7 @@ def numpy_array_to_list(array):
 
 class NDArrayType(AsdfType):
     name = 'core/ndarray'
+    version = '1.0.0'
     types = [np.ndarray, ma.MaskedArray]
 
     def __init__(self, source, shape, dtype, offset, strides,

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -230,7 +230,7 @@ history:
 
 def test_metadata_with_custom_extension(tmpdir):
 
-    class FractionType(types.AsdfType):
+    class FractionType(types.CustomType):
         name = 'fraction'
         organization = 'nowhere.org'
         version = (1, 0, 0)

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -399,19 +399,19 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
         # but shares a tag with that class, so it isn't really a distinct type.
         return
 
-    assert extension_type.name is not None, f"{extension_type.__name__} must set the 'name' class attribute"
+    assert extension_type.name is not None, "{} must set the 'name' class attribute".format(extension_type.__name__)
 
     # Currently ExtensionType sets a default version of 1.0.0,
     # but we want to encourage an explicit version on the subclass.
-    assert "version" in extension_type.__dict__, f"{extension_type.__name__} must set the 'version' class attribute"
+    assert "version" in extension_type.__dict__, "{} must set the 'version' class attribute".format(extension_type.__name__)
 
     for check_type in extension_type.versioned_siblings + [extension_type]:
         schema_location = resolver(check_type.yaml_tag)
 
         assert schema_location is not None, (
-            f"{extension_type.__name__} supports tag, {check_type.yaml_tag}, "
-            "but tag does not resolve.  Check the tag_mapping and uri_mapping "
-            f"properties on the related extension ({extension.__name__})."
+            "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +
+            "but tag does not resolve.  Check the tag_mapping and uri_mapping " +
+            "properties on the related extension ({}).".format(extension_type.__name__)
         )
 
         try:
@@ -419,19 +419,19 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
                 schema = yaml.load(f.read())
         except Exception:
             assert False, (
-                f"{extension_type.__name__} supports tag, {check_type.yaml_tag}, "
-                f"which resolves to schema at {schema_location}, but "
+                "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +
+                "which resolves to schema at {}, but ".format(schema_location) +
                 "schema cannot be read."
             )
 
         assert "tag" in schema, (
-            f"{extension_type.__name__} supports tag, {check_type.yaml_tag}, "
-            f"but tag resolves to a schema at {schema_location} that is "
+            "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +
+            "but tag resolves to a schema at {} that is ".format(schema_location) +
             "missing its tag field."
         )
 
         assert schema["tag"] == check_type.yaml_tag, (
-            f"{extension_type.__name__} supports tag, {check_type.yaml_tag}, "
-            f"but tag resolves to a schema at {schema_location} that "
-            f"describes a different tag: {schema['tag']}"
+            "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +
+            "but tag resolves to a schema at {} that ".format(schema_location) +
+            "describes a different tag: {}".format(schema["tag"])
         )

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -1,0 +1,7 @@
+from asdf.extension import BuiltinExtension
+
+from asdf.tests.helpers import assert_extension_correctness
+
+def test_builtin_extension():
+    extension = BuiltinExtension()
+    assert_extension_correctness(extension)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -319,10 +319,15 @@ def test_version_mismatch_file():
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
     # This is the warning that we expect from opening the FITS file
-    assert len(w) == 1, display_warnings(w)
+    assert len(w) == 2, display_warnings(w)
     assert str(w[0].message) == (
         "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
-        "'{}', but latest supported version is 1.0.0".format(testfile))
+        "'{}', but latest supported version is 1.0.0".format(testfile)
+    )
+    assert str(w[1].message) == (
+        "'tag:stsci.edu:asdf/core/asdf' with version 1.0.0 found in file "
+        "'{}', but latest supported version is 1.1.0".format(testfile)
+    )
 
     # Make sure warning does not occur when warning is ignored (default)
     with pytest.warns(None) as w:
@@ -334,10 +339,15 @@ def test_version_mismatch_file():
         with fits_embed.AsdfInFits.open(testfile,
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
-    assert len(w) == 1
+    assert len(w) == 2
     assert str(w[0].message) == (
         "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
-        "'{}', but latest supported version is 1.0.0".format(testfile))
+        "'{}', but latest supported version is 1.0.0".format(testfile)
+    )
+    assert str(w[1].message) == (
+        "'tag:stsci.edu:asdf/core/asdf' with version 1.0.0 found in file "
+        "'{}', but latest supported version is 1.1.0".format(testfile)
+    )
 
     # Make sure warning does not occur when warning is ignored (default)
     with pytest.warns(None) as w:

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -5,7 +5,15 @@
 import pytest
 from itertools import combinations
 
-from asdf.versioning import AsdfVersion, AsdfSpec
+from asdf.versioning import (
+    AsdfVersion,
+    AsdfSpec,
+    supported_versions,
+    get_version_map,
+    join_tag_version,
+)
+from asdf.extension import default_extensions
+from asdf.schema import load_schema
 
 
 def test_version_constructor():
@@ -244,3 +252,50 @@ def test_spec_equal():
     assert (1, 1, 0) != spec
     assert spec == (1, 3, 0)
     assert (1, 3, 0) == spec
+
+
+@pytest.mark.parametrize("version", supported_versions)
+def test_version_map_core_support(version):
+    _test_version_map_support(version, "core")
+
+
+@pytest.mark.parametrize("version", supported_versions)
+@pytest.mark.xfail(
+    reason="astropy does not yet explicitly support older schema versions",
+    strict=True
+)
+def test_version_map_standard_support(version):
+    _test_version_map_support(version, "standard")
+
+
+def _test_version_map_support(version, schema_type):
+    vm = get_version_map(version)
+
+    type_index = default_extensions.extension_list.type_index
+    class MockContext:
+        def __init__(self):
+            self._fname = None
+    ctx = MockContext()
+
+    for tag_base, tag_version in vm[schema_type].items():
+        tag = join_tag_version(tag_base, tag_version)
+
+        try:
+            load_schema(tag)
+        except Exception:
+            assert False, (
+                f"ASDF Standard version {version} requires support for "
+                f"{tag}, but the corresponding schema cannot be loaded."
+            )
+
+        extension_type = type_index.from_yaml_tag(ctx, tag)
+        assert extension_type is not None, (
+            f"ASDF Standard version {version} requires support for "
+            f"{tag}, but no ExtensionType exists to support that tag."
+        )
+
+        assert extension_type.yaml_tag == tag, (
+            f"ASDF Standard version {version} requires support for "
+            f"{tag}, but no ExtensionType exists that explicitly "
+            "supports that version."
+        )

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -284,18 +284,18 @@ def _test_version_map_support(version, schema_type):
             load_schema(tag)
         except Exception:
             assert False, (
-                f"ASDF Standard version {version} requires support for "
-                f"{tag}, but the corresponding schema cannot be loaded."
+                "ASDF Standard version {} requires support for ".format(version) +
+                "{}, but the corresponding schema cannot be loaded.".format(tag)
             )
 
         extension_type = type_index.from_yaml_tag(ctx, tag)
         assert extension_type is not None, (
-            f"ASDF Standard version {version} requires support for "
-            f"{tag}, but no ExtensionType exists to support that tag."
+            "ASDF Standard version {} requires support for ".format(version) +
+            "{}, but no ExtensionType exists to support that tag.".format(tag)
         )
 
         assert extension_type.yaml_tag == tag, (
-            f"ASDF Standard version {version} requires support for "
-            f"{tag}, but no ExtensionType exists that explicitly "
+            "ASDF Standard version {} requires support for ".format(version) +
+            "{}, but no ExtensionType exists that explicitly ".format(tag) +
             "supports that version."
         )

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -163,7 +163,8 @@ class AsdfTypeMeta(ExtensionTypeMeta):
         cls = super(AsdfTypeMeta, mcls).__new__(mcls, name, bases, attrs)
         # Classes using this metaclass get added to the list of built-in
         # extensions
-        _all_asdftypes.add(cls)
+        if name != "AsdfType":
+            _all_asdftypes.add(cls)
 
         return cls
 

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -202,3 +202,8 @@ class VersionedMixin:
                 "Don't have information about version {0}".format(
                     self.version_string))
         return version_map
+
+
+# This is the ASDF Standard version at which the format of the history
+# field changed to include extension metadata.
+NEW_HISTORY_FORMAT_MIN_VERSION = AsdfVersion("1.1.0")

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -206,4 +206,4 @@ class VersionedMixin:
 
 # This is the ASDF Standard version at which the format of the history
 # field changed to include extension metadata.
-NEW_HISTORY_FORMAT_MIN_VERSION = AsdfVersion("1.1.0")
+NEW_HISTORY_FORMAT_MIN_VERSION = AsdfVersion("1.2.0")

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -322,11 +322,16 @@ def dump_tree(tree, fd, ctx):
     AsdfDumperTmp.ctx = ctx
 
     tags = None
-    if hasattr(tree, 'yaml_tag'):
-        tag = tree.yaml_tag
-        tag = tag[:tag.index('/core/asdf') + 1]
-        if tag.strip():
-            tags = {'!': tag}
+    tree_type = ctx.type_index.from_custom_type(type(tree))
+    if tree_type is not None:
+        tag_parts = tree_type.yaml_tag.split(':')
+        last_part = tag_parts[-1]
+        if '/' in last_part:
+            last_part = last_part[0:last_part.index('/') + 1]
+        else:
+            last_part = ''
+        yaml_tag = ':'.join(tag_parts[0:-1] + [last_part])
+        tags = {'!': yaml_tag}
 
     tree = custom_tree_to_tagged_tree(tree, ctx)
     schema.validate(tree, ctx)

--- a/docs/asdf/developer_versioning.rst
+++ b/docs/asdf/developer_versioning.rst
@@ -133,6 +133,11 @@ it proceeds as follows:
   and AsdfType are available for 1.1.0 and 1.3.0, it will
   use the 1.1.0 subclass.
 - If the above fails, use the earliest available AsdfType
+- If no AsdfType exists that supports any version of that tag,
+  then ASDF will deserialize the data into vanilla diff.
+
+The library does not currently emit a warning in either of the
+first two cases, but in the third case, a warning is emitted.
 
 The rules for selecting an AsdfType for a given tag are implemented
 by ``asdf.type_index.AsdfTypeIndex.fix_yaml_tag``.
@@ -142,6 +147,10 @@ to the ASDF Standard version in use, which dictates the subset of
 schema versions that are available.  From the subset of AsdfType
 subclasses that handle those schema versions, it selects the subclass
 that is able to handle the type of the core object being serialized.
+
+If an object is not supported by an AsdfType, its serialization will be
+handled by pyyaml.  If pyyaml doesn't know how to serialize, it will
+raise ``yaml.representer.RepresenterError``.
 
 The rules for selecting an AsdfType for a given serializable object
 are implemented by ``asdf.type_index.AsdfTypeIndex.from_custom_type``.

--- a/docs/asdf/developer_versioning.rst
+++ b/docs/asdf/developer_versioning.rst
@@ -1,0 +1,253 @@
+Schema Versioning and You
+=========================
+
+Here we'll explore ASDF schema versioning, and walk through the process
+of supporting new and updated schemas with AsdfType subclasses.
+
+ASDF versioning conventions
+---------------------------
+
+The ASDF Standard document provides a helpful overview_ of the various ASDF
+versioning conventions.  We will be concerned with the *standard version*
+and individual *schema versions*.
+
+.. _overview: https://asdf-standard.readthedocs.io/en/latest/versioning.html
+
+Overview
+--------
+
+The "standard version" or "ASDF Standard version" refers to the subset
+of individual schema versions that correspond to a specific release version
+of the ASDF Standard.  The list of schemas and versions is maintained in
+version_map files in the asdf-standard repository.  For example,
+version_map-1.3.0.yaml contains a list of all schema versions that
+we must handle in order to fully support version 1.3.0 of the ASDF
+Standard.  This list contains both "core" schemas and non-core schemas.
+The distinction there is that core schemas are supported by this library,
+while the others are supported by some external Python library,
+such as astropy.
+
+Our support for specific versions of the ASDF core schemas is implemented
+with AsdfType subclasses.  We'll discuss these more later, but
+for now the important thing to know is that each AsdfType class
+identifies the schema name and version(s) that it supports.  Any core
+schema objects that lack this support will not serialize or deserialize
+properly.
+
+When reading an ASDF file, the standard version doesn't play a
+significant role.  The schema of each core object is self-described
+by a YAML tag, which will be used to deserialize the object even
+if that tag conflicts with the overall standard version of the file.
+The library will use the tag to identify the most appropriate
+AsdfType to deserialize the object.
+
+On write, the situation is different.  The library may have a choice
+in which schema and/or AsdfType to use when serializing
+a given core object -- if multiple versions of the same schema
+are present, which shall we choose?  Here the standard version
+becomes important.  The schema version selected is specified by
+the version map of the standard version that the file is being
+written under.
+
+By default, the standard version used for writes is the latest
+offered, but users may override with another version.
+
+Implementation details
+----------------------
+
+Supported ASDF standard version list
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The list of supported ASDF standard versions is maintained in
+``asdf.versioning.supported_versions``.  The default version,
+``asdf.versioning.default_version``, is applied whenever a user declines to
+specify the standard version of a new file, and is set to the latest
+supported version.
+
+AsdfType
+~~~~~~~~
+
+In this library, each core schema is handled by a distinct
+``asdf.types.AsdfType`` subclass.  The AsdfType subclass is responsible
+for identifying the base name of its schema and the schema version(s)
+that it supports.  It also provides any custom serialization/deserialization
+behavior that is required -- AsdfType provides a default
+implementation that is only able to get and set attributes on dict-like
+objects.
+
+In some cases, the AsdfType subclass also serves as the deserialized
+object type.  For example, ``asdf.types.core.Software`` subclasses both
+AsdfType and dict.  Its AsdfType-like behavior is
+to identify its schema and version, while its dict-like behavior is
+to act as a container for the attributes described by the schema.  The class
+definition is mostly empty because as a dict it can rely on
+AsdfType's default implementation for (de)serialization.
+
+Meanwhile, other AsdfType subclasses deserialize ASDF objects
+into instances of entirely separate classes.  For example,
+``asdf.types.core.complex.ComplexType`` handles complex number types,
+which aren't natively supported by YAML.  ComplexType includes
+an additional class attribute, ``types``, that lists the types that
+it is able to handle.  It also provides custom implementations
+of the ``to_tree`` and ``from_tree`` class methods, which enable it to
+serialize a complex value into the appropriate string, and later
+rebuild the complex value from that string.  This additional code is
+necessary because ComplexType does not (de)serialize itself.
+
+We won't find an explicit list of AsdfType subclasses
+in the code; that list is assembled at runtime by AsdfType's
+metaclass, ``asdf.types.AsdfTypeMeta``.  The list can be inspected in
+the console like so:
+
+.. code-block:: pycon
+
+    >>> import asdf
+    >>> asdf.types._all_asdftypes # doctest: +SKIP
+    ...
+
+The AsdfType class attributes relevant to versioning are as follows:
+
+- *name*: the base name of the schema, without its version string.
+  For example, a schema located at
+  ``asdf-standard/schemas/stsci.edu/asdf/core/example-1.2.0.yaml`` will
+  have a name value of ``"core/example"``.
+
+- *version*: the primary schema version supported by the AsdfType.
+  For the example above, version should be set to ``"1.2.0"``.  This should
+  be the latest version that the AsdfType supports.
+
+- *supported_versions*: a set of schema versions that the AsdfType
+  supports.  In the above example, this might be
+  ``{"1.0.0", "1.1.0", "1.2.0"}``.
+
+AsdfType selection rules
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+On read, the library will ideally be able to identify an AsdfType
+subclass that explicitly supports a given tag (either in the ``version``
+class attribute or ``supported_versions``.  If that is not possible,
+it proceeds as follows:
+
+- Use the AsdfType that supports the latest version that is
+  less than the tag version.  For example, if the tag is example-1.2.0,
+  and AsdfType are available for 1.1.0 and 1.3.0, it will
+  use the 1.1.0 subclass.
+- If the above fails, use the earliest available AsdfType
+
+The rules for selecting an AsdfType for a given tag are implemented
+by ``asdf.type_index.AsdfTypeIndex.fix_yaml_tag``.
+
+On write, the library will read the version map that corresponds
+to the ASDF Standard version in use, which dictates the subset of
+schema versions that are available.  From the subset of AsdfType
+subclasses that handle those schema versions, it selects the subclass
+that is able to handle the type of the core object being serialized.
+
+The rules for selecting an AsdfType for a given serializable object
+are implemented by ``asdf.type_index.AsdfTypeIndex.from_custom_type``.
+
+Implementing updates to the standard
+------------------------------------
+
+Let's assume that there is a new standard version, 2.0.0, which
+includes one entirely new core schema, ``core/new_object-1.0.0.yaml``,
+one backwards-compatible update to an existing schema,
+``core/updated_object-1.1.0.yaml``, and one breaking change to an
+existing schema, ``core/breaking_object-2.0.0.yaml``.  The following
+sections walk through the steps we'll need to take to support
+this new material.
+
+Update the asdf-standard submodule commit pointer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The asdf-standard repository is integrated into the asdf repository
+as a submodule.  To pull in new commits from the remote master (
+assumed to be named ``origin``:
+
+.. code-block:: console
+
+    $ cd asdf-standard
+    $ git fetch origin
+    $ git checkout origin/master
+
+Support the new standard version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The list can be found in ``asdf.versioning.supported_versions``.
+Add ``AsdfVersion("2.0.0")`` to the end of the list
+(maintaining the sort order).  This new version will become the default
+for new files, but we can update the definition of
+``asdf.versioning.default_version`` if that is undesirable.
+
+Support the new schema
+~~~~~~~~~~~~~~~~~~~~~~
+
+Schemas for previously unsupported objects are straightforward, since
+we don't need to worry about compatibility issues.  Create a new
+AsdfType subclass with ``name`` and ``version`` set appropriately:
+
+.. code-block:: python
+
+    class NewObjectType(AsdfType):
+        name = "core/new_object"
+        version = "1.0.0"
+
+In a real-life scenario, we'd need to actually support (de)serialization
+in some way, but those details are beyond the scope of this document.
+
+Support the backwards-compatible schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since our updated_object-1.1.0.yaml schema is backwards-compatible,
+we can share the same AsdfType subclass between it and the previous
+version.  Presumably there exists an AsdfType that looks something
+like this:
+
+.. code-block:: python
+
+    class UpdatedObjectType(AsdfType):
+        name = "core/updated_object"
+        version = "1.0.0"
+
+We'll need to update the version, and list 1.0.0 as a supported
+version, so that this class can continue to handle it:
+
+.. code-block:: python
+
+    class UpdatedObjectType(AsdfType):
+        name = "core/updated_object"
+        version = "1.1.0"
+        supported_versions = {"1.0.0", "1.1.0"}
+
+Support the breaking schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The schema with breaking changes, core/breaking_object-2.0.0.yaml,
+may not be easily supported by the same AsdfType as the previous
+version.  In that case, we can create a new AsdfType for 2.0.0,
+and as long as the two subclasses have distinct ``version`` values
+and non-overlapping ``supported_versions`` sets, they should coexist
+peaceably.
+
+If this is the existing AsdfType:
+
+.. code-block:: python
+
+    class BreakingObjectType(AsdfType):
+        name = "core/breaking_object"
+        version = "1.0.0"
+
+The new AsdfType might look something like this:
+
+.. code-block:: python
+
+    class BreakingObjectType2(AsdfType):
+        name = "core/breaking_object"
+        version = "2.0.0"
+
+**CAUTION:** We might be tempted here to simply update the original
+BreakingObjectType, but failing to handle an older version of the schema
+constitutes dropping support for any ASDF Standard version that relies
+on that schema.  This should only be done after a deprecation period and
+with a major version release of the library, since files written by an
+older release will not be readable by the new code.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,13 +48,14 @@ API Documentation
 Developer Overview
 ==================
 
-Currently a work in progress. Intended to give an overview of how the various 
+Currently a work in progress. Intended to give an overview of how the various
 parts of ASDF interact and which modules do what and how.
 
 .. toctree::
   :maxdepth: 1
 
   asdf/developer_overview
+  asdf/developer_versioning
 
 Contributing and reporting issues
 =================================

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -115,7 +115,7 @@ class AsdfSchemaExampleItem(pytest.Item):
 
     def _find_standard_version(self, name, version):
         from asdf import versioning
-        for sv in versioning.supported_versions:
+        for sv in reversed(versioning.supported_versions):
             map_version = versioning.get_version_map(sv)['tags'].get(name)
             if map_version is not None and version == map_version:
                 return sv


### PR DESCRIPTION
This PR updates the asdf-standard pointer to latest master, and adds some tests to ensure that each of the ASDF Standard versions are fully supported.  Happily, only one of the core schemas was updated since 1.0.0.  Here's a summary of the changes:

- Fix handling of history entries for ASDF Standard 1.0.0.  Previously we had claimed to support 1.0.0, but bugs in the `AsdfType` subclass definitions resulted in corrupted 1.0.0-ish files being written.  Probably we should drop this version of the standard in library 3.0.
- Separate `AsdfObjectType` from `AsdfObject`.  This is the one core schema that received an update, and it turns out the library doesn't gracefully handle `AsdfType` classes that support multiple versions and (de)serialize themselves.  I think we should separate the `AsdfType` from the serialized class in all cases, but I'll open a separate issue to discuss that.
- Add explicit versions to all `AsdfType` subclasses.  There is a default 1.0.0, but I think it's safer to be explicit -- relying on the default is what got us into trouble with CompoundModel serialization.  I'll open an additional issue to consider deprecating the defaults so that users are forced to set a version.
- Fix an issue in a test where a new AsdfType was registered, which caused heisenbugs in downstream tests.
- Fix the yaml_to_asdf test helper, which conflated the ASDF file version with the standard version, and did not correctly set the tree's tag for all standard versions.
- Change schema validator to use the latest standard version that supports the tested schema (instead of the earliest).
- Add a new `test_extension_correctness` test helper that checks an extension's types for the correct features (version, name, etc) and confirms that the extension is able to resolve each type's schema.  We should be able to use this helper in gwcs and astropy.
- Test `BuiltinExtension` with the new helper
- Add tests for each of the supported ASDF Standard versions that confirm availability of the standard's component schemas, and confirms that an `AsdfType` exists to support each schema.  These tests pass for the core schemas, but are xfail'ed for the "standard" schemas that are supported by astropy, which hasn't been updated yet.
- Exclude `AsdfType` itself from `BuiltinExtension`'s types, as it is an abstract base class with no schema and can't actually be written to an ASDF file.
- Generalize the code that dumps trees to YAML, which previously had only set a tag namespace when the tree was a self-serializing ASDF core object.
- Add a new documentation page on the joys of versioning
