### PR TITLE
Update asdf-standard pointer to add missing 1.4.0 schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-2.6 (unreleased)
-----------------
+2.6.0 (unreleased)
+------------------
 
 - Add a developer overview document to help understand how ASDF works
   internally. Still a work in progress. [#730]
@@ -17,6 +17,12 @@
 - Add developer documentation on schema versioning, additional
   schema and extension-related tests, and fix a variety of
   issues in ``AsdfType`` subclasses. [#750]
+
+2.5.2 (unreleased)
+------------------
+
+- Update asdf-standard to include schemas that were previously
+  missing from 1.4.0 version maps.  [#???]
 
 2.5.1 (2020-01-07)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@
 ------------------
 
 - Update asdf-standard to include schemas that were previously
-  missing from 1.4.0 version maps.  [#???]
+  missing from 1.4.0 version maps.  [#764]
 
 2.5.1 (2020-01-07)
 ------------------


### PR DESCRIPTION
This advances the asdf-standard commit pointer to the current master, which I'll use in the 2.5.2 release.