### PR TITLE
Fix generic_io read_blocks() reading past the requested size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Add pytest plugin option to skip warning when a tag is
   unrecognized. [#771]
+  
+- Fix generic_io `read_blocks()` reading past the requested size [#773]
 
 2.5.2 (2020-02-28)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@
 - Add pytest plugin option to skip warning when a tag is
   unrecognized. [#771]
   
-- Fix generic_io `read_blocks()` reading past the requested size [#773]
+- Fix generic_io ``read_blocks()`` reading past the requested size [#773]
 
 2.5.2 (2020-02-28)
 ------------------

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -359,6 +359,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
         i = 0
         for i in range(0, size - self._blksize, self._blksize):
             yield self.read(self._blksize)
+        i += self._blksize
         if i < size:
             yield self.read(size - i)
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -357,11 +357,9 @@ class GenericFile(metaclass=util.InheritDocstrings):
         object.
         """
         i = 0
-        for i in range(0, size - self._blksize, self._blksize):
-            yield self.read(self._blksize)
-        i += self._blksize
-        if i < size:
-            yield self.read(size - i)
+        for i in range(0, size, self._blksize):
+            thissize = min(self._blksize, size - i)
+            yield self.read(thissize)
 
     def write(self, content):
         self._fd.write(content)

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -356,7 +356,6 @@ class GenericFile(metaclass=util.InheritDocstrings):
         time.  The result is a generator where each value is a bytes
         object.
         """
-        i = 0
         for i in range(0, size, self._blksize):
             thissize = min(self._blksize, size - i)
             yield self.read(thissize)


### PR DESCRIPTION
Hi there,

I was looking at some anomalies in the lz4 decompression performance, which led me in a roundabout way to find this bug.  Basically, `GenericFile.read_blocks()` was reading more than the requested amount, causing the decompressor to start reading an extra compression block, the first int of which is the size of the compression block.  The lz4 decompressor would then allocate a `bytearray` of this size, which is zero-initialized.  So it was sometimes doing a `memset()` of up to 4 GB, which is a noticeable performance hit!  I think this could also have resulted in corrupted data reads, but that would require the "random" int value to be less than 4K (the file system block size).  I think all the other compressors were at similar risk, depending on how big their internal buffers were.

Thanks for developing this package, by the way—I've found it very useful for my work!