### PR TITLE
Update asdf-standard pointer and add version 1.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,11 @@
 
 - Add pytest plugin option to skip warning when a tag is
   unrecognized. [#771]
-  
+
 - Fix generic_io ``read_blocks()`` reading past the requested size [#773]
+
+- Add support for ASDF Standard 1.5.0, which includes several new
+  transform schemas. [#776]
 
 2.5.2 (2020-02-28)
 ------------------

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -164,10 +164,12 @@ supported_versions = [
     AsdfVersion('1.1.0'),
     AsdfVersion('1.2.0'),
     AsdfVersion('1.3.0'),
-    AsdfVersion('1.4.0')
+    AsdfVersion('1.4.0'),
+    AsdfVersion('1.5.0'),
 ]
 
-default_version = supported_versions[-1]
+# Version 1.5.0 is currently (2020-03-27) a work in progress.
+default_version = AsdfVersion('1.4.0')
 
 
 class VersionedMixin:


### PR DESCRIPTION
This PR updates the asdf-standard to latest master and adds support for version 1.5.0 (but doesn't promote it to the default version, yet).