### PR TITLE
Support (de)serialization of custom objects containing implicit references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@
 - Enable validation and serialization of previously unhandled numpy
   scalar types. [#778]
 
+- Fix handling of trees containing implicit internal references and
+  reference cycles.  Eliminate need to call ``yamlutil.custom_tree_to_tagged_tree``
+  and ``yamlutil.tagged_tree_to_custom_tree`` from extension code,
+  and allow ``ExtensionType`` subclasses to return generators. [#777]
+
 2.5.2 (2020-02-28)
 ------------------
 

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -128,7 +128,7 @@ class Reference(AsdfType):
         pass
 
 
-def find_references(tree, ctx, ignore_implicit_conversion=False):
+def find_references(tree, ctx):
     """
     Find all of the JSON references in the tree, and convert them into
     `Reference` objects.
@@ -139,7 +139,7 @@ def find_references(tree, ctx, ignore_implicit_conversion=False):
         return tree
 
     return treeutil.walk_and_modify(
-        tree, do_find, ignore_implicit_conversion=ignore_implicit_conversion)
+        tree, do_find, ignore_implicit_conversion=ctx._ignore_implicit_conversion)
 
 
 def resolve_references(tree, ctx, do_not_fill_defaults=False):
@@ -154,7 +154,8 @@ def resolve_references(tree, ctx, do_not_fill_defaults=False):
 
     tree = find_references(tree, ctx)
 
-    return treeutil.walk_and_modify(tree, do_resolve)
+    return treeutil.walk_and_modify(
+        tree, do_resolve, ignore_implicit_conversion=ctx._ignore_implicit_conversion)
 
 
 def make_reference(asdffile, path):

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 from ...types import AsdfType
-from ...yamlutil import custom_tree_to_tagged_tree
 
 
 class AsdfObject(dict):
@@ -49,7 +48,7 @@ class ExtensionMetadata(AsdfType):
     def to_tree(cls, node, ctx):
         tree = {}
         tree['extension_class'] = node.extension_class
-        tree['software'] = custom_tree_to_tagged_tree(node.software, ctx)
+        tree['software'] = node.software
 
         return tree
 

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -6,7 +6,6 @@ from numbers import Integral
 import numpy as np
 
 from ...types import AsdfType
-from ...yamlutil import custom_tree_to_tagged_tree
 
 
 class IntegerType(AsdfType):
@@ -82,7 +81,7 @@ class IntegerType(AsdfType):
 
         tree = dict()
         ctx.set_array_storage(array, node._storage)
-        tree['words'] = custom_tree_to_tagged_tree(array, ctx)
+        tree['words'] = array
         tree['sign'] = node._sign
         tree['string'] = str(int(node._value))
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -442,8 +442,7 @@ class NDArrayType(AsdfType):
 
         if block.array_storage == 'inline':
             listdata = numpy_array_to_list(data)
-            result['data'] = yamlutil.custom_tree_to_tagged_tree(
-                listdata, ctx)
+            result['data'] = listdata
             result['datatype'] = dtype
         else:
             result['shape'] = list(shape)
@@ -464,8 +463,7 @@ class NDArrayType(AsdfType):
             if np.any(data.mask):
                 if block.array_storage == 'inline':
                     ctx.blocks.set_array_storage(ctx.blocks[data.mask], 'inline')
-                result['mask'] = yamlutil.custom_tree_to_tagged_tree(
-                    data.mask, ctx)
+                result['mask'] = data.mask
 
         return result
 

--- a/asdf/tests/data/fraction_with_inverse-1.0.0.yaml
+++ b/asdf/tests/data/fraction_with_inverse-1.0.0.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://nowhere.org/schemas/custom/fraction_with_inverse-1.0.0"
+title: An example custom type for handling fractions with inverses
+
+tag: "tag:nowhere.org:custom/fraction_with_inverse-1.0.0"
+type: object
+properties:
+  numerator:
+    type: integer
+  denominator:
+    type: integer
+  inverse:
+    $ref: fraction_with_inverse-1.0.0
+required: [numerator, denominator]
+...

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -319,15 +319,17 @@ def test_version_mismatch_file():
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
     # This is the warning that we expect from opening the FITS file
-    assert len(w) == 2, display_warnings(w)
-    assert str(w[0].message) == (
-        "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
-        "'{}', but latest supported version is 1.0.0".format(testfile)
-    )
-    assert str(w[1].message) == (
-        "'tag:stsci.edu:asdf/core/asdf' with version 1.0.0 found in file "
-        "'{}', but latest supported version is 1.1.0".format(testfile)
-    )
+    expected_messages = {
+        (
+            "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
+            "'{}', but latest supported version is 1.0.0".format(testfile)
+        ),
+        (
+            "'tag:stsci.edu:asdf/core/asdf' with version 1.0.0 found in file "
+            "'{}', but latest supported version is 1.1.0".format(testfile)
+        ),
+    }
+    assert expected_messages == {warn.message.args[0] for warn in w}, display_warnings(w)
 
     # Make sure warning does not occur when warning is ignored (default)
     with pytest.warns(None) as w:
@@ -339,15 +341,17 @@ def test_version_mismatch_file():
         with fits_embed.AsdfInFits.open(testfile,
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
-    assert len(w) == 2
-    assert str(w[0].message) == (
-        "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
-        "'{}', but latest supported version is 1.0.0".format(testfile)
-    )
-    assert str(w[1].message) == (
-        "'tag:stsci.edu:asdf/core/asdf' with version 1.0.0 found in file "
-        "'{}', but latest supported version is 1.1.0".format(testfile)
-    )
+    expected_messages = {
+        (
+            "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
+            "'{}', but latest supported version is 1.0.0".format(testfile)
+        ),
+        (
+            "'tag:stsci.edu:asdf/core/asdf' with version 1.0.0 found in file "
+            "'{}', but latest supported version is 1.1.0".format(testfile)
+        ),
+    }
+    assert expected_messages == {warn.message.args[0] for warn in w}, display_warnings(w)
 
     # Make sure warning does not occur when warning is ignored (default)
     with pytest.warns(None) as w:

--- a/asdf/tests/test_reference.py
+++ b/asdf/tests/test_reference.py
@@ -252,3 +252,24 @@ def test_internal_reference(tmpdir):
     ff = asdf.AsdfFile()
     content = asdf.AsdfFile()._open_impl(ff, buff, _get_yaml_content=True)
     assert b"{$ref: ''}" in content
+
+
+def test_implicit_internal_reference(tmpdir):
+    target = {"foo": "bar"}
+    nested_in_dict = {"target": target}
+    nested_in_list = [target]
+    tree = {"target": target, "nested_in_dict": nested_in_dict, "nested_in_list": nested_in_list}
+
+    assert tree["target"] is tree["nested_in_dict"]["target"]
+    assert tree["target"] is tree["nested_in_list"][0]
+
+    af = asdf.AsdfFile(tree)
+
+    assert af["target"] is af["nested_in_dict"]["target"]
+    assert af["target"] is af["nested_in_list"][0]
+
+    output_path = os.path.join(str(tmpdir), "test.asdf")
+    af.write_to(output_path)
+    with asdf.open(output_path) as af:
+        assert af["target"] is af["nested_in_dict"]["target"]
+        assert af["target"] is af["nested_in_list"][0]

--- a/asdf/tests/test_treeutil.py
+++ b/asdf/tests/test_treeutil.py
@@ -24,3 +24,27 @@ def test_is_container():
 
     for value in ["foo", 12, 13.9827]:
         assert treeutil.is_container(value) is False
+
+
+def test_walk_and_modify_shared_references():
+    target = {"foo": "bar"}
+    nested_in_dict = {"target": target}
+    nested_in_list = [target]
+    tree = {"target": target, "nested_in_dict": nested_in_dict, "nested_in_list": nested_in_list}
+
+    assert tree["target"] is tree["nested_in_dict"]["target"]
+    assert tree["target"] is tree["nested_in_list"][0]
+
+    def _callback(node):
+        if "foo" in node:
+            return {"foo": "baz"}
+        else:
+            return node
+
+    result = treeutil.walk_and_modify(tree, _callback)
+
+    assert result is not tree
+    assert result["target"] is not target
+    assert result["target"]["foo"] == "baz"
+    assert result["target"] is result["nested_in_dict"]["target"]
+    assert result["target"] is result["nested_in_list"][0]

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -248,8 +248,7 @@ def test_yaml_internal_reference(tmpdir):
     }
 
     def check_yaml(content):
-        assert b'list:--&id002-*id002' in b''.join(content.split())
-
+        assert b'list:&id002-*id002' in b''.join(content.split())
     helpers.assert_roundtrip_tree(tree, tmpdir, raw_yaml_check_func=check_yaml)
 
 

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -6,8 +6,10 @@ Utility functions for managing tree-like data structures.
 
 import inspect
 import warnings
+import types
+from contextlib import contextmanager
 
-from .tagged import tag_object
+from . import tagged
 
 
 __all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container"]
@@ -84,7 +86,128 @@ def iter_tree(top):
     return recurse(top)
 
 
-def walk_and_modify(top, callback, ignore_implicit_conversion=False):
+class _TreeModificationContext:
+    """
+    Context of a call to walk_and_modify, which includes a map
+    of already modified nodes, a list of generators to drain
+    before exiting the call, and a set of node object ids that
+    are currently pending modification.
+
+    Instances of this class are context managers that track
+    how many times they have been entered, and only drain
+    generators and reset themselves when exiting the outermost
+    context.  They are also collections that map unmodified
+    nodes to the corresponding modified result.
+    """
+    def __init__(self):
+        self._map = {}
+        self._generators = []
+        self._depth = 0
+        self._pending = set()
+
+    def add_generator(self, generator):
+        """
+        Add a generator that should be drained before exiting
+        the outermost call to walk_and_modify.
+        """
+        self._generators.append(generator)
+
+    def is_pending(self, node):
+        """
+        Return True if the node is already being modified.
+        This will not be the case unless the node contains a
+        reference to itself somewhere among its descendents.
+        """
+        return id(node) in self._pending
+
+    @contextmanager
+    def pending(self, node):
+        """
+        Context manager that marks a node as pending for the
+        duration of the context.
+        """
+        if id(node) in self._pending:
+            raise RuntimeError(
+                "Unhandled cycle in tree.  This is possibly a bug "
+                "in extension code, which should be yielding "
+                "nodes that may contain reference cycles."
+            )
+
+        self._pending.add(id(node))
+        try:
+            yield self
+        finally:
+            self._pending.remove(id(node))
+
+    def __enter__(self):
+        self._depth += 1
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._depth -= 1
+
+        if self._depth == 0:
+            # If we're back to 0 depth, then we're exiting
+            # the outermost context, so it's time to drain
+            # the generators and reset this object for next
+            # time.
+            if exc_type is None:
+                self._drain_generators()
+            self._generators = []
+            self._map = {}
+            self._pending = set()
+
+    def _drain_generators(self):
+        """
+        Drain each generator we've accumulated during this
+        call to walk_and_modify.
+        """
+        # Generator code may add yet more generators
+        # to the list, so we need to loop until the
+        # list is empty.
+        while len(self._generators) > 0:
+            generators = self._generators
+            self._generators = []
+            for generator in generators:
+                for _ in generator:
+                    # Subsequent yields of the generator should
+                    # always return the same value.  What we're
+                    # really doing here is executing the generator's
+                    # remaining code, to further modify that first
+                    # yielded object.
+                    pass
+
+    def __contains__(self, node):
+        return id(node) in self._map
+
+    def __getitem__(self, node):
+        return self._map[id(node)][1]
+
+    def __setitem__(self, node, result):
+        if id(node) in self._map:
+            # This indicates that an already defined
+            # modified node is being replaced, which is an
+            # error because it breaks references within the
+            # tree.
+            raise RuntimeError("Node already has an associated result")
+
+        self._map[id(node)] = (node, result)
+
+
+class _PendingValue:
+    """
+    Class of the PendingValue singleton instance.  The presence of the instance
+    in an asdf tree indicates that extension code is failing to handle
+    reference cycles.
+    """
+    def __repr__(self):
+        return "PendingValue"
+
+
+PendingValue = _PendingValue()
+
+
+def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=True, _context=None):
     """Modify a tree by walking it with a callback function.  It also has
     the effect of doing a deep copy.
 
@@ -106,8 +229,14 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False):
         The json id is the context under which any relative URLs
         should be resolved.  It may be `None` if no ids are in the file
 
-        The callback is called on an instance after all of its
-        children have been visited (depth-first order).
+        The tree is traversed depth-first, with order specified by the
+        ``postorder`` argument.
+
+    postorder : bool
+        Determines the order in which the callable is invoked on nodes of
+        the tree.  If `True`, the callable will be invoked on children
+        before their parents.  If `False`, the callable is invoked on the
+        parents first.  Defaults to `True`.
 
     ignore_implicit_conversion : bool
         Controls whether warnings should be issued when implicitly converting a
@@ -122,91 +251,162 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False):
         The modified tree.
 
     """
-    # For speed reasons, there are two different versions of the inner
-    # function
+    callback_arity = callback.__code__.co_argcount
+    if callback_arity < 1 or callback_arity > 2:
+        raise ValueError("Expected callback to accept one or two arguments")
 
-    seen = set()
-
-    def recurse(tree):
-        id_tree = id(tree)
-
-        if id_tree in seen:
-            return tree
-
-        if isinstance(tree, dict):
-            result = tree.__class__()
-            seen.add(id_tree)
-            for key, val in tree.items():
-                val = recurse(val)
-                if val is not None:
-                    result[key] = val
-            seen.remove(id_tree)
-            if hasattr(tree, '_tag'):
-                result = tag_object(tree._tag, result)
-        elif isinstance(tree, (list, tuple)):
-            seen.add(id_tree)
-            contents = [recurse(val) for val in tree]
-            try:
-                result = tree.__class__(contents)
-            except TypeError:
-                # the derived class' signature is different
-                # erase the type
-                result = contents
-            seen.remove(id_tree)
-            if hasattr(tree, '_tag'):
-                result = tag_object(tree._tag, result)
-        else:
-            result = tree
-
-        result = callback(result)
+    def _handle_generator(result):
+        # If the result is a generator, generate one value to
+        # extract the true result, then register the generator
+        # to be drained later.
+        if isinstance(result, types.GeneratorType):
+            generator = result
+            result = next(generator)
+            _context.add_generator(generator)
 
         return result
 
-    def recurse_with_json_ids(tree, json_id):
-        id_tree = id(tree)
-
-        if id_tree in seen:
-            return tree
-
-        if isinstance(tree, dict):
-            if 'id' in tree:
-                json_id = tree['id']
-            result = tree.__class__()
-            seen.add(id_tree)
-            for key, val in tree.items():
-                val = recurse_with_json_ids(val, json_id)
-                if val is not None:
-                    result[key] = val
-            seen.remove(id_tree)
-            if hasattr(tree, '_tag'):
-                result = tag_object(tree._tag, result)
-        elif isinstance(tree, (list, tuple)):
-            seen.add(id_tree)
-            contents = [recurse_with_json_ids(val, json_id) for val in tree]
-            try:
-                result = tree.__class__(contents)
-            except TypeError:
-                # The derived class signature is different, so simply store the
-                # list representing the contents. Currently this is primarly
-                # intended to handle namedtuple and NamedTuple instances.
-                if not ignore_implicit_conversion:
-                    msg = "Failed to serialize instance of {}, converting to list instead"
-                    warnings.warn(msg.format(type(tree)))
-                result = contents
-            seen.remove(id_tree)
-            if hasattr(tree, '_tag'):
-                result = tag_object(tree._tag, result)
+    def _handle_callback(node, json_id):
+        if callback_arity == 1:
+            result = callback(node)
         else:
-            result = tree
+            result = callback(node, json_id)
 
-        result = callback(result, json_id)
+        return _handle_generator(result)
+
+    def _handle_mapping(node, json_id):
+        result = node.__class__()
+        if isinstance(node, tagged.Tagged):
+            result._tag = node._tag
+
+        pending_items = {}
+        for key, value in node.items():
+            if _context.is_pending(value):
+                # The child node is pending modification, which means
+                # it must be its own ancestor.  Assign the special
+                # PendingValue instance for now, and note that we'll
+                # need to fill in the real value later.
+                pending_items[key] = value
+                result[key] = PendingValue
+            else:
+                value = _recurse(value, json_id)
+                if value is not None:
+                    result[key] = value
+
+        yield result
+
+        if len(pending_items) > 0:
+            # Now that we've yielded, the pending children should
+            # be available.
+            for key, value in pending_items.items():
+                value = _recurse(value, json_id)
+                if value is not None:
+                    result[key] = value
+                else:
+                    # The callback may have decided to delete
+                    # this node after all.
+                    del result[key]
+
+    def _handle_mutable_sequence(node, json_id):
+        result = node.__class__()
+        if isinstance(node, tagged.Tagged):
+            result._tag = node._tag
+
+        pending_items = {}
+        for i, value in enumerate(node):
+            if _context.is_pending(value):
+                # The child node is pending modification, which means
+                # it must be its own ancestor.  Assign the special
+                # PendingValue instance for now, and note that we'll
+                # need to fill in the real value later.
+                pending_items[i] = value
+                result.append(PendingValue)
+            else:
+                result.append(_recurse(value, json_id))
+
+        yield result
+
+        for i, value in pending_items.items():
+            # Now that we've yielded, the pending children should
+            # be available.
+            result[i] = _recurse(value, json_id)
+
+    def _handle_immutable_sequence(node, json_id):
+        # Immutable sequences containing themselves are impossible
+        # to construct (well, maybe possible in a C extension, but
+        # we're not going to worry about that), so we don't need
+        # to yield here.
+        contents = [_recurse(value, json_id) for value in node]
+
+        try:
+            result = node.__class__(contents)
+            if isinstance(node, tagged.Tagged):
+                result._tag = node._tag
+        except TypeError:
+            # The derived class signature is different, so simply store the
+            # list representing the contents. Currently this is primarly
+            # intended to handle namedtuple and NamedTuple instances.
+            if not ignore_implicit_conversion:
+                msg = "Failed to serialize instance of {}, converting to list instead"
+                warnings.warn(msg.format(type(node)))
+            result = contents
 
         return result
 
-    if callback.__code__.co_argcount == 2:
-        return recurse_with_json_ids(top, None)
-    else:
-        return recurse(top)
+    def _handle_children(node, json_id):
+        if isinstance(node, dict):
+            result = _handle_mapping(node, json_id)
+        elif isinstance(node, tuple):
+            result = _handle_immutable_sequence(node, json_id)
+        elif isinstance(node, list):
+            result = _handle_mutable_sequence(node, json_id)
+        else:
+            result = node
+
+        return _handle_generator(result)
+
+    def _recurse(node, json_id=None):
+        if node in _context:
+            # The node's modified result has already been
+            # created, all we need to do is return it.  This
+            # occurs when the tree contains multiple references
+            # to the same object id.
+            return _context[node]
+
+        # Inform the context that we're going to start modifing
+        # this node.
+        with _context.pending(node):
+            # Take note of the "id" field, in case we're modifying
+            # a schema and need to know the namespace for resolving
+            # URIs.
+            if isinstance(node, dict) and "id" in node:
+                json_id = node["id"]
+
+            if postorder:
+                # If this is a postorder modification, invoke the
+                # callback on this node's children first.
+                result = _handle_children(node, json_id)
+                result = _handle_callback(result, json_id)
+            else:
+                # Otherwise, invoke the callback on the node first,
+                # then its children.
+                result = _handle_callback(node, json_id)
+                result = _handle_children(result, json_id)
+
+        # Store the result in the context, in case there are
+        # additional references to the same node elsewhere in
+        # the tree.
+        _context[node] = result
+
+        return result
+
+    if _context is None:
+        _context = _TreeModificationContext()
+
+    with _context:
+        return _recurse(top)
+        # Generators will be drained here, if this is the outermost
+        # call to walk_and_modify.
 
 
 def get_children(node):

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -293,7 +293,7 @@ class ExtensionType:
         Converts instances of custom types into tagged objects.
 
         It is more common for custom tag types to override `to_tree` instead of
-        this method. This method should only be overridden if it is necessary
+        this method. This method should be overridden if it is necessary
         to modify the YAML tag that will be used to tag this object.
 
         Parameters
@@ -345,8 +345,11 @@ class ExtensionType:
 
         This method should be overridden by custom extension classes in order
         to define how custom types are deserialized from the YAML
-        representation back into their original types. The method will return
-        an instance of the original custom type.
+        representation back into their original types. Typically the method will
+        return an instance of the original custom type.  It is also permitted
+        to return a generator, which yields a partially constructed result, then
+        completes construction once the generator is drained.  This is useful
+        when constructing objects that contain reference cycles.
 
         This method is called as part of the process of reading an ASDF file in
         order to construct an `AsdfFile` object. Whenever a YAML subtree is
@@ -365,7 +368,8 @@ class ExtensionType:
 
         Returns
         -------
-            An instance of the custom type represented by this extension class.
+            An instance of the custom type represented by this extension class,
+            or a generator that yields that instance.
         """
         return cls(tree)
 


### PR DESCRIPTION
This PR fixes a variety of issues related to serialization/deserialization of "implicit references", that is to say, references to the same object id that aren't explicitly wrapped in `asdf.reference.Reference`.  Changes include:

- Fix infinite loops and preserve implicit references through calls to `walk_and_modify` (this is what fixes `custom_tree_to_tagged_tree` and `tagged_tree_to_custom_tree` as well as loading schemas containing reference cycles).
- Fix infinite loops when deserializing reference cycles in our custom YAML loader
- Fix infinite loops when validating trees containing reference cycles in our custom jsonschema validator
- Eliminate need to call `custom_tree_to_tagged_tree` within extension code; instead, any nested custom types returned by a `ExtensionType` subclass will be automatically handled by asdf.  Re-entering `custom_tree_to_tagged_tree` is still supported at this time, but I intend to add a deprecation warning after fixing up other packages and a hard error in 3.0.
- Eliminate need to call `tagged_tree_to_custom_tree` within extension code; instead, any nested tagged objects will already be converted before the `ExtensionType` subclass receives a call to `from_tree_tagged`.  If an object isn't yet available due to a reference cycle, it will have the special value `PendingValue` in its place.  Re-entering `tagged_tree_to_custom_tree` will also be an error in 3.0.
- Allow `ExtensionType` subclasses to return a generator from `from_tree_tagged` and `to_tree_tagged` instead of a fully (de)serialized value.  This will allow the subclass to start building the object but yield it before setting a field that might lead back to the current node.  Taking advantage of this feature in astropy's `CompoundType` will allow us to handle @mcara's user inverses.

This should all be fully backwards compatible, though I still still need to run our dependent packages through their paces.

Resolves #745 
Resolves #744 

(but to fully resolve these issues I'll be opening another PR in astropy)