### PR TITLE
Fix history entries initialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@
   and ``yamlutil.tagged_tree_to_custom_tree`` from extension code,
   and allow ``ExtensionType`` subclasses to return generators. [#777]
 
+- Fix bug preventing history entries when a file was previously
+  saved without them. [#779]
+
 2.5.2 (2020-02-28)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1203,6 +1203,8 @@ class AsdfFile(versioning.VersionedMixin):
         if self.version >= versioning.NEW_HISTORY_FORMAT_MIN_VERSION:
             if 'history' not in self.tree:
                 self.tree['history'] = dict(entries=[])
+            elif 'entries' not in self.tree['history']:
+                self.tree['history']['entries'] = []
 
             self.tree['history']['entries'].append(entry)
 

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -513,3 +513,20 @@ def test_search():
 
     result = af.search(value="hello")
     assert result.node == "hello"
+
+
+def test_history_entries(tmpdir):
+    path = str(tmpdir.join("test.asdf"))
+    message = "Twas brillig, and the slithy toves"
+
+    af = asdf.AsdfFile()
+    af.add_history_entry(message)
+    af.write_to(path)
+    with asdf.open(path) as af:
+        assert af["history"]["entries"][0]["description"] == message
+
+    af = asdf.AsdfFile()
+    af.write_to(path)
+    with asdf.open(path) as af:
+        af.add_history_entry(message)
+        assert af["history"]["entries"][0]["description"] == message


### PR DESCRIPTION
@stscieisenhamer pointed out a bug in adding a history entry to a file that was previously saved without them.  This PR fixes that issue and adds a relevant test.