### PR TITLE
Update changelogs for 2.6.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.6.0 (unreleased)
+2.6.0 (2020-04-22)
 ------------------
 
 - AsdfDeprecationWarning now subclasses DeprecationWarning. [#710]
@@ -28,7 +28,7 @@
 - Fix bug preventing history entries when a file was previously
   saved without them. [#779]
 
-- Update developer overview documentation to describe design of changes 
+- Update developer overview documentation to describe design of changes
   to handle internal references and reference cycles. [#781]
 
 2.5.2 (2020-02-28)

--- a/docs/asdf/changes.rst
+++ b/docs/asdf/changes.rst
@@ -4,6 +4,37 @@
 Changes
 *******
 
+What's New in ASDF 2.6.0?
+=========================
+
+The ASDF Standard is at v1.5.0.
+
+Changes include:
+
+* ASDF Standard 1.5.0 is now the default for new files.  Changes to
+  the standard include several new and updated transform schemas,
+  and removal of wcs schemas that were previously deprecated and
+  moved to the ``gwcs`` package.
+
+* Add ``asdf.info`` and ``AsdfFile.search`` methods for visualizing
+  and interactively searching an ASDF tree.
+
+* Fix bug causing too many bytes to be consumed when reading
+  compressed blocks.
+
+* Support validation and serialization of additional numpy
+  scalar types.
+
+* Fix serialization of trees containing implicit internal references
+  and reference cycles, and simplify handling of children in
+  ``ExtensionType`` subclasses.
+
+* Fix bug preventing addition of history entires to a file that
+  was initially saved without them.
+
+* Expand developer documentation to cover the details of pyyaml
+  integration and conversion between tagged trees and custom trees.
+
 What's New in ASDF 2.5.2?
 =========================
 


### PR DESCRIPTION
Add today's date to CHANGES.rst, and a `What's new in ASDF 2.6.0?` section to the docs