### PR TITLE
Improve validation performance by avoiding deep copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 - Fix bug causing duplicate elements to appear when calling
   ``copy.deepcopy`` on a ``TaggedList``. [#788]
 
+- Improve validator performance by skipping unnecessary step of
+  copying schema objects. [#784]
+
 2.6.0 (2020-04-22)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -117,7 +117,7 @@ class AsdfFile(versioning.VersionedMixin):
         self._process_extensions(extensions)
 
         if custom_schema is not None:
-            self._custom_schema = schema.load_schema(custom_schema, self.resolver, True)
+            self._custom_schema = schema._load_schema_cached(custom_schema, self.resolver, True, False)
         else:
             self._custom_schema = None
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -250,7 +250,7 @@ class _ValidationContext:
 
 @lru_cache()
 def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
-    meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID, extension.get_default_resolver())
+    meta_schema = _load_schema_cached(YAML_SCHEMA_METASCHEMA_ID, extension.get_default_resolver(), False, False)
 
     if JSONSCHEMA_LT_3:
         base_cls = mvalidators.create(meta_schema=meta_schema, validators=validators)
@@ -308,7 +308,7 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
                         schema_path = self.ctx.resolver(tag)
                         if schema_path != tag:
                             try:
-                                s = load_schema(schema_path, self.ctx.resolver)
+                                s = _load_schema_cached(schema_path, self.ctx.resolver, False, False)
                             except FileNotFoundError:
                                 msg = "Unable to locate schema file for '{}': '{}'"
                                 warnings.warn(msg.format(tag, schema_path))
@@ -683,7 +683,7 @@ def check_schema(schema):
     })
 
     meta_schema_id = schema.get('$schema', YAML_SCHEMA_METASCHEMA_ID)
-    meta_schema = load_schema(meta_schema_id, extension.get_default_resolver())
+    meta_schema = _load_schema_cached(meta_schema_id, extension.get_default_resolver(), False, False)
 
     resolver = _make_resolver(extension.get_default_resolver())
 


### PR DESCRIPTION
When we fixed caching of schema objects in #682, we had to continue returning unique copies of those objects from `load_schema`, since a certain package (ahem, jwst) was mutating some schemas and thereby corrupting the cache.  That copy isn't necessary within asdf, since it doesn't mess with schemas once they're loaded, but at the time I didn't think to skip the copy step internally.

It turns out that copy adds a significant performance penalty in the validator, where schemas are loaded by tag for every tagged object in an asdf file.  For files with complex trees, making deep copies about doubles the read time!  So, this PR changes internal calls to `load_schema` to `_load_schema_cached`, which dodges the copy.

I tested this with the asdf file described [here](https://github.com/spacetelescope/asdf/issues/159#issuecomment-125716549) and on my laptop, the read time decreases from an average of 11.6 seconds to 5.7 seconds.

