### PR TITLE
Fix diffing of simplified ndarray

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.6.1 (unreleased)
+------------------
+
+- Fix bug preventing diff of files containing ndarray-1.0.0
+  objects in simplified form. [#786]
+
 2.6.0 (2020-04-22)
 ------------------
 

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -190,12 +190,17 @@ def print_dict_diff(diff_ctx, tree, node_list, keys, other):
 
 def compare_ndarrays(diff_ctx, array0, array1, keys):
     """Compares two ndarray objects"""
+    if isinstance(array0, list):
+        array0 = {"data": array0}
+    if isinstance(array1, list):
+        array1 = {"data": array1}
+
     ignore_keys = set(['source', 'data'])
     compare_dicts(diff_ctx, array0, array1, keys, ignore_keys)
 
     differences = []
     for field in ['shape', 'datatype']:
-        if array0[field] != array1[field]:
+        if array0.get(field) != array1.get(field):
             differences.append(field)
 
     array0 = NDArrayType.from_tree(array0, diff_ctx.asdf0)

--- a/asdf/commands/tests/data/simple_inline_array.diff
+++ b/asdf/commands/tests/data/simple_inline_array.diff
@@ -1,0 +1,1 @@
+    [31mndarrays differ by contents[0m

--- a/asdf/commands/tests/data/simple_inline_array0.asdf
+++ b/asdf/commands/tests/data/simple_inline_array0.asdf
@@ -1,0 +1,14 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.5.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 2.6.1.dev2+gef67341}
+history:
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension.BuiltinExtension
+    software: !core/software-1.0.0 {name: asdf, version: 2.6.1.dev2+gef67341}
+array: !core/ndarray-1.0.0 [0, 1, 2]
+...

--- a/asdf/commands/tests/data/simple_inline_array1.asdf
+++ b/asdf/commands/tests/data/simple_inline_array1.asdf
@@ -1,0 +1,14 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.5.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 2.6.1.dev2+gef67341}
+history:
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension.BuiltinExtension
+    software: !core/software-1.0.0 {name: asdf, version: 2.6.1.dev2+gef67341}
+array: !core/ndarray-1.0.0 [0, 1, 3]
+...

--- a/asdf/commands/tests/test_diff.py
+++ b/asdf/commands/tests/test_diff.py
@@ -42,7 +42,11 @@ def test_diff_minimal():
 def test_diff_block():
     filenames = ['block0.asdf', 'block1.asdf']
     result_file = 'blocks.diff'
+    _assert_diffs_equal(filenames, result_file, minimal=False)
 
+def test_diff_simple_inline_array():
+    filenames = ['simple_inline_array0.asdf', 'simple_inline_array1.asdf']
+    result_file = 'simple_inline_array.diff'
     _assert_diffs_equal(filenames, result_file, minimal=False)
 
 def test_file_not_found():


### PR DESCRIPTION
This PR fixes a bug in the diff tool, which wasn't able to handle a serialized ndarray in "simplified" form, meaning an array that is serialized like this:

```
array: !core/ndarray-1.0.0 [0, 1, 2]
```
Instead of the usual:
```
array: !core/ndarray-1.0.0
  data: [0, 1, 2]
  datatype: int64
  shape: [3]
```

Both are permitted by the ndarray-1.0.0 schema.  I noticed this when working on fixing issues with schema defaults -- the frame-1.1.0 schema's defaults are represented in the simplified form, and once they start appearing in files, tests in tests_diff.py start failing.