### PR TITLE
Improve read performance by skipping rebuild of tree before validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.7.0 (unreleased)
+------------------
+
+- Improve read performance by skipping unnecessary rebuild
+  of tagged tree. [#787]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -424,8 +424,13 @@ class AsdfFile(versioning.VersionedMixin):
         return self._comments
 
     def _validate(self, tree, custom=True, reading=False):
-        tagged_tree = yamlutil.custom_tree_to_tagged_tree(
-            tree, self)
+        if reading:
+            # If we're validating on read then the tree
+            # is already guaranteed to be in tagged form.
+            tagged_tree = tree
+        else:
+            tagged_tree = yamlutil.custom_tree_to_tagged_tree(
+                tree, self)
         schema.validate(tagged_tree, self, reading=reading)
         # Perform secondary validation pass if requested
         if custom and self._custom_schema:


### PR DESCRIPTION
While I was profiling validation to assess the value of #570, I noticed this unrelated opportunity for a significant speedup (~ 13% less time for complex files).  When the tree is first read, it's already in tagged form.  Then we modify it twice: once to wrap `$ref` fields in `reference.Reference` objects, and again to fill in defaults from the schema.  From the validator's point of view, neither of these steps wrecks the tagged form of the tree, since references are ignored during validation, and the schema defaults are already tagged objects.

Given that, we can proceed to validation without first calling `yamlutil.custom_tree_to_tagged_tree` on the tree, which is an expensive operation.