### PR TITLE
Validate and fill/remove defaults in a single pass

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 - Add option to ``asdf.open`` and ``fits_embed.AsdfInFits.open``
   that disables validation on read. [#792]
 
+- Improve read and write performance by validating and
+  filling/removing defaults in a single pass. [#793]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -423,7 +423,7 @@ class AsdfFile(versioning.VersionedMixin):
         """
         return self._comments
 
-    def _validate(self, tree, custom=True, reading=False):
+    def _validate(self, tree, custom=True, reading=False, fill_defaults=False):
         if reading:
             # If we're validating on read then the tree
             # is already guaranteed to be in tagged form.
@@ -431,7 +431,12 @@ class AsdfFile(versioning.VersionedMixin):
         else:
             tagged_tree = yamlutil.custom_tree_to_tagged_tree(
                 tree, self)
-        schema.validate(tagged_tree, self, reading=reading)
+
+        if fill_defaults:
+            schema.validate_and_fill_defaults(tagged_tree, self, reading=reading)
+        else:
+            schema.validate(tagged_tree, self, reading=reading)
+
         # Perform secondary validation pass if requested
         if custom and self._custom_schema:
             schema.validate(tagged_tree, self, self._custom_schema,
@@ -668,15 +673,15 @@ class AsdfFile(versioning.VersionedMixin):
             self._blocks.read_block_index(fd, self)
 
         tree = reference.find_references(tree, self)
-        if not do_not_fill_defaults:
-            schema.fill_defaults(tree, self, reading=True)
 
         if validate_on_read:
             try:
-                self._validate(tree, reading=True)
+                self._validate(tree, reading=True, fill_defaults=(not do_not_fill_defaults))
             except ValidationError:
                 self.close()
                 raise
+        elif not do_not_fill_defaults:
+            schema.fill_defaults(tree, self, reading=True)
 
         tree = yamlutil.tagged_tree_to_custom_tree(tree, self, _force_raw_types)
 

--- a/asdf/commands/tests/data/frames0.asdf
+++ b/asdf/commands/tests/data/frames0.asdf
@@ -6,35 +6,29 @@
 asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
   name: asdf, version: 1.2.2.dev858}
 frames:
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {type: ICRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: FK5}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
       00:00:00.000', type: FK4}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
       00:00:00.000', type: FK4_noeterms}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {type: galactic}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [x, y, z]
+- axes_names: [x, y, z]
   axes_order: [0, 1, 2]
   name: CelestialFrame
   reference_frame:
@@ -52,8 +46,7 @@ frames:
     type: galactocentric
     z_sun: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 pc, value: 3.0}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame:
     obsgeoloc:
@@ -67,19 +60,16 @@ frames:
     obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
     type: GCRS
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {obstime: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: CIRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [x, y, z]
+- axes_names: [x, y, z]
   axes_order: [0, 1, 2]
   name: CelestialFrame
   reference_frame: {obstime: !time/time-1.1.0 '2022-01-03 00:00:00.000', type: ITRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame:
     equinox: !time/time-1.1.0 J2000.000

--- a/asdf/commands/tests/data/frames1.asdf
+++ b/asdf/commands/tests/data/frames1.asdf
@@ -6,35 +6,29 @@
 asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
   name: asdf, version: 1.2.2.dev846}
 frames:
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat, blurg]
+- axes_names: [lon, lat, blurg]
   name: CelestialFrame
   reference_frame: {type: ICRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: FK5}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
       00:00:00.000', type: FK4}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {equinox: !time/time-1.1.0 '2010-01-01 00:00:00.000', obstime: !time/time-1.1.0 '2015-01-01
       00:00:00.000', type: FK4_noeterms}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {type: galactic}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [x, y, z]
+- axes_names: [x, y, z]
   axes_order: [0, 1, 2]
   name: CelestialFrame
   reference_frame:
@@ -55,8 +49,7 @@ frames:
       unit: pc
       value: 3.0
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame:
     obsgeoloc:
@@ -82,19 +75,16 @@ frames:
     obstime: !time/time-1.1.0 2010-01-01 00:00:00.000
     type: GCRS
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame: {obstime: !time/time-1.1.0 '2010-01-01 00:00:00.000', type: CIRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [x, y, z]
+- axes_names: [x, y, z]
   axes_order: [0, 1, 2]
   name: CelestialFrame
   reference_frame: {obstime: !time/time-1.1.0 '2022-01-03 00:00:00.000', type: ITRS}
   unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
-- !wcs/celestial_frame-1.1.0
-  axes_names: [lon, lat]
+- axes_names: [lon, lat]
   name: CelestialFrame
   reference_frame:
     equinox: !time/time-1.1.0 J2000.000

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -204,7 +204,7 @@ def validate_remove_default(validator, properties, instance, schema):
 
 # Used when removing defaults in a separate validation pass:
 REMOVE_DEFAULTS = util.HashableDict()
-for key in ('allOf', 'anyOf', 'oneOf', 'items'):
+for key in ('allOf', 'anyOf', 'oneOf', 'items', '$ref'):
     REMOVE_DEFAULTS[key] = mvalidators.Draft4Validator.VALIDATORS[key]
 REMOVE_DEFAULTS['properties'] = validate_remove_default
 

--- a/asdf/tests/test_asdftypes.py
+++ b/asdf/tests/test_asdftypes.py
@@ -734,18 +734,16 @@ def test_tag_without_schema(tmpdir):
     with pytest.warns(UserWarning) as w:
         with asdf.AsdfFile(tree, extensions=FooExtension()) as af:
             af.write_to(tmpfile)
-        # There are three validation passes when writing. Eventually this may
-        # change
-        assert len(w) == 3, helpers.display_warnings(w)
+        # We expected one warning on read and another on write:
+        assert len(w) == 2, helpers.display_warnings(w)
         assert str(w[0].message).startswith('Unable to locate schema file')
         assert str(w[1].message).startswith('Unable to locate schema file')
-        assert str(w[2].message).startswith('Unable to locate schema file')
 
     with pytest.warns(UserWarning) as w:
         with asdf.AsdfFile(tree, extensions=FooExtension()) as ff:
             assert isinstance(ff.tree['foo'], FooType)
             assert ff.tree['foo'] == tree['foo']
-        # There is only one validation pass when writing.
+        # Here we're just reading, so there should only be one warning:
         assert len(w) == 1, helpers.display_warnings(w)
         assert str(w[0].message).startswith('Unable to locate schema file')
 

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -518,11 +518,8 @@ def test_read_large_literal():
         with asdf.open(buff) as af:
             assert af['integer'] == value
 
-        # We get two warnings: one for validation time, and one when defaults
-        # are filled. It seems like we could improve this architecture, though...
-        assert len(w) == 2
+        assert len(w) == 1
         assert str(w[0].message).startswith('Invalid integer literal value')
-        assert str(w[1].message).startswith('Invalid integer literal value')
 
 
 def test_nested_array():
@@ -856,13 +853,9 @@ a: !core/doesnt_exist-1.0.0
     with pytest.warns(None) as w:
         with asdf.open(buff) as af:
             assert str(af['a']) == 'hello'
-            # Currently there are 3 warnings since one occurs on each of the
-            # validation passes. It would be good to consolidate these
-            # eventually
-            assert len(w) == 3, helpers.display_warnings(w)
+            assert len(w) == 2, helpers.display_warnings(w)
             assert str(w[0].message).startswith("Unable to locate schema file")
-            assert str(w[1].message).startswith("Unable to locate schema file")
-            assert str(w[2].message).startswith(af['a']._tag)
+            assert str(w[1].message).startswith(af['a']._tag)
 
     # This is a more realistic case since we're using an external extension
     yaml = """
@@ -874,10 +867,9 @@ a: !<tag:nowhere.org:custom/doesnt_exist-1.0.0>
     with pytest.warns(None) as w:
         with asdf.open(buff, extensions=CustomExtension()) as af:
             assert str(af['a']) == 'hello'
-            assert len(w) == 3, helpers.display_warnings(w)
+            assert len(w) == 2, helpers.display_warnings(w)
             assert str(w[0].message).startswith("Unable to locate schema file")
-            assert str(w[1].message).startswith("Unable to locate schema file")
-            assert str(w[2].message).startswith(af['a']._tag)
+            assert str(w[1].message).startswith(af['a']._tag)
 
 
 @pytest.mark.parametrize("numpy_value,valid_types", [

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -349,8 +349,8 @@ def dump_tree(tree, fd, ctx):
         tags = {'!': yaml_tag}
 
     tree = custom_tree_to_tagged_tree(tree, ctx)
-    schema.validate(tree, ctx)
-    schema.remove_defaults(tree, ctx)
+
+    schema.validate_and_remove_defaults(tree, ctx)
 
     yaml_version = tuple(
         int(x) for x in ctx.version_map['YAML_VERSION'].split('.'))


### PR DESCRIPTION
This PR combines filling defaults and validation on read into a single pass, when both are enabled, and the same treatment for removing defaults and validation on write.  This improves performance since until now we've been walking the tree and schema twice.

Branched off of #792, so probably worth waiting for that one to merge before reviewing this.

Resolves #570 