### PR TITLE
Eliminate warnings from test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,9 @@ matrix:
     # Test against an installed asdf package
     - env: TOXENV=packaged
 
+    # Test with warnings converted to errors
+    - env: TOXENV=warnings
+
     # Test on OS X
     - env:
         - TOXENV=py38
@@ -101,6 +104,8 @@ matrix:
     - env: TOXENV=prerelease
 
     - env: TOXENV=py38-numpydev
+
+    - env: TOXENV=warnings
 
 install: pip install tox
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
 
 - Fix bugs and code style found by adding F and W ``flake8`` checks. [#797]
 
+- Eliminate warnings in pytest plugin by using ``from_parent``
+  when available. [#799]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/commands/tests/test_info.py
+++ b/asdf/commands/tests/test_info.py
@@ -1,5 +1,7 @@
 from functools import partial
 
+import pytest
+
 from ...tests import helpers
 from . import data as test_data
 
@@ -9,6 +11,10 @@ from .. import main
 get_test_data_path = partial(helpers.get_test_data_path, module=test_data)
 
 
+# The test file we're using here contains objects whose schemas
+# have been dropped from the ASDF Standard.  We should select
+# a new file once the locations of schemas are more stable.
+@pytest.mark.filterwarnings("ignore::asdf.exceptions.AsdfConversionWarning")
 def test_info_command(capsys):
     file_path = get_test_data_path("frames0.asdf")
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -416,7 +416,7 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
 
         try:
             with generic_io.get_file(schema_location) as f:
-                schema = yaml.load(f.read())
+                schema = yaml.safe_load(f.read())
         except Exception:
             assert False, (
                 "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,10 @@ norecursedirs = build docs/_build
 doctest_plus = enabled
 remote_data_strict = True
 open_files_ignore = test.fits asdf.fits
+# The asdf.asdftypes module emits a warning on import,
+# which pytest trips over during collection:
+filterwarnings =
+    ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes
 # Configuration for pytest-doctestplus
 text_file_format = rst
 # Account for both the astropy test runner case and the native pytest case

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ deps=
     numpy12: numpy==1.12
     numpydev,astrodev,s390x: cython
 extras= all,tests
+# astropy will complain if the home directory is missing
+passenv= HOME
 commands=
     pytest --remote-data
 
@@ -36,6 +38,11 @@ install_command= python -m pip install --no-cache-dir {opts} {packages}
 [testenv:prerelease]
 basepython= python3.8
 pip_pre= true
+
+[testenv:warnings]
+basepython= python3.8
+commands=
+    pytest --remote-data -W error -W ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes
 
 [testenv:packaged]
 basepython= python3.8


### PR DESCRIPTION
This fixes or hides the following warnings that come up when running our tests:

```
PytestDeprecationWarning: direct construction of AsdfSchemaFile has been deprecated, please use AsdfSchemaFile.from_parent
PytestDeprecationWarning: direct construction of AsdfSchemaItem has been deprecated, please use AsdfSchemaItem.from_parent
PytestDeprecationWarning: direct construction of AsdfSchemaExampleItem has been deprecated, please use AsdfSchemaExampleItem.from_parent
```
The pytest plugin has been updated to use `from_parent` when available.

```
AsdfConversionWarning: tag:stsci.edu:asdf/wcs/celestial_frame-1.1.0 is not recognized, converting to raw Python data structure
AsdfConversionWarning: tag:stsci.edu:asdf/wcs/icrs_coord-1.1.0 is not recognized, converting to raw Python data structure
```
Some of the tests open a file that references schemas that have been deprecated.  At some point we'll want to create new test data, but it seems like we should wait until the dust settles on moving schemas around.  For the time being I just asked pytest to ignore the warning.

```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```
Changed `asdf.tests.helpers` to use `safe_load` instead.

The PR also adds a not-required Travis build that converts warnings into errors.

Resolves #789 
