### PR TITLE
Fix auto_inline when block is already set to inline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@
 - Improve validator performance by skipping unnecessary step of
   copying schema objects. [#784]
 
+- Fix bug with ``auto_inline`` option where inline blocks
+  are not converted to internal when they exceed the threshold. [#802]
+
 2.6.0 (2020-04-22)
 ------------------
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -12,7 +12,6 @@ from collections import namedtuple
 from urllib import parse as urlparse
 
 import numpy as np
-from numpy.ma.core import masked_array
 
 import yaml
 
@@ -586,7 +585,6 @@ class BlockManager:
 
         auto_inline = getattr(ctx, '_auto_inline', None)
         if auto_inline and block.array_storage in ['internal', 'inline']:
-            num_elements = np.product(block.data.shape)
             if np.product(block.data.shape) < auto_inline:
                 self.set_array_storage(block, 'inline')
             else:

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -321,14 +321,81 @@ def test_extension_version_check(installed, extension, warns):
         af._check_extensions(tree)
 
 
-@pytest.mark.xfail(reason='Setting auto_inline option modifies AsdfFile state')
 def test_auto_inline(tmpdir):
-
     outfile = str(tmpdir.join('test.asdf'))
-    tree = dict(data=np.arange(6))
+    tree = {"small_array": np.arange(6), "large_array": np.arange(100)}
 
     # Use the same object for each write in order to make sure that there
     # aren't unanticipated side effects
+    with asdf.AsdfFile(tree) as af:
+        # By default blocks are written internal.
+        af.write_to(outfile)
+        assert len(list(af.blocks.inline_blocks)) == 0
+        assert len(list(af.blocks.internal_blocks)) == 2
+
+        af.write_to(outfile, auto_inline=10)
+        assert len(list(af.blocks.inline_blocks)) == 1
+        assert len(list(af.blocks.internal_blocks)) == 1
+
+        # The previous write modified the small array block's storage
+        # to inline, and a subsequent write should maintain that setting.
+        af.write_to(outfile)
+        assert len(list(af.blocks.inline_blocks)) == 1
+        assert len(list(af.blocks.internal_blocks)) == 1
+
+        af.write_to(outfile, auto_inline=7)
+        assert len(list(af.blocks.inline_blocks)) == 1
+        assert len(list(af.blocks.internal_blocks)) == 1
+
+        af.write_to(outfile, auto_inline=5)
+        assert len(list(af.blocks.inline_blocks)) == 0
+        assert len(list(af.blocks.internal_blocks)) == 2
+
+
+def test_auto_inline_masked_array(tmpdir):
+    outfile = str(tmpdir.join('test.asdf'))
+    arr = np.arange(6)
+    masked_arr = np.ma.masked_equal(arr, 3)
+    tree = {"masked_arr": masked_arr}
+
+    with asdf.AsdfFile(tree) as af:
+        af.write_to(outfile)
+        assert len(list(af.blocks.inline_blocks)) == 0
+        assert len(list(af.blocks.internal_blocks)) == 2
+
+        af.write_to(outfile, auto_inline=10)
+        assert len(list(af.blocks.inline_blocks)) == 2
+        assert len(list(af.blocks.internal_blocks)) == 0
+
+        af.write_to(outfile, auto_inline=5)
+        assert len(list(af.blocks.inline_blocks)) == 0
+        assert len(list(af.blocks.internal_blocks)) == 2
+
+
+def test_auto_inline_large_value(tmpdir):
+    outfile = str(tmpdir.join('test.asdf'))
+    arr = np.arange(6)
+    arr[0] = 2**52 + 1
+    tree = {"array": arr}
+
+    with asdf.AsdfFile(tree) as af:
+        af.write_to(outfile)
+        assert len(list(af.blocks.inline_blocks)) == 0
+        assert len(list(af.blocks.internal_blocks)) == 1
+
+        with pytest.raises(ValidationError):
+            af.write_to(outfile, auto_inline=10)
+
+        af.write_to(outfile, auto_inline=5)
+        assert len(list(af.blocks.inline_blocks)) == 0
+        assert len(list(af.blocks.internal_blocks)) == 1
+
+
+def test_auto_inline_string_array(tmpdir):
+    outfile = str(tmpdir.join('test.asdf'))
+    arr = np.array(["peach", "plum", "apricot", "nectarine", "cherry", "pluot"])
+    tree = {"array": arr}
+
     with asdf.AsdfFile(tree) as af:
         af.write_to(outfile)
         assert len(list(af.blocks.inline_blocks)) == 0
@@ -338,99 +405,9 @@ def test_auto_inline(tmpdir):
         assert len(list(af.blocks.inline_blocks)) == 1
         assert len(list(af.blocks.internal_blocks)) == 0
 
-        af.write_to(outfile)
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 1
-
-        af.write_to(outfile, auto_inline=7)
-        assert len(list(af.blocks.inline_blocks)) == 1
-        assert len(list(af.blocks.internal_blocks)) == 0
-
         af.write_to(outfile, auto_inline=5)
         assert len(list(af.blocks.inline_blocks)) == 0
         assert len(list(af.blocks.internal_blocks)) == 1
-
-
-@pytest.mark.skip(reason='Until inline_threshold is added as a write option')
-def test_inline_threshold(tmpdir):
-
-    tree = {
-        'small': np.ones(10),
-        'large': np.ones(100)
-    }
-
-    with asdf.AsdfFile(tree) as af:
-        assert len(list(af.blocks.inline_blocks)) == 1
-        assert len(list(af.blocks.internal_blocks)) == 1
-
-    with asdf.AsdfFile(tree, inline_threshold=10) as af:
-        assert len(list(af.blocks.inline_blocks)) == 1
-        assert len(list(af.blocks.internal_blocks)) == 1
-
-    with asdf.AsdfFile(tree, inline_threshold=5) as af:
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 2
-
-    with asdf.AsdfFile(tree, inline_threshold=100) as af:
-        assert len(list(af.blocks.inline_blocks)) == 2
-        assert len(list(af.blocks.internal_blocks)) == 0
-
-
-@pytest.mark.skip(reason='Until inline_threshold is added as a write option')
-def test_inline_threshold_masked(tmpdir):
-
-    mask = np.random.randint(0, 1+1, 20)
-    masked_array = np.ma.masked_array(np.ones(20), mask=mask)
-
-    tree = {
-        'masked': masked_array
-    }
-
-    # Make sure that masked arrays aren't automatically inlined, even if they
-    # are small enough
-    with asdf.AsdfFile(tree) as af:
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 2
-
-    tree = {
-        'masked': masked_array,
-        'normal': np.random.random(20)
-    }
-
-    with asdf.AsdfFile(tree) as af:
-        assert len(list(af.blocks.inline_blocks)) == 1
-        assert len(list(af.blocks.internal_blocks)) == 2
-
-
-@pytest.mark.skip(reason='Until inline_threshold is added as a write option')
-def test_inline_threshold_override(tmpdir):
-
-    tmpfile = str(tmpdir.join('inline.asdf'))
-
-    tree = {
-        'small': np.ones(10),
-        'large': np.ones(100)
-    }
-
-    with asdf.AsdfFile(tree) as af:
-        af.set_array_storage(tree['small'], 'internal')
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 2
-
-    with asdf.AsdfFile(tree) as af:
-        af.set_array_storage(tree['large'], 'inline')
-        assert len(list(af.blocks.inline_blocks)) == 2
-        assert len(list(af.blocks.internal_blocks)) == 0
-
-    with asdf.AsdfFile(tree) as af:
-        af.write_to(tmpfile, all_array_storage='internal')
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 2
-
-    with asdf.AsdfFile(tree) as af:
-        af.write_to(tmpfile, all_array_storage='inline')
-        assert len(list(af.blocks.inline_blocks)) == 2
-        assert len(list(af.blocks.internal_blocks)) == 0
 
 
 def test_resolver_deprecations():

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -374,8 +374,7 @@ def test_auto_inline_masked_array(tmpdir):
 
 def test_auto_inline_large_value(tmpdir):
     outfile = str(tmpdir.join('test.asdf'))
-    arr = np.arange(6)
-    arr[0] = 2**52 + 1
+    arr = np.array([2**52 + 1, 1, 2, 3, 4, 5])
     tree = {"array": arr}
 
     with asdf.AsdfFile(tree) as af:


### PR DESCRIPTION
This fixes auto_inline's behavior when a block is already set to inline, and the associated array exceeds the limit for inline representation.  Previously the block would continue to be written inline, but with these changes it will change to "internal".

I'm also removing an unused internal method, `_should_inline`, which is a remnant of the similar inline_threshold feature that was reverted.

Resolves #599