### PR TITLE
Enable tests on Windows

### DIFF
--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -233,7 +233,7 @@ def _assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
             asdf_check_func(ff)
 
     # Now try everything on an HTTP range server
-    if not INTERNET_OFF and not sys.platform.startswith('win'):
+    if not INTERNET_OFF:
         server = RangeHTTPServer()
         try:
             ff = AsdfFile(tree, extensions=extensions, **init_options)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -4,7 +4,6 @@
 
 import copy
 import os
-import sys
 import pytest
 
 import numpy as np
@@ -337,8 +336,6 @@ def test_bad_input(tmpdir):
     with pytest.raises(ValueError):
         asdf_open(text_file)
 
-@pytest.mark.skipif(sys.platform.startswith('win'),
-    reason='Avoid path manipulation on Windows')
 def test_version_mismatch_file():
 
     testfile = str(get_test_data_path('version_mismatch.fits'))

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -238,8 +238,6 @@ def test_streams2():
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    reason="Windows firewall prevents test")
 def test_urlopen(tree, httpserver):
     path = os.path.join(httpserver.tmpdir, 'test.asdf')
 
@@ -258,8 +256,6 @@ def test_urlopen(tree, httpserver):
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    reason="Windows firewall prevents test")
 def test_http_connection(tree, httpserver):
     path = os.path.join(httpserver.tmpdir, 'test.asdf')
 
@@ -283,8 +279,6 @@ def test_http_connection(tree, httpserver):
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    reason="Windows firewall prevents test")
 def test_http_connection_range(tree, rhttpserver):
     path = os.path.join(rhttpserver.tmpdir, 'test.asdf')
     connection = [None]
@@ -348,8 +342,6 @@ def test_exploded_filesystem_fail(tree, tmpdir):
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    reason="Windows firewall prevents test")
 def test_exploded_http(tree, httpserver):
     path = os.path.join(httpserver.tmpdir, 'test.asdf')
 


### PR DESCRIPTION
Turns out with a few small adjustments we don't need to skip these tests on Windows.  I suspect the Travis environment may have disabled the firewall since last time someone tested this, and the path manipulation stuff is straightforward enough if we use a cross-platform utility instead of constructing paths ourselves.