### PR TITLE
Use AsdfWarning instead of UserWarning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
 - Prevent validation of empty tree when ``AsdfFile`` is
   initialized. [#794]
 
+- All warnings now subclass ``asdf.exceptions.AsdfWarning``. [#804]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -24,7 +24,7 @@ from . import version
 from . import versioning
 from . import yamlutil
 from . import _display as display
-from .exceptions import AsdfDeprecationWarning
+from .exceptions import AsdfDeprecationWarning, AsdfWarning
 from .extension import AsdfExtensionList, default_extensions
 from .util import NotSet
 from .search import AsdfSearchResult
@@ -186,7 +186,7 @@ class AsdfFile(versioning.VersionedMixin):
                 if strict:
                     raise RuntimeError(fmt_msg)
                 else:
-                    warnings.warn(fmt_msg)
+                    warnings.warn(fmt_msg, AsdfWarning)
 
             elif extension.software:
                 installed = self._extension_metadata[extension.extension_class]
@@ -205,7 +205,7 @@ class AsdfFile(versioning.VersionedMixin):
                     if strict:
                         raise RuntimeError(fmt_msg)
                     else:
-                        warnings.warn(fmt_msg)
+                        warnings.warn(fmt_msg, AsdfWarning)
 
     def _process_extensions(self, extensions):
         if extensions is None or extensions == []:
@@ -241,7 +241,8 @@ class AsdfFile(versioning.VersionedMixin):
             self.tree['history'] = dict(entries=histlist, extensions=[])
             warnings.warn("The ASDF history format has changed in order to "
                           "support metadata about extensions. History entries "
-                          "should now be stored under tree['history']['entries'].")
+                          "should now be stored under tree['history']['entries'].",
+                          AsdfWarning)
         elif 'extensions' not in self.tree['history']:
             self.tree['history']['extensions'] = []
 

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -11,7 +11,7 @@ from . import resolver
 from .util import get_class_name
 from .type_index import AsdfTypeIndex
 from .version import version as asdf_version
-from .exceptions import AsdfDeprecationWarning
+from .exceptions import AsdfDeprecationWarning, AsdfWarning
 
 
 __all__ = ['AsdfExtension', 'AsdfExtensionList']
@@ -199,7 +199,8 @@ class _DefaultExtensions:
             if not issubclass(ext, AsdfExtension):
                 warnings.warn("Found entry point {}, from {} but it is not a "
                               "subclass of AsdfExtension, as expected. It is "
-                              "being ignored.".format(ext, entry_point.dist))
+                              "being ignored.".format(ext, entry_point.dist),
+                              AsdfWarning)
                 continue
 
             dist = entry_point.dist

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -23,7 +23,7 @@ from . import treeutil
 from . import util
 from .compat.jsonschemacompat import JSONSCHEMA_LT_3
 from . import extension
-from .exceptions import AsdfDeprecationWarning
+from .exceptions import AsdfDeprecationWarning, AsdfWarning
 
 
 YAML_SCHEMA_METASCHEMA_ID = 'http://stsci.edu/schemas/yaml-schema/draft-01'
@@ -308,7 +308,7 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
                                 s = _load_schema_cached(schema_path, self.ctx.resolver, False, False)
                             except FileNotFoundError:
                                 msg = "Unable to locate schema file for '{}': '{}'"
-                                warnings.warn(msg.format(tag, schema_path))
+                                warnings.warn(msg.format(tag, schema_path), AsdfWarning)
                                 s = {}
                             if s:
                                 with self.resolver.in_scope(schema_path):
@@ -576,7 +576,8 @@ def validate_large_literals(instance, reading=False):
         warnings.warn(
             "Invalid integer literal value {0} detected while reading file. "
             "The value has been read safely, but the file should be "
-            "fixed.".format(instance)
+            "fixed.".format(instance),
+            AsdfWarning
         )
 
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -4,6 +4,7 @@ import io
 import os
 import sys
 import warnings
+from contextlib import contextmanager
 
 try:
     from astropy.coordinates import ICRS
@@ -365,6 +366,18 @@ def display_warnings(_warnings):
             warning.category.__name__,
             warning.message)
     return msg
+
+
+@contextmanager
+def assert_no_warnings():
+    """
+    Assert that no warnings were emitted within the context.
+    Requires that pytest be installed.
+    """
+    import pytest
+    with pytest.warns(None) as recorded_warnings:
+        yield
+    assert len(recorded_warnings) == 0, display_warnings(recorded_warnings)
 
 
 def assert_extension_correctness(extension):

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -18,8 +18,13 @@ from asdf import extension
 from asdf import resolver
 from asdf import schema
 from asdf import versioning
-from asdf.exceptions import AsdfDeprecationWarning
-from .helpers import assert_tree_match, assert_roundtrip_tree, display_warnings, yaml_to_asdf
+from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
+from .helpers import (
+    assert_tree_match,
+    assert_roundtrip_tree,
+    yaml_to_asdf,
+    assert_no_warnings,
+)
 
 
 def test_get_data_from_closed_file(tmpdir):
@@ -47,9 +52,8 @@ def test_no_warning_nan_array(tmpdir):
 
     tree = dict(array=np.array([1, 2, np.nan]))
 
-    with pytest.warns(None) as w:
+    with assert_no_warnings():
         assert_roundtrip_tree(tree, tmpdir)
-        assert len(w) == 0, display_warnings(w)
 
 
 def test_warning_deprecated_open(tmpdir):
@@ -310,9 +314,8 @@ def test_extension_version_check(installed, extension, warns):
     }
 
     if warns:
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(AsdfWarning, match="File 'test.asdf' was created with"):
             af._check_extensions(tree)
-        assert str(w[0].message).startswith("File 'test.asdf' was created with")
 
         with pytest.raises(RuntimeError) as err:
             af._check_extensions(tree, strict=True)

--- a/asdf/tests/test_helpers.py
+++ b/asdf/tests/test_helpers.py
@@ -4,7 +4,7 @@
 import pytest
 
 from asdf import types
-from asdf.exceptions import AsdfConversionWarning
+from asdf.exceptions import AsdfConversionWarning, AsdfWarning
 from asdf.tests.helpers import assert_roundtrip_tree
 
 
@@ -45,8 +45,5 @@ def test_conversion_error(tmpdir):
     tree = dict(foo=foo)
 
     with pytest.raises(AsdfConversionWarning):
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(AsdfWarning, match="Unable to locate schema file"):
             assert_roundtrip_tree(tree, tmpdir, extensions=FooExtension())
-        # Make sure we still get other warnings
-        assert len(w) == 1
-        assert str(w[0].message).startswith('Unable to locate schema file')

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -12,6 +12,7 @@ from asdf import types
 from asdf import extension
 from asdf import util
 from asdf import versioning
+from asdf.exceptions import AsdfWarning, AsdfConversionWarning
 
 from . import helpers, CustomTestType, CustomExtension
 
@@ -179,34 +180,21 @@ a: !core/complex-42.0.0
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.warns(None) as warning:
+    with pytest.warns(AsdfWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
-
-    assert len(warning) == 1
-    assert str(warning[0].message) == (
-        "'tag:stsci.edu:asdf/core/complex' with version 42.0.0 found in file, "
-        "but latest supported version is 1.0.0")
 
     # Make sure warning is repeatable
     buff.seek(0)
-    with pytest.warns(None) as warning:
+    with pytest.warns(AsdfWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
 
-    assert len(warning) == 1
-    assert str(warning[0].message) == (
-        "'tag:stsci.edu:asdf/core/complex' with version 42.0.0 found in file, "
-        "but latest supported version is 1.0.0")
-
     # Make sure the warning does not occur if it is being ignored (default)
     buff.seek(0)
-    with pytest.warns(None) as warning:
+    with helpers.assert_no_warnings():
         with asdf.open(buff) as ff:
             assert isinstance(ff.tree['a'], complex)
-
-    assert len(warning) == 0, helpers.display_warnings(warning)
-
 
     # If the major and minor match, there should be no warning.
     yaml = """
@@ -215,11 +203,9 @@ a: !core/complex-1.0.1
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.warns(None) as warning:
+    with helpers.assert_no_warnings():
         with asdf.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
-
-    assert len(warning) == 0
 
 
 def test_version_mismatch_file(tmpdir):
@@ -235,16 +221,10 @@ a: !core/complex-42.0.0
 
     expected_uri = util.filepath_to_url(str(testfile))
 
-    with pytest.warns(None) as w:
+    with pytest.warns(AsdfWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(testfile, ignore_version_mismatch=False) as ff:
             assert ff._fname == expected_uri
             assert isinstance(ff.tree['a'], complex)
-
-    assert len(w) == 1
-    assert str(w[0].message) == (
-        "'tag:stsci.edu:asdf/core/complex' with version 42.0.0 found in file "
-        "'{}', but latest supported version is 1.0.0".format(expected_uri)
-    )
 
 
 def test_version_mismatch_with_supported_versions():
@@ -274,13 +254,9 @@ flow_thing:
     d: 3.14
 """
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.warns(None) as w:
+    with pytest.warns(AsdfWarning, match="tag:nowhere.org:custom/custom_flow"):
         asdf.open(buff, ignore_version_mismatch=False,
             extensions=CustomFlowExtension())
-    assert len(w) == 1, helpers.display_warnings(w)
-    assert str(w[0].message) == (
-        "'tag:nowhere.org:custom/custom_flow' with version 1.0.0 found in "
-        "file, but latest supported version is 1.1.0")
 
 
 def test_versioned_writing(monkeypatch):
@@ -430,9 +406,8 @@ undefined_data:
 
     # Make sure no warning occurs if explicitly ignored
     buff.seek(0)
-    with pytest.warns(None) as warning:
+    with helpers.assert_no_warnings():
         afile = asdf.open(buff, ignore_unrecognized_tag=True)
-    assert len(warning) == 0
 
 
 def test_newer_tag():
@@ -488,15 +463,11 @@ flow_thing:
     b: 3.14
 """
     old_buff = helpers.yaml_to_asdf(old_yaml)
-    with pytest.warns(None) as warning:
-        asdf.open(old_buff, extensions=CustomFlowExtension())
-
-    assert len(warning) == 1, helpers.display_warnings(warning)
     # We expect this warning since it will not be possible to convert version
     # 1.0.0 of CustomFlow to a CustomType (by design, for testing purposes).
-    assert str(warning[0].message).startswith(
-        "Failed to convert "
-        "tag:nowhere.org:custom/custom_flow-1.0.0 to custom type")
+    with pytest.warns(AsdfConversionWarning, match="Failed to convert tag:nowhere.org:custom/custom_flow-1.0.0"):
+        asdf.open(old_buff, extensions=CustomFlowExtension())
+
 
 def test_incompatible_version_check():
     class TestType0(types.CustomType):
@@ -631,13 +602,9 @@ flow_thing:
 """
     buff = helpers.yaml_to_asdf(yaml)
 
-    with pytest.warns(None) as _warnings:
+    with pytest.warns(AsdfConversionWarning, match="Version 1.1.0 of tag:nowhere.org:custom/custom_flow is not compatible"):
         asdf.open(buff, extensions=CustomFlowExtension())
 
-    assert len(_warnings) == 1
-    assert str(_warnings[0].message) == (
-        "Version 1.1.0 of tag:nowhere.org:custom/custom_flow is not compatible "
-        "with any existing tag implementations")
 
 def test_extension_override(tmpdir):
 
@@ -724,23 +691,14 @@ def test_tag_without_schema(tmpdir):
     foo = FooType('hello', 42)
     tree = dict(foo=foo)
 
-    with pytest.warns(UserWarning) as w:
+    with pytest.warns(AsdfWarning, match="Unable to locate schema file"):
         with asdf.AsdfFile(tree, extensions=FooExtension()) as af:
             af.write_to(tmpfile)
-        # There are three validation passes when writing. Eventually this may
-        # change
-        assert len(w) == 3, helpers.display_warnings(w)
-        assert str(w[0].message).startswith('Unable to locate schema file')
-        assert str(w[1].message).startswith('Unable to locate schema file')
-        assert str(w[2].message).startswith('Unable to locate schema file')
 
-    with pytest.warns(UserWarning) as w:
+    with pytest.warns(AsdfWarning, match="Unable to locate schema file"):
         with asdf.AsdfFile(tree, extensions=FooExtension()) as ff:
             assert isinstance(ff.tree['foo'], FooType)
             assert ff.tree['foo'] == tree['foo']
-        # There is only one validation pass when writing.
-        assert len(w) == 1, helpers.display_warnings(w)
-        assert str(w[0].message).startswith('Unable to locate schema file')
 
 
 def test_subclass_decorator(tmpdir):
@@ -888,11 +846,9 @@ def test_subclass_decorator_warning():
 
     tree = dict(fraction=MyFraction(7, 9, custom='TESTING!'))
 
-    with pytest.warns(UserWarning) as w:
+    with pytest.warns(AsdfWarning, match="Failed to add subclass attribute"):
         with asdf.AsdfFile(tree, extensions=FractionExtension()):
             pass
-        assert len(w) == 1, helpers.display_warnings(w)
-        assert str(w[0].message).startswith("Failed to add subclass attribute(s)")
 
 
 def test_custom_reference_cycle(tmpdir):

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -16,6 +16,7 @@ from asdf import tagged
 from asdf import treeutil
 from asdf import yamlutil
 from asdf.compat.numpycompat import NUMPY_LT_1_14
+from asdf.exceptions import AsdfWarning
 
 from . import helpers
 
@@ -179,13 +180,13 @@ def test_implicit_conversion_warning():
         "val": nt(1, 2, np.ones(3))
     }
 
-    with pytest.warns(UserWarning, match="Failed to serialize instance"):
+    with pytest.warns(AsdfWarning, match="Failed to serialize instance"):
         with asdf.AsdfFile(tree):
             pass
 
-    with pytest.warns(None) as w:
+    with helpers.assert_no_warnings():
         with asdf.AsdfFile(tree, ignore_implicit_conversion=True):
-            assert len(w) == 0
+            pass
 
 
 @pytest.mark.xfail(reason='pyyaml has a bug and does not support tuple keys')

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -9,7 +9,7 @@ import types
 from contextlib import contextmanager
 
 from . import tagged
-
+from .exceptions import AsdfWarning
 
 __all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container"]
 
@@ -347,7 +347,7 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
             # intended to handle namedtuple and NamedTuple instances.
             if not ignore_implicit_conversion:
                 msg = "Failed to serialize instance of {}, converting to list instead"
-                warnings.warn(msg.format(type(node)))
+                warnings.warn(msg.format(type(node)), AsdfWarning)
             result = contents
 
         return result

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from . import util
 from .versioning import (AsdfVersion, get_version_map, default_version,
                          split_tag_version, join_tag_version)
+from .exceptions import AsdfWarning
 
 
 __all__ = ['AsdfTypeIndex']
@@ -275,7 +276,7 @@ class AsdfTypeIndex:
             # TODO: If it is useful to only have a single warning per file on
             # disk, then use `fname` in the key instead of `ctx`.
             if not (ctx, tag) in self._has_warned:
-                warnings.warn(warning_string.format(fname))
+                warnings.warn(warning_string.format(fname), AsdfWarning)
                 self._has_warned[(ctx, tag)] = True
 
     def fix_yaml_tag(self, ctx, tag, ignore_version_mismatch=True):

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -12,6 +12,7 @@ from copy import copy
 from . import tagged
 from . import util
 from .versioning import AsdfVersion, AsdfSpec
+from .exceptions import AsdfWarning
 
 
 __all__ = ['format_tag', 'CustomType']
@@ -332,7 +333,8 @@ class ExtensionType:
                     "Failed to add subclass attribute(s) to node that is "
                     "not an object (is a {}). No subclass attributes are being "
                     "added (tag={}, subclass={})".format(
-                        type(obj).__name__, cls, node_cls)
+                        type(obj).__name__, cls, node_cls),
+                    AsdfWarning
                 )
 
         return tagged.tag_object(cls.yaml_tag, obj, ctx=ctx)


### PR DESCRIPTION
Many of our warnings are `UserWarning` instead of `AsdfWarning` of some kind, which makes it difficult for users to squelch warnings from the whole package all at once.  This converts all previously untyped warnings to `AsdfWarning` and cleans up warning checks in the tests, which weren't making effective use of the `pytest.warns` match parameter.