### PR TITLE
Fix collection issues with doctestplus 0.7.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ show-response = 1
 [tool:pytest]
 testpaths = asdf docs asdf-standard/schemas
 minversion = 3.1
-norecursedirs = build docs/_build
+norecursedirs = build docs/_build docs/sphinxext
 doctest_plus = enabled
 remote_data_strict = True
 open_files_ignore = test.fits asdf.fits


### PR DESCRIPTION
The new version stops automatically ignoring import errors on collection.  This causes a failure at collection time due to missing dependencies for docs/sphinxext.  We don't have any docstrings or tests in docs/sphinxext anyway, so I'm just going to ask pytest to ignore that directory.