### PR TITLE
Clean up version mismatch warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@
 
 - All warnings now subclass ``asdf.exceptions.AsdfWarning``. [#804]
 
+- Improve warning message when falling back to an older schema,
+  and note that fallback behavior will be removed in 3.0. [#806]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -369,15 +369,26 @@ def display_warnings(_warnings):
 
 
 @contextmanager
-def assert_no_warnings():
+def assert_no_warnings(warning_class=None):
     """
     Assert that no warnings were emitted within the context.
     Requires that pytest be installed.
+
+    Parameters
+    ----------
+    warning_class : type, optional
+        Assert only that no warnings of the specified class were
+        emitted.
     """
     import pytest
     with pytest.warns(None) as recorded_warnings:
         yield
-    assert len(recorded_warnings) == 0, display_warnings(recorded_warnings)
+
+    if warning_class is not None:
+        assert not any(isinstance(w.message, warning_class) for w in recorded_warnings), \
+            display_warnings(recorded_warnings)
+    else:
+        assert len(recorded_warnings) == 0, display_warnings(recorded_warnings)
 
 
 def assert_extension_correctness(extension):

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -18,7 +18,7 @@ from jsonschema.exceptions import ValidationError
 import asdf
 from asdf import fits_embed
 from asdf import open as asdf_open
-from asdf.exceptions import AsdfWarning
+from asdf.exceptions import AsdfWarning, AsdfConversionWarning
 
 from .helpers import (
     assert_tree_match,
@@ -344,49 +344,25 @@ def test_bad_input(tmpdir):
         asdf_open(text_file)
 
 def test_version_mismatch_file():
-
     testfile = str(get_test_data_path('version_mismatch.fits'))
 
-    with pytest.warns(None) as w:
+    with pytest.warns(AsdfConversionWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(testfile,
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
-    # This is the warning that we expect from opening the FITS file
-    expected_messages = {
-        (
-            "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
-            "'{}', but latest supported version is 1.0.0".format(testfile)
-        ),
-        (
-            "'tag:stsci.edu:asdf/core/asdf' with version 1.0.0 found in file "
-            "'{}', but latest supported version is 1.1.0".format(testfile)
-        ),
-    }
-    assert expected_messages == {warn.message.args[0] for warn in w}, display_warnings(w)
 
     # Make sure warning does not occur when warning is ignored (default)
-    with assert_no_warnings():
+    with assert_no_warnings(AsdfConversionWarning):
         with asdf.open(testfile) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
 
-    with pytest.warns(None) as w:
+    with pytest.warns(AsdfConversionWarning, match="tag:stsci.edu:asdf/core/complex"):
         with fits_embed.AsdfInFits.open(testfile,
                 ignore_version_mismatch=False) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
-    expected_messages = {
-        (
-            "'tag:stsci.edu:asdf/core/complex' with version 7.0.0 found in file "
-            "'{}', but latest supported version is 1.0.0".format(testfile)
-        ),
-        (
-            "'tag:stsci.edu:asdf/core/asdf' with version 1.0.0 found in file "
-            "'{}', but latest supported version is 1.1.0".format(testfile)
-        ),
-    }
-    assert expected_messages == {warn.message.args[0] for warn in w}, display_warnings(w)
 
     # Make sure warning does not occur when warning is ignored (default)
-    with assert_no_warnings():
+    with assert_no_warnings(AsdfConversionWarning):
         with fits_embed.AsdfInFits.open(testfile) as fits_handle:
             assert fits_handle.tree['a'] == complex(0j)
 

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -22,7 +22,6 @@ from asdf.exceptions import AsdfWarning, AsdfConversionWarning
 
 from .helpers import (
     assert_tree_match,
-    display_warnings,
     get_test_data_path,
     yaml_to_asdf,
     assert_no_warnings,

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -610,7 +610,7 @@ custom: !<tag:nowhere.org:custom/missing-1.1.0>
   b: {foo: 42}
     """
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.warns(AsdfWarning, match="Failed to convert tag:nowhere.org:custom/missing-1.1.0"):
+    with pytest.warns(AsdfConversionWarning, match="Failed to convert tag:nowhere.org:custom/missing-1.1.0"):
         with asdf.open(buff, extensions=[DefaultTypeExtension()]) as ff:
             assert ff.tree['custom']['b']['foo'] == 42
 

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -180,30 +180,31 @@ a: !core/complex-42.0.0
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.warns(AsdfWarning, match="tag:stsci.edu:asdf/core/complex"):
+    with pytest.warns(AsdfConversionWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
 
     # Make sure warning is repeatable
     buff.seek(0)
-    with pytest.warns(AsdfWarning, match="tag:stsci.edu:asdf/core/complex"):
+    with pytest.warns(AsdfConversionWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
 
     # Make sure the warning does not occur if it is being ignored (default)
     buff.seek(0)
-    with helpers.assert_no_warnings():
+    with helpers.assert_no_warnings(AsdfConversionWarning):
         with asdf.open(buff) as ff:
             assert isinstance(ff.tree['a'], complex)
 
-    # If the major and minor match, there should be no warning.
+    # If the major and minor match, but the patch doesn't, there
+    # should still be a warning.
     yaml = """
 a: !core/complex-1.0.1
   0j
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with helpers.assert_no_warnings():
+    with pytest.warns(AsdfConversionWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(buff, ignore_version_mismatch=False) as ff:
             assert isinstance(ff.tree['a'], complex)
 
@@ -221,15 +222,15 @@ a: !core/complex-42.0.0
 
     expected_uri = util.filepath_to_url(str(testfile))
 
-    with pytest.warns(AsdfWarning, match="tag:stsci.edu:asdf/core/complex"):
+    with pytest.warns(AsdfConversionWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(testfile, ignore_version_mismatch=False) as ff:
             assert ff._fname == expected_uri
             assert isinstance(ff.tree['a'], complex)
 
 
 def test_version_mismatch_with_supported_versions():
-    """Make sure that defining the supported_versions field does not affect
-    whether or not schema mismatch warnings are triggered."""
+    """Make sure that defining the supported_versions field eliminates
+    the schema mismatch warning."""
 
     class CustomFlow:
         pass
@@ -254,7 +255,7 @@ flow_thing:
     d: 3.14
 """
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.warns(AsdfWarning, match="tag:nowhere.org:custom/custom_flow"):
+    with helpers.assert_no_warnings():
         asdf.open(buff, ignore_version_mismatch=False,
             extensions=CustomFlowExtension())
 

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -307,6 +307,6 @@ def test_numpy_scalar(numpy_value, expected_value):
     buffer.seek(0)
 
     if isinstance(expected_value, float) and NUMPY_LT_1_14:
-        assert yamlutil.load_tree(buffer, ctx)["value"] == pytest.approx(expected_value, rel=0.001)
+        assert yamlutil.load_tree(buffer)["value"] == pytest.approx(expected_value, rel=0.001)
     else:
-        assert yamlutil.load_tree(buffer, ctx)["value"] == expected_value
+        assert yamlutil.load_tree(buffer)["value"] == expected_value

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -2,14 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import bisect
-import warnings
 from functools import lru_cache
 from collections import OrderedDict
 
 from . import util
 from .versioning import (AsdfVersion, get_version_map, default_version,
                          split_tag_version, join_tag_version)
-from .exceptions import AsdfWarning
 
 
 __all__ = ['AsdfTypeIndex']
@@ -201,7 +199,6 @@ class AsdfTypeIndex:
         # the same type, the result is currently undefined.
         self._versions_by_type_name = OrderedDict()
         self._best_matches = {}
-        self._real_tag = {}
         self._unnamed_types = set()
         self._hooks_by_type = {}
         self._all_types = set()
@@ -258,28 +255,7 @@ class AsdfTypeIndex:
 
         return write_type_index.from_custom_type(custom_type)
 
-    def _get_version_mismatch(self, name, version, latest_version):
-        warning_string = None
-
-        if (latest_version.major, latest_version.minor) != \
-                (version.major, version.minor):
-            warning_string = \
-                "'{}' with version {} found in file{{}}, but latest " \
-                "supported version is {}".format(
-                    name, version, latest_version)
-
-        return warning_string
-
-    def _warn_version_mismatch(self, ctx, tag, warning_string, fname):
-        if warning_string is not None:
-            # Ensure that only a single warning occurs per tag per AsdfFile
-            # TODO: If it is useful to only have a single warning per file on
-            # disk, then use `fname` in the key instead of `ctx`.
-            if not (ctx, tag) in self._has_warned:
-                warnings.warn(warning_string.format(fname), AsdfWarning)
-                self._has_warned[(ctx, tag)] = True
-
-    def fix_yaml_tag(self, ctx, tag, ignore_version_mismatch=True):
+    def fix_yaml_tag(self, ctx, tag):
         """
         Given a YAML tag, adjust it to the best supported version.
 
@@ -287,37 +263,17 @@ class AsdfTypeIndex:
         understood that is still less than the version in file.  Or,
         the earliest understood version if none are less than the
         version in the file.
-
-        If ``ignore_version_mismatch==False``, this function raises a warning
-        if it could not find a match where the major and minor numbers are the
-        same.
         """
-        warning_string = None
-
-        name, version = split_tag_version(tag)
-
-        fname = " '{}'".format(ctx._fname) if ctx._fname else ''
-
         if tag in self._type_by_tag:
             asdftype = self._type_by_tag[tag]
-            # Issue warnings for the case where there exists a class for the
-            # given tag due to the 'supported_versions' attribute being
-            # defined, but this tag is not the latest version of the type.
-            # This prevents 'supported_versions' from affecting the behavior of
-            # warnings that are purely related to YAML validation.
-            if not ignore_version_mismatch and hasattr(asdftype, '_latest_version'):
-                warning_string = self._get_version_mismatch(
-                    name, version, asdftype._latest_version)
-                self._warn_version_mismatch(ctx, tag, warning_string, fname)
             return tag
 
         if tag in self._best_matches:
-            best_tag, warning_string = self._best_matches[tag]
-
-            if not ignore_version_mismatch:
-                self._warn_version_mismatch(ctx, tag, warning_string, fname)
-
+            best_tag = self._best_matches[tag]
+            ctx._warn_tag_mismatch(tag, best_tag)
             return best_tag
+
+        name, version = split_tag_version(tag)
 
         versions = self._versions_by_type_name.get(name)
         if versions is None:
@@ -327,25 +283,11 @@ class AsdfTypeIndex:
         # quickly find the best option.
         i = bisect.bisect_left(versions, version)
         i = max(0, i - 1)
-
-        if not ignore_version_mismatch:
-            warning_string = self._get_version_mismatch(
-                name, version, versions[-1])
-            self._warn_version_mismatch(ctx, tag, warning_string, fname)
-
         best_version = versions[i]
         best_tag = join_tag_version(name, best_version)
-        self._best_matches[tag] = best_tag, warning_string
-        if tag != best_tag:
-            self._real_tag[best_tag] = tag
+        ctx._warn_tag_mismatch(tag, best_tag)
+        self._best_matches[tag] = best_tag
         return best_tag
-
-    def get_real_tag(self, tag):
-        if tag in self._real_tag:
-            return self._real_tag[tag]
-        elif tag in self._type_by_tag:
-            return tag
-        return None
 
     def from_yaml_tag(self, ctx, tag):
         """

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -265,7 +265,6 @@ class AsdfTypeIndex:
         version in the file.
         """
         if tag in self._type_by_tag:
-            asdftype = self._type_by_tag[tag]
             return tag
 
         if tag in self._best_matches:

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -4,7 +4,6 @@ import io
 import os
 from importlib.util import find_spec
 from pkg_resources import parse_version
-import warnings
 
 import yaml
 import pytest
@@ -169,7 +168,6 @@ class AsdfSchemaExampleItem(pytest.Item):
     def runtest(self):
         from asdf import AsdfFile, block, util
         from asdf.tests import helpers
-        from asdf.exceptions import AsdfDeprecationWarning
 
         name, version = parse_schema_filename(self.filename)
         if should_skip(name, version):


### PR DESCRIPTION
This PR fixes a number of issues related to the version mismatch warning:

- Move the cache of previously emitted warnings from TypeIndex to AsdfFile, avoiding accumulation of AsdfFiles in memory
- Make the version mismatch warning message more useful by including the tag that was chosen as a fallback.  I also added a note stating that the fallback behavior is deprecated and will be removed in 3.0.
- Start warning even when only the schema patch version is different.  A patch version is likely to include new fields that would be discarded by an older ExtensionType implementation, so modifying the file may cause unintended data loss.
- Stop warning simply because a file contains a tag with a supported but older version.  That doesn't seem useful.
- Stop coercing tag versions in the YAML parser.  This is a significant change, and a behavior that we've had since 1.3.3, but I don't think it's correct.  If we leave the tag alone and ultimately decide that we can't interpret the associated custom object, then the tag will remain intact when we write the file back out.  Otherwise the file will end up corrupted to some extent, with a set of fields for one version of the schema but tagged with a different version.  I suspect this was originally done so that objects with unsupported patch versions would still be validated against the schema with the closest version, but I don't think that's a worthy cause.
- Add a config option to the pytest plugin to enable version mismatch warnings when testing schemas.  We can't enable it right now because astropy is missing support for so many older schema versions, but I checked the schemas with ExtensionType class in asdf and they're all compliant.

This is branched off of #804 so I'd recommend waiting to review until we've merged that one, since it introduces a lot of noise.

Resolves #801