### PR TITLE
Remove jsonschema 2.x support and update minimal dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@
 - Improve warning message when falling back to an older schema,
   and note that fallback behavior will be removed in 3.0. [#806]
 
+- Drop support for jsonschema 2.x. [#807]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/compat/jsonschemacompat.py
+++ b/asdf/compat/jsonschemacompat.py
@@ -1,7 +1,0 @@
-from ..util import minversion
-
-
-__all__ = ['JSONSCHEMA_LT_3']
-
-
-JSONSCHEMA_LT_3 = not minversion('jsonschema', '3.0.0')

--- a/docs/asdf/install.rst
+++ b/docs/asdf/install.rst
@@ -12,15 +12,15 @@ Requirements
 
 The ``asdf`` package has the following dependencies:
 
-- `python <https://www.python.org/>`__  3.3 or later
+- `python <https://www.python.org/>`__  3.5 or later
 
-- `numpy <https://www.numpy.org/>`__ 1.8 or later
+- `numpy <https://www.numpy.org/>`__ 1.10 or later
 
-- `jsonschema <https://python-jsonschema.readthedocs.io/>`__ 2.3.0 or later
+- `jsonschema <https://python-jsonschema.readthedocs.io/>`__ 3.0.2 or later
 
 - `pyyaml <https://pyyaml.org>`__ 3.10 or later
 
-- `semantic_version <https://python-semanticversion.readthedocs.io/>`__ 2.3.1 or later
+- `semantic_version <https://python-semanticversion.readthedocs.io/>`__ 2.8 or later
 
 Support for units, time, transform, wcs, or running the tests also
 requires:
@@ -31,10 +31,6 @@ Optional support for `lz4 <https://en.wikipedia.org/wiki/LZ4_(compression_algori
 compression is provided by:
 
 - `lz4 <https://python-lz4.readthedocs.io/>`__ 0.10 or later
-
-Also required for running the tests:
-
-- `pytest-astropy <https://github.com/astropy/pytest-astropy>`__
 
 Installing with pip
 ===================

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ include_package_data = True
 install_requires =
     semantic_version>=2.8
     pyyaml>=3.10
-    jsonschema>=2.3,<4
-    numpy>=1.8
+    jsonschema>=3.0.2,<4
+    numpy>=1.10
 
 [options.extras_require]
 all =

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ deps=
     # isn't compatible with the older versions of numpy
     # that we test with.
     py35,py36: gwcs==0.9.1
-    legacy: semantic_version==2.3.1
+    legacy: semantic_version==2.8
     legacy: pyyaml==3.10
-    legacy: jsonschema==2.3
+    legacy: jsonschema==3.0.2
     legacy: numpy~=1.10.0
     numpy11,numpy12,legacy: astropy~=3.0.0
     numpy11: numpy==1.11


### PR DESCRIPTION
This PR drops support for jsonschema 2.x, in anticipation of needing 3.x for draft-07.

I also compared tox.ini, setup.cfg, and the documentation, and noticed a few discrepancies.  I chose the highest minimum versions from among them and updated everything to match.