### PR TITLE
Fix misinterpretation of byte order of blocks stored in FITS files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@
 - Fix bug with ``auto_inline`` option where inline blocks
   are not converted to internal when they exceed the threshold. [#802]
 
+- Fix misinterpretation of byte order of blocks stored
+  in FITS files. [#810]
+
 2.6.0 (2020-04-22)
 ------------------
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -859,7 +859,20 @@ class Block:
         return self.offset + self.header_size + self.allocated
 
     def override_byteorder(self, byteorder):
+        """
+        Hook to permit overriding the byteorder value stored in the
+        tree.  This is used to support blocks stored in FITS files.
+        """
         return byteorder
+
+    @property
+    def trust_data_dtype(self):
+        """
+        If True, ignore the datatype and byteorder fields from the
+        tree and take the data array's dtype at face value.  This
+        is used to support blocks stored in FITS files.
+        """
+        return False
 
     @property
     def array_storage(self):

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -51,7 +51,19 @@ class _FitsBlock:
         return 'fits'
 
     def override_byteorder(self, byteorder):
+        # FITS data is always stored in big-endian byte order.
+        # The data array may not report big-endian, but we want
+        # the value written to the tree to match the actual
+        # byte order on disk.
         return 'big'
+
+    @property
+    def trust_data_dtype(self):
+        # astropy.io.fits returns arrays in native byte order
+        # when it has to apply scaling.  In that case, we don't
+        # want to interpret the bytes as big-endian, since astropy
+        # has already converted them properly.
+        return True
 
 
 class _EmbeddedBlockManager(block.BlockManager):

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -261,8 +261,14 @@ class NDArrayType(AsdfType):
             block = self.block
             shape = self.get_actual_shape(
                 self._shape, self._strides, self._dtype, len(block))
+
+            if block.trust_data_dtype:
+                dtype = block.data.dtype
+            else:
+                dtype = self._dtype
+
             self._array = np.ndarray(
-                shape, self._dtype, block.data,
+                shape, dtype, block.data,
                 self._offset, self._strides, self._order)
             self._block_data_weakref = weakref.ref(block.data)
             self._array = self._apply_mask(self._array, self._mask)


### PR DESCRIPTION
This PR fixes an issue with reading binary blocks stored in FITS files.

When astropy reads data that requires scaling, it performs said scaling and returns the result in native byte order.  Until now asdf has been assuming that all data from a FITS file is big-endian, since that's how the bytes are stored on disk, but due to the scaling operation that's not always the case.

The fix is to accept that the dtype reported by an array from a FITS file is correct.

CC @stscieisenhamer 

