### PR TITLE
Stop traversing oneOf and anyOf combiners when filling/removing defaults

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@
 
 - Drop support for jsonschema 2.x. [#807]
 
+- Stop traversing oneOf and anyOf combiners when filling
+  or removing default values. [#811]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -178,7 +178,7 @@ def validate_fill_default(validator, properties, instance, schema):
 
 
 FILL_DEFAULTS = util.HashableDict()
-for key in ('allOf', 'anyOf', 'oneOf', 'items'):
+for key in ('allOf', 'items'):
     FILL_DEFAULTS[key] = mvalidators.Draft4Validator.VALIDATORS[key]
 FILL_DEFAULTS['properties'] = validate_fill_default
 
@@ -198,7 +198,7 @@ def validate_remove_default(validator, properties, instance, schema):
 
 
 REMOVE_DEFAULTS = util.HashableDict()
-for key in ('allOf', 'anyOf', 'oneOf', 'items'):
+for key in ('allOf', 'items'):
     REMOVE_DEFAULTS[key] = mvalidators.Draft4Validator.VALIDATORS[key]
 REMOVE_DEFAULTS['properties'] = validate_remove_default
 

--- a/asdf/tests/data/default-1.0.0.yaml
+++ b/asdf/tests/data/default-1.0.0.yaml
@@ -13,3 +13,43 @@ properties:
       c:
         type: integer
         default: 82
+  d:
+    allOf:
+      - type: object
+        properties:
+          e:
+            type: integer
+            default: 122
+      - type: object
+        properties:
+          f:
+            type: integer
+            default: 162
+  g:
+    anyOf:
+      - type: object
+        properties:
+          h:
+            type: integer
+            default: 202
+      - type: object
+        properties:
+          i:
+            type: integer
+            default: 242
+  j:
+    oneOf:
+      - type: object
+        properties:
+          k:
+            type: integer
+            default: 282
+        required: [k]
+        additionalProperties: false
+      - type: object
+        properties:
+          l:
+            type: integer
+            default: 322
+        required: [l]
+        additionalProperties: false

--- a/asdf/tests/data/one_of-1.0.0.yaml
+++ b/asdf/tests/data/one_of-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://nowhere.org/schemas/custom/one_of-1.0.0"
+title: |
+  oneOf test schema
+oneOf:
+  - type: object
+    properties:
+      value:
+        type: number
+    required: [value]
+    additionalProperties: false
+
+  - type: object
+    properties:
+      value:
+        type: string
+    required: [value]
+    additionalProperties: false
+...


### PR DESCRIPTION
This PR completely disables filling/remove defaults from subschemas within `oneOf` or `anyOf` combiners.  #809 demonstrates a serious bug in the defaults code that prevents use of `oneOf` in most realistic cases.  Given that there isn't a clear correct answer when choosing a default from among multiple `oneOf` subschemas, I'm inclined to ignore them when processing defaults.

I also propose that we do away with defaults for `anyOf`.  The way `anyOf` currently behaves is to always add a default from the first subschema.  If the object actually matches one of the subsequent subschemas, then we'll be adding a default from the wrong type!

With these changes, the remaining default rules are as follows, for a given missing property:

- If an object's own property definition has a default, use that
- Otherwise, if there is an `allOf` combiner, use the first default value available for that property among the combiner's subschemas.  The first listed subschema in the `allOf` array has highest precedence.
- Defaults from any other combiners are ignored

Milestoning this as 2.7.0, since it doesn't seem possible that anyone could be successfully using defaults with these combiners given the bugs.

Resolves #809 